### PR TITLE
Travis Compatible build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: csharp
+solution: "./OptimizelySDK.sln"
+install:
+  - nuget restore ./OptimizelySDK.sln
+  - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory testrunner
+script:
+  - xbuild /p:Configuration=Release ./OptimizelySDK.sln
+  - mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe ./OptimizelySDK.Tests/bin/Release/OptimizelySDK.Tests.dll 

--- a/OptimizelySDK.DemoApp/OptimizelySDK.DemoApp.csproj
+++ b/OptimizelySDK.DemoApp/OptimizelySDK.DemoApp.csproj
@@ -37,7 +37,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>none</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>

--- a/OptimizelySDK.Tests/BucketerTest.cs
+++ b/OptimizelySDK.Tests/BucketerTest.cs
@@ -13,14 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OptimizelySDK.Entity;
 using OptimizelySDK.Logger;
 using Moq;
+using NUnit.Framework;
 
 namespace OptimizelySDK.Tests
 {
-    [TestClass]
+    [TestFixture]
     public class BucketerTest
     {
         private Mock<ILogger> LoggerMock;
@@ -48,21 +48,21 @@ namespace OptimizelySDK.Tests
             }
         }
 
-        [TestInitialize]
+        [SetUp]
         public void Initialize()
         {
             LoggerMock = new Mock<ILogger>();
             Config = ProjectConfig.Create(TestData.Datafile, LoggerMock.Object, new ErrorHandler.NoOpErrorHandler());
         }
 
-        [TestCleanup]
+        [TestFixtureSetUp]
         public void Cleanup()
         {
             LoggerMock = null;
             Config = null;
         }
 
-        [TestMethod]
+        [Test]
         public void TestGenerateBucketValue()
         {
             var bucketer = new Bucketer(LoggerMock.Object);
@@ -83,7 +83,7 @@ namespace OptimizelySDK.Tests
             }
         }
 
-        [TestMethod]
+        [Test]
         public void TestBucketValidExperimentNotInGroup()
         {
             TestBucketer bucketer = new TestBucketer(LoggerMock.Object);
@@ -114,7 +114,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [testUserId] is in no variation."));
         }
 
-        [TestMethod]
+        [Test]
         public void TestBucketValidExperimentInGroup()
         {
             TestBucketer bucketer = new TestBucketer(LoggerMock.Object);
@@ -148,7 +148,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(10));
         }
 
-        [TestMethod]
+        [Test]
         public void TestBucketInvalidExperiment()
         {
             var bucketer = new Bucketer(LoggerMock.Object);
@@ -159,7 +159,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Never);
         }
 
-        [TestMethod]
+        [Test]
         public void TestBucketValidExperimentNotInGroupUserInForcedVariation()
         {
             var bucketer = new Bucketer(LoggerMock.Object);
@@ -171,7 +171,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(1));
         }
 
