### PR TITLE
runtime enviornment issue netframework 4.0 fixed

### DIFF
--- a/OptimizelySDK.Net35/packages.config
+++ b/OptimizelySDK.Net35/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="murmurhash" version="1.0.0" targetFramework="net35" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net35" />
 </packages>

--- a/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
+++ b/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{C8FF7012-37B7-4D64-AB45-0C62195302EC}</ProjectGuid>
+    <ProjectGuid>{41AFD990-BC81-49E3-BD85-40972BB2C262}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>OptimizelySDK.Net35</RootNamespace>
-    <AssemblyName>OptimizelySDK.Net35</AssemblyName>
-    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <RootNamespace>OptimizelySDK.Net40</RootNamespace>
+    <AssemblyName>OptimizelySDK.Net40</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -31,16 +31,16 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="MurmurHash, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\murmurhash.1.0.0\lib\net35\MurmurHash.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\murmurhash.1.0.0\lib\net40\MurmurHash.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net35\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -171,11 +171,4 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/OptimizelySDK.Net40/Properties/AssemblyInfo.cs
+++ b/OptimizelySDK.Net40/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("OptimizelySDK.Net40")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("OptimizelySDK.Net40")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("41afd990-bc81-49e3-bd85-40972bb2c262")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/OptimizelySDK.Net40/packages.config
+++ b/OptimizelySDK.Net40/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="murmurhash" version="1.0.0" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
+</packages>

--- a/OptimizelySDK.Package/pack.ps1
+++ b/OptimizelySDK.Package/pack.ps1
@@ -14,7 +14,7 @@ Write-Host "Build complete. Copying files..."
 
 Copy-Item  -Path "..\OptimizelySDK\bin\Release\OptimizelySDK.dll" -Destination ".\lib\net45"  -Recurse -force
 Copy-Item  -Path "..\OptimizelySDK.Net35\bin\Release\OptimizelySDK.Net35.dll" -Destination ".\lib\net35"  -Recurse -force
-Copy-Item  -Path "..\OptimizelySDK.Net35\bin\Release\OptimizelySDK.Net35.dll" -Destination ".\lib\net40\"  -Recurse -force
+Copy-Item  -Path "..\OptimizelySDK.Net40\bin\Release\OptimizelySDK.Net40.dll" -Destination ".\lib\net40"  -Recurse -force
 Copy-Item  -Path "..\OptimizelySDK.NetStandard16\bin\Release\netstandard1.6\OptimizelySDK.NetStandard16.dll" -Destination ".\lib\netstandard1.6"  -Recurse -force
 
 

--- a/OptimizelySDK.sln
+++ b/OptimizelySDK.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.10
+VisualStudioVersion = 15.0.26430.16
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OptimizelySDK.DemoApp", "OptimizelySDK.DemoApp\OptimizelySDK.DemoApp.csproj", "{9394F666-6397-41C0-8867-C3E4DA9156E3}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -20,9 +20,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OptimizelySDK.NetStandard16", "OptimizelySDK.NetStandard16\OptimizelySDK.NetStandard16.csproj", "{EDCF3773-56E7-416E-A379-B6999A8D8570}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OptimizelySDK.NetStandard16", "OptimizelySDK.NetStandard16\OptimizelySDK.NetStandard16.csproj", "{EDCF3773-56E7-416E-A379-B6999A8D8570}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OptimizelySDK.Net35", "OptimizelySDK.Net35\OptimizelySDK.Net35.csproj", "{C8FF7012-37B7-4D64-AB45-0C62195302EC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OptimizelySDK.Net40", "OptimizelySDK.Net40\OptimizelySDK.Net40.csproj", "{41AFD990-BC81-49E3-BD85-40972BB2C262}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -50,6 +52,10 @@ Global
 		{C8FF7012-37B7-4D64-AB45-0C62195302EC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8FF7012-37B7-4D64-AB45-0C62195302EC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8FF7012-37B7-4D64-AB45-0C62195302EC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{41AFD990-BC81-49E3-BD85-40972BB2C262}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41AFD990-BC81-49E3-BD85-40972BB2C262}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41AFD990-BC81-49E3-BD85-40972BB2C262}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41AFD990-BC81-49E3-BD85-40972BB2C262}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Newtonsoft for .netframework 4.0 had runtime 4.000 version while 3.5 had 2.000.

When OptimizelySDK dll for framework was being used, it was installing runtime 4.0 version while we were using 3.5 dll for framework 4.0 as well, so it was assuming 2.0 runtime version. I have separated out 4.0 & 3.5 using same code base but DLL is different now.
@mikeng13