-        [TestMethod]
+        [Test]
         public void TestBucketValidExperimentInGroupUserInForcedVariation()
         {
             var bucketer = new Bucketer(LoggerMock.Object);

--- a/OptimizelySDK.Tests/EventTests/DefaultEventDispatcherTest.cs
+++ b/OptimizelySDK.Tests/EventTests/DefaultEventDispatcherTest.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OptimizelySDK.Entity;
+﻿using OptimizelySDK.Entity;
 using OptimizelySDK.Logger;
 using Moq;
 using OptimizelySDK.Event.Builder;
@@ -8,11 +7,14 @@ using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using System;
 using OptimizelySDK.Event.Dispatcher;
+using NUnit.Framework;
 
 namespace OptimizelySDK.Tests.EventTests
 {
+    [TestFixture]
     public class DefaultEventDispatcherTest
     {
+        [Test]
         public void TestDispatchEvent()
         {
             var logEvent = new LogEvent("",

--- a/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using OptimizelySDK.Entity;
+﻿using OptimizelySDK.Entity;
 using OptimizelySDK.Logger;
 using Moq;
 using OptimizelySDK.Event.Builder;
@@ -7,17 +6,18 @@ using OptimizelySDK.Event;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using System;
+using NUnit.Framework;
 
 namespace OptimizelySDK.Tests.EventTests
 {
-    [TestClass]
+    [TestFixture]
     public class EventBuilderTest
     {
         private string TestUserId = string.Empty;
         private ProjectConfig Config;
         private EventBuilder EventBuilder;
 
-        [TestInitialize]
+        [TestFixtureSetUp]
         public void Setup()
         {
             TestUserId = "testUserId";
@@ -30,7 +30,7 @@ namespace OptimizelySDK.Tests.EventTests
             return (long)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds;
         }
 
-        [TestMethod]
+        [Test]
         public void TestCreateImpressionEventNoAttributes()
         {
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/log/decision",
@@ -65,7 +65,7 @@ namespace OptimizelySDK.Tests.EventTests
 
         }
 
-        [TestMethod]
+        [Test]
         public void TestCreateImpressionEventWithAttributes()
         {
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/log/decision",
@@ -116,7 +116,7 @@ namespace OptimizelySDK.Tests.EventTests
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
         }
 
-        [TestMethod]
+        [Test]
         public void TestCreateConversionEventNoAttributesNovalue()
         {
             var expectedEvent = new LogEvent(
@@ -162,7 +162,7 @@ namespace OptimizelySDK.Tests.EventTests
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
 
-        [TestMethod]
+        [Test]
         public void TestCreateConversionEventWithAttributesNoValue()
         {
             var expectedEvent = new LogEvent(
@@ -229,7 +229,7 @@ namespace OptimizelySDK.Tests.EventTests
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
 
-        [TestMethod]
+        [Test]
         public void TestCreateConversionEventNoAttributesWithValue()
         {
             var expectedEvent = new LogEvent(
@@ -301,7 +301,7 @@ namespace OptimizelySDK.Tests.EventTests
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
 
-        [TestMethod]
+        [Test]
         public void TestCreateConversionEventWithAttributesWithValue()
         {
             var expectedEvent = new LogEvent(
@@ -400,7 +400,7 @@ namespace OptimizelySDK.Tests.EventTests
 
 
         /* Start */
-        [TestMethod]
+        [Test]
         public void TestCreateConversionEventNoAttributesWithInvalidValue()
         {
 

--- a/OptimizelySDK.Tests/EventTests/LogEventTest.cs
+++ b/OptimizelySDK.Tests/EventTests/LogEventTest.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿
 using Newtonsoft.Json.Linq;
+using NUnit.Framework;
 using OptimizelySDK.Event;
 using System;
 using System.Collections.Generic;
@@ -9,7 +10,7 @@ using System.Threading.Tasks;
 
 namespace OptimizelySDK.Tests.EventTests
 {
-    [TestClass]
+    [TestFixture]
     public class LogEventTest
     {
         private LogEvent LogEvent;
@@ -25,7 +26,7 @@ namespace OptimizelySDK.Tests.EventTests
             return JToken.DeepEquals(jtoken1, jtoken2);
         }
 
-        [TestInitialize]
+        [TestFixtureSetUp]
         public void Setup()
         {
             LogEvent = new LogEvent(
@@ -43,13 +44,13 @@ namespace OptimizelySDK.Tests.EventTests
                 });
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetUrl()
         {
             Assert.AreEqual("https://logx.optimizely.com", LogEvent.Url);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetParams()
         {
             var testParams = new Dictionary<string, object>
@@ -61,13 +62,13 @@ namespace OptimizelySDK.Tests.EventTests
             Assert.IsTrue(CompareObjects(testParams, LogEvent.Params));
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetHttpVerb()
         {
             Assert.AreEqual("POST", LogEvent.HttpVerb);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetHeaders()
         {
             var headers = new Dictionary<string, string>

--- a/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
+++ b/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
@@ -39,15 +39,16 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Moq, Version=4.7.1.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.7.1\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -77,6 +78,7 @@
     <Compile Include="BucketerTest.cs" />
     <Compile Include="ProjectConfigTest.cs" />
     <Compile Include="UtilsTests\ConditionEvaluatorTest.cs" />
+    <Compile Include="UtilsTests\PrivateObject.cs" />
     <Compile Include="UtilsTests\ValidatorTest.cs" />
     <Compile Include="ValidEventDispatcher.cs" />
   </ItemGroup>
@@ -87,10 +89,6 @@
     <EmbeddedResource Include="TestData.json" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\OptimizelySDK.DemoApp\OptimizelySDK.DemoApp.csproj">
-      <Project>{9394F666-6397-41C0-8867-C3E4DA9156E3}</Project>
-      <Name>OptimizelySDK.DemoApp</Name>
-    </ProjectReference>
     <ProjectReference Include="..\OptimizelySDK\OptimizelySDK.csproj">
       <Project>{4dde7faa-110d-441c-ab3b-3f31b593e8bf}</Project>
       <Name>OptimizelySDK</Name>

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -16,7 +16,6 @@
 using System;
 using System.Collections.Generic;
 using Moq;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Event.Builder;
 using OptimizelySDK.Event.Dispatcher;
@@ -24,10 +23,12 @@ using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Exceptions;
 using OptimizelySDK.Event;
 using OptimizelySDK.Entity;
+using NUnit.Framework;
+using OptimizelySDK.Tests.UtilsTests;
 
 namespace OptimizelySDK.Tests
 {
-    [TestClass]
+    [TestFixture]
     public class OptimizelyTest
     {
         private Mock<ILogger> LoggerMock;
@@ -39,7 +40,7 @@ namespace OptimizelySDK.Tests
         private const string TestUserId = "testUserId";
         private OptimizelyHelper Helper;
 
-        [TestInitialize]
+        [SetUp]
         public void Initialize()
         {
             LoggerMock = new Mock<ILogger>();
@@ -74,14 +75,14 @@ namespace OptimizelySDK.Tests
             };
         }
 
-        [TestCleanup]
+        [TestFixtureTearDown]
         public void Cleanup()
         {
             LoggerMock = null;
             Config = null;
             EventBuilderMock = null;
         }
-
+        
         private class OptimizelyHelper
         {
             static Type[] ParameterTypes = new[]
@@ -125,7 +126,7 @@ namespace OptimizelySDK.Tests
             }
         }
 
-        [TestMethod]
+        [Test]
         public void TestValidateInputsInvalidFileJsonValidationNotSkipped()
         {
             string datafile = "{\"name\":\"optimizely\"}";
@@ -133,7 +134,7 @@ namespace OptimizelySDK.Tests
             Assert.IsFalse(optimizely.IsValid);
         }
 
-        [TestMethod]
+        [Test]
         public void TestValidateInputsInvalidFileJsonValidationSkipped()
         {
             string datafile = "{\"name\":\"optimizely\"}";
@@ -141,7 +142,7 @@ namespace OptimizelySDK.Tests
             Assert.IsTrue(optimizely.IsValid);
         }
 
-        [TestMethod]
+        [Test]
         public void TestValidatePreconditionsExperimentNotRunning()
         {
             var optly = Helper.CreatePrivateOptimizely();
@@ -151,7 +152,7 @@ namespace OptimizelySDK.Tests
             Assert.IsFalse(result);
         }
 
-        [TestMethod]
+        [Test]
         public void TestValidatePreconditionsExperimentRunning()
         {
             var optly = Helper.CreatePrivateOptimizely();
@@ -167,7 +168,7 @@ namespace OptimizelySDK.Tests
             Assert.IsTrue(result);
         }
 
-        [TestMethod]
+        [Test]
         public void TestValidatePreconditionsUserInForcedVariationNotInExperiment()
         {
             var optly = Helper.CreatePrivateOptimizely();
@@ -177,7 +178,7 @@ namespace OptimizelySDK.Tests
             Assert.IsTrue(result);
         }
 
-        [TestMethod]
+        [Test]
         public void TestValidatePreconditionsUserInForcedVariationInExperiment()
         {
             var optly = Helper.CreatePrivateOptimizely();
@@ -187,7 +188,7 @@ namespace OptimizelySDK.Tests
             Assert.IsTrue(result);
         }
 
-        [TestMethod]
+        [Test]
         public void TestValidatePreconditionsUserNotInForcedVariationNotInExperiment()
         {
             var optly = Helper.CreatePrivateOptimizely();
@@ -197,7 +198,7 @@ namespace OptimizelySDK.Tests
             Assert.IsFalse(result);
         }
 
-        [TestMethod]
+        [Test]
         public void TestValidatePreconditionsUserNotInForcedVariationInExperiment()
         {
             var optly = Helper.CreatePrivateOptimizely();
@@ -213,7 +214,7 @@ namespace OptimizelySDK.Tests
             Assert.IsTrue(result);
         }
 
-        [TestMethod]
+        [Test]
         public void TestActivateInvalidOptimizelyObject()
         {
             var optly = new Optimizely("Random datafile", null, LoggerMock.Object);
@@ -239,7 +240,7 @@ namespace OptimizelySDK.Tests
             Assert.IsNull(result);
         } */
 
-        [TestMethod]
+        [Test]
         public void TestActivateUserInNoVariation()
         {
             var optly = Helper.CreatePrivateOptimizely();
@@ -258,7 +259,7 @@ namespace OptimizelySDK.Tests
             Assert.IsNull(result);
         }
 
-        [TestMethod]
+        [Test]
         public void TestActivateNoAudienceNoAttributes()
         {
             var parameters = new Dictionary<string, object>
@@ -290,7 +291,7 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual("group_exp_1_var_2", variationkey);
         }
 
-        [TestMethod]
+        [Test]
         public void TestActivateAudienceNoAttributes()
         {
             var optly = Helper.CreatePrivateOptimizely();
@@ -308,7 +309,7 @@ namespace OptimizelySDK.Tests
             Assert.IsNull(variationkey);
         }
 
-        [TestMethod]
+        [Test]
         public void TestActivateWithAttributes()
         {
             EventBuilderMock.Setup(b => b.CreateImpressionEvent(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(),
@@ -332,7 +333,7 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual("control", variationkey);
         }
 
-        [TestMethod]
+        [Test]
         public void TestActivateExperimentNotRunning()
         {
             var optly = Helper.CreatePrivateOptimizely();
@@ -350,7 +351,7 @@ namespace OptimizelySDK.Tests
             Assert.IsNull(variationkey);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetVariationInvalidOptimizelyObject()
         {
             var optly = new Optimizely("Random datafile", null, LoggerMock.Object);
@@ -376,7 +377,7 @@ namespace OptimizelySDK.Tests
             Assert.IsNull(result);
         } */
 
-        [TestMethod]
+        [Test]
         public void TestGetVariationAudienceMatch()
         {
             var attributes = new UserAttributes
@@ -394,7 +395,7 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual("control", variation);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetVariationAudienceNoMatch()
         {
             var variation = Optimizely.Activate("test_experiment", "test_user");
@@ -402,7 +403,7 @@ namespace OptimizelySDK.Tests
             Assert.IsNull(variation);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetVariationExperimentNotRunning()
         {
             var variation = Optimizely.Activate("paused_experiment", "test_user");
@@ -410,7 +411,7 @@ namespace OptimizelySDK.Tests
             Assert.IsNull(variation);
         }
 
-        [TestMethod]
+        [Test]
         public void TestTrackInvalidOptimizelyObject()
         {
             var optly = new Optimizely("Random datafile", null, LoggerMock.Object);
@@ -419,7 +420,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'track'."), Times.Once);
         }
 
-        [TestMethod]
+        [Test]
         public void TestTrackInvalidAttributes()
         {
             var attributes = new UserAttributes
@@ -433,7 +434,7 @@ namespace OptimizelySDK.Tests
             ErrorHandlerMock.Verify(e => e.HandleError(It.IsAny<InvalidAttributeException>()), Times.Once);
         }
 
-        [TestMethod]
+        [Test]
         public void TestTrackNoAttributesNoEventValue()
         {
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),
@@ -454,7 +455,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Dispatching conversion event to URL logx.optimizely.com/track with params {\"param1\":\"val1\"}."), Times.Once);
         }
 
-        [TestMethod]
+        [Test]
         public void TestTrackWithAttributesNoEventValue()
         {
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),
@@ -473,7 +474,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Dispatching conversion event to URL logx.optimizely.com/track with params {\"param1\":\"val1\"}."), Times.Once);
         }
 
-        [TestMethod]
+        [Test]
         public void TestTrackNoAttributesWithEventValue()
         {
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),
@@ -497,7 +498,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Dispatching conversion event to URL logx.optimizely.com/track with params {\"param1\":\"val1\"}."), Times.Once);
         }
 
-        [TestMethod]
+        [Test]
         public void TestTrackWithAttributesWithEventValue()
         {
             var attributes = new UserAttributes
@@ -527,7 +528,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Dispatching conversion event to URL logx.optimizely.com/track with params {\"param1\":\"val1\"}."), Times.Once);
         }
 
-        [TestMethod]
+        [Test]
         public void TestInvalidDispatchImpressionEvent()
         {
             EventBuilderMock.Setup(b => b.CreateImpressionEvent(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(),
@@ -549,7 +550,7 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual("control", variationkey);
         }
 
-        [TestMethod]
+        [Test]
         public void TestInvalidDispatchConversionEvent()
         {
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -14,24 +14,24 @@
  * limitations under the License.
  */
 using System;
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
 using Moq;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using OptimizelySDK.Exceptions;
+using NUnit.Framework;
 
 namespace OptimizelySDK.Tests
 {
-    [TestClass]
+    [TestFixture]
     public class ProjectConfigTest
     {
         private Mock<ILogger> LoggerMock;
         private Mock<IErrorHandler> ErrorHandlerMock;
         private ProjectConfig Config;
 
-        [TestInitialize]
+        [SetUp]
         public void Setup()
         {
             LoggerMock = new Mock<ILogger>();
@@ -46,7 +46,7 @@ namespace OptimizelySDK.Tests
             return new Dictionary<string, object>() { { name, entityObject } };
         }
 
-        [TestMethod]
+        [Test]
         public void TestInit()
         {
             // Check Version
@@ -173,19 +173,19 @@ namespace OptimizelySDK.Tests
             Assert.IsTrue(TestData.CompareObjects(variationIdMap, Config.VariationIdMap));
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetAccountId()
         {
             Assert.AreEqual("1592310167", Config.AccountId);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetProjectId()
         {
             Assert.AreEqual("7720880029", Config.ProjectId);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetGroupValidId()
         {
             var group = Config.GetGroup("7722400015");
@@ -193,7 +193,7 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual("random", group.Policy);            
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetGroupInvalidId()
         {
 
@@ -210,7 +210,7 @@ namespace OptimizelySDK.Tests
             Assert.IsTrue(TestData.CompareObjects(group, new Entity.Group()));
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetExperimentValidKey()
         {
             var experiment = Config.GetExperimentFromKey("test_experiment");
@@ -218,7 +218,7 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual("7716830082", experiment.Id);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetExperimentInvalidKey()
         {
             var experiment = Config.GetExperimentFromKey("invalid_key");
@@ -231,7 +231,7 @@ namespace OptimizelySDK.Tests
             Assert.IsTrue(TestData.CompareObjects(new Entity.Experiment(), experiment));
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetExperimentValidId()
         {
             var experiment = Config.GetExperimentFromId("7716830082");
@@ -239,7 +239,7 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual("test_experiment", experiment.Key);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetExperimentInvalidId()
         {
             var experiment = Config.GetExperimentFromId("42");
@@ -252,7 +252,7 @@ namespace OptimizelySDK.Tests
             Assert.IsTrue(TestData.CompareObjects(new Entity.Experiment(), experiment));
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetEventValidKey()
         {
             var ev = Config.GetEvent("purchase");
@@ -263,7 +263,7 @@ namespace OptimizelySDK.Tests
 
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetEventInvalidKey()
         {
             var ev = Config.GetEvent("invalid_key");
@@ -276,7 +276,7 @@ namespace OptimizelySDK.Tests
             Assert.IsTrue(TestData.CompareObjects(new Entity.Event(), ev));
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetAudienceValidId()
         {
             var audience = Config.GetAudience("7718080042");
@@ -285,7 +285,7 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual("iPhone users in San Francisco", audience.Name);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetAudienceInvalidKey()
         {
             var audience = Config.GetAudience("invalid_id");
@@ -297,7 +297,7 @@ namespace OptimizelySDK.Tests
             Assert.IsTrue(TestData.CompareObjects(new Entity.Audience(), audience));
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetAttributeValidKey()
         {
             var attribute = Config.GetAttribute("device_type");
@@ -306,7 +306,7 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual("7723280020", attribute.Id);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetAttributeInvalidKey()
         {
 
@@ -323,7 +323,7 @@ namespace OptimizelySDK.Tests
         /// EK = Experiment Key 
         /// VK = Variation Key
         /// </summary>
-        [TestMethod]
+        [Test]
         public void TestGetVariationFromKeyValidEKValidVK()
         {
             var variation = Config.GetVariationFromKey("test_experiment", "control");
@@ -336,7 +336,7 @@ namespace OptimizelySDK.Tests
         /// EK = Experiment Key 
         /// VK = Variation Key
         /// </summary>
-        [TestMethod]
+        [Test]
         public void TestGetVariationFromKeyValidEKInvalidVK()
         {
             var variation = Config.GetVariationFromKey("test_experiment", "invalid_key");
@@ -351,7 +351,7 @@ namespace OptimizelySDK.Tests
 
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetVariationFromKeyInvalidEK()
         {
             var variation = Config.GetVariationFromKey("invalid_experiment", "control");
@@ -363,7 +363,7 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(new Entity.Variation(), variation);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetVariationFromIdValidEKValidVId()
         {
 
@@ -372,7 +372,7 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual("7722370027", variation.Id);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetVariationFromIdValidEKInvalidVId()
         {
 
@@ -385,7 +385,7 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(new Entity.Variation(), variation);
         }
 
-        [TestMethod]
+        [Test]
         public void TestGetVariationFromIdInvalidEK()
         {
             var variation = Config.GetVariationFromId("invalid_experiment", "7722370027");
@@ -397,7 +397,7 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(new Entity.Variation(), variation);
         }
 
-        [TestMethod]
+        [Test]
         public void TempProjectConfigTest()
         {
             ProjectConfig config = ProjectConfig.Create(TestData.Datafile, new Mock<ILogger>().Object, new DefaultErrorHandler());

--- a/OptimizelySDK.Tests/UtilsTests/ConditionEvaluatorTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/ConditionEvaluatorTest.cs
@@ -13,20 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NUnit.Framework;
 using OptimizelySDK.Entity;
 using OptimizelySDK.Utils;
 
 namespace OptimizelySDK.Tests.UtilsTests
 {
-    [TestClass]
+    [TestFixture]
     public class ConditionEvaluatorTest
     {
         private ConditionEvaluator ConditionEvaluator = null;
         private object[] Conditions = null;
         private const string ConditionsStr = @"[""and"", [""or"", [""or"", {""name"": ""device_type"", ""type"": ""custom_attribute"", ""value"": ""iPhone""}]], [""or"", [""or"", {""name"": ""location"", ""type"": ""custom_attribute"", ""value"": ""San Francisco""}]], [""or"", [""not"", [""or"", {""name"": ""browser"", ""type"": ""custom_attribute"", ""value"": ""Firefox""}]]]]";
 
-        [TestInitialize]
+        [TestFixtureSetUp]
         public void Initialize()
         {
             ConditionEvaluator = new ConditionEvaluator();
@@ -34,14 +34,14 @@ namespace OptimizelySDK.Tests.UtilsTests
             Conditions = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(ConditionsStr);
         }
 
-        [TestCleanup]
+        [TestFixtureTearDown]
         public void TestCleanUp()
         {
             Conditions = null;
             ConditionEvaluator = null;
         }
 
-        [TestMethod]
+        [Test]
         public void TestEvaluateConditionsMatch()
         {
             var userAttributes = new UserAttributes
@@ -54,7 +54,7 @@ namespace OptimizelySDK.Tests.UtilsTests
             Assert.IsTrue(ConditionEvaluator.Evaluate(Conditions, userAttributes));
         }
 
-        [TestMethod]
+        [Test]
         public void TestEvaluateConditionsDoNotMatch()
         {
             var userAttributes = new UserAttributes
@@ -67,7 +67,7 @@ namespace OptimizelySDK.Tests.UtilsTests
             Assert.IsFalse(ConditionEvaluator.Evaluate(Conditions, userAttributes));
         }
 
-        [TestMethod]
+        [Test]
         public void TestEvaluateEmptyUserAttributes()
         {
             var userAttributes = new UserAttributes();
@@ -75,7 +75,7 @@ namespace OptimizelySDK.Tests.UtilsTests
             Assert.IsFalse(ConditionEvaluator.Evaluate(Conditions, userAttributes));
         }
 
-        [TestMethod]
+        [Test]
         public void TestEvaluateNullUserAttributes()
         {
             UserAttributes userAttributes = null;

--- a/OptimizelySDK.Tests/UtilsTests/PrivateObject.cs
+++ b/OptimizelySDK.Tests/UtilsTests/PrivateObject.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Reflection;
+
+namespace OptimizelySDK.Tests.UtilsTests
+{
+    internal class PrivateObject
+    {
+        private object createdInstance;
+        private Type instanceType;
+
+        public PrivateObject(Type privateObject, Type[] parameterTypes, object[] parameterValues)
+        {
+            instanceType = privateObject;
+            createdInstance = Activator.CreateInstance(instanceType, parameterValues);
+        }
+        private PrivateObject(Type privateObject, object[] parameterValues)
+        {
+            instanceType = privateObject;
+            createdInstance = Activator.CreateInstance(instanceType, parameterValues);
+        }
+
+        public void SetFieldOrProperty(string propertyName, object value)
+        {
+            instanceType.InvokeMember(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.SetProperty | BindingFlags.NonPublic | BindingFlags.SetField,
+                Type.DefaultBinder, createdInstance, new object[] { value });
+        }
+
+        public object Invoke(string name, params object[] args)
+        {
+            return instanceType.InvokeMember(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.InvokeMethod | BindingFlags.NonPublic,
+                Type.DefaultBinder, createdInstance, args);
+        }
+    }
+}

--- a/OptimizelySDK.Tests/UtilsTests/ValidatorTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/ValidatorTest.cs
@@ -13,22 +13,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-using Microsoft.VisualStudio.TestTools.UnitTesting;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Utils;
 using OptimizelySDK.Entity;
+using NUnit.Framework;
 
 namespace OptimizelySDK.Tests.UtilsTests
 {
-    [TestClass]
+    [TestFixture]
     public class ValidatorTest
     {
         private ILogger Logger;
         private IErrorHandler ErrorHandler;
         private ProjectConfig Config;
 
-        [TestInitialize]
+        [TestFixtureSetUp]
         public void Setup()
         {
             Logger = new DefaultLogger();
@@ -37,7 +37,7 @@ namespace OptimizelySDK.Tests.UtilsTests
             Config = ProjectConfig.Create(TestData.Datafile, Logger, ErrorHandler);
         }
 
-        [TestMethod]
+        [Test]
         public void TestValidateJsonSchemaValidFileWithAdditionalProperty()
         {
             Assert.IsTrue(Validator.ValidateJSONSchema(TestData.Datafile));
@@ -46,13 +46,13 @@ namespace OptimizelySDK.Tests.UtilsTests
             Assert.IsTrue(testDataJSON.ContainsKey("tempproperty"));
         }
 
-        [TestMethod]
+        [Test]
         public void TestValidateJsonSchemaValidFile()
         {
             Assert.IsTrue(Validator.ValidateJSONSchema(TestData.Datafile));
         }
 
-        [TestMethod]
+        [Test]
         public void TestValidateJsonSchemaInvalidFile()
         {
             var invalidScehma = @"{""key1"": ""val1""}";
@@ -60,7 +60,7 @@ namespace OptimizelySDK.Tests.UtilsTests
         }
 
 
-        [TestMethod]
+        [Test]
         public void TestValidateJsonSchemaNoJsonContent()
         {
             var invalidDataFile = @"Some Randaom file";
@@ -77,13 +77,13 @@ namespace OptimizelySDK.Tests.UtilsTests
          */
 
 
-        [TestMethod]
+        [Test]
         public void TestIsUserInExperimentNoAudienceUsedInExperiment()
         {
             Assert.IsTrue(Validator.IsUserInExperiment(Config, Config.GetExperimentFromKey("paused_experiment"), new UserAttributes()));
         }
 
-        [TestMethod]
+        [Test]
         public void TestIsUserInExperimentAudienceUsedInExperimentNoAttributesProvided()
         {
             Assert.IsFalse(Validator.IsUserInExperiment(Config, Config.GetExperimentFromKey("test_experiment"), new UserAttributes()));
@@ -91,7 +91,7 @@ namespace OptimizelySDK.Tests.UtilsTests
             Assert.IsFalse(Validator.IsUserInExperiment(Config, Config.GetExperimentFromKey("test_experiment"), null));
         }
 
-        [TestMethod]
+        [Test]
         public void TestUserInExperimentAudienceMatch()
         {
             var userAttributes = new UserAttributes
@@ -102,7 +102,7 @@ namespace OptimizelySDK.Tests.UtilsTests
             Assert.IsTrue(Validator.IsUserInExperiment(Config, Config.GetExperimentFromKey("test_experiment"), userAttributes));
         }
 
-        [TestMethod]
+        [Test]
         public void TestIsUserInExperimentAudienceNoMatch()
         {
             var userAttributes = new UserAttributes
@@ -114,7 +114,7 @@ namespace OptimizelySDK.Tests.UtilsTests
             Assert.IsFalse(Validator.IsUserInExperiment(Config, Config.GetExperimentFromKey("test_experiment"), null));
         }
 
-        [TestMethod]
+        [Test]
         public void TestAreEventTagsValidValidEventTags()
         {
             Assert.IsTrue(Validator.AreEventTagsValid(new System.Collections.Generic.Dictionary<string, object>()));

--- a/OptimizelySDK.Tests/packages.config
+++ b/OptimizelySDK.Tests/packages.config
@@ -3,6 +3,7 @@
   <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
   <package id="Moq" version="4.7.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="OpenCover" version="4.6.519" targetFramework="net45" />
   <package id="ReportGenerator" version="2.5.6" targetFramework="net45" />
 </packages>

--- a/OptimizelySDK/OptimizelySDK.csproj
+++ b/OptimizelySDK/OptimizelySDK.csproj
@@ -34,8 +34,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
-    <DefineConstants Condition=" !$(DefineConstants.Contains(';NET')) ">$(DefineConstants);$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", ""))</DefineConstants>
-    <DefineConstants Condition=" $(DefineConstants.Contains(';NET')) ">$(DefineConstants.Remove($(DefineConstants.LastIndexOf(";NET"))));$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", ""))</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v3.5'">NET35</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v4.0'">NET40</DefineConstants>
+    <!-- <DefineConstants Condition=" !$(DefineConstants.Contains(';NET')) ">$(DefineConstants);$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", ""))</DefineConstants> -->
+    <!-- <DefineConstants Condition=" $(DefineConstants.Contains(';NET')) ">$(DefineConstants.Remove($(DefineConstants.LastIndexOf(";NET"))));$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", ""))</DefineConstants> -->
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="MurmurHash, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">


### PR DESCRIPTION
Summary of Changes.
- Replaced UnitTesting framework to NUnit (Compatible with Mono)
- Logic for changing .net framework changed.
- Removed Microsoft. Unittesting assembly (Not compatible with travis & Mono)
- A class created to access private memebers & fields using reflection. (Microsoft.UnitTesting assembly was being used before).
@mikeng13 @aliabbasrizvi 