### PR TITLE
Kroach/oasis 1806 null

### DIFF
--- a/OptimizelySDK.DemoApp/OptimizelySDK.DemoApp.csproj
+++ b/OptimizelySDK.DemoApp/OptimizelySDK.DemoApp.csproj
@@ -28,8 +28,8 @@
     <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType></DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
@@ -71,7 +71,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web.DynamicData" />
-    <Reference Include="System.Web.Entity" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Web.Extensions" />
@@ -222,6 +221,11 @@
         </WebProjectProperties>
       </FlavorProperties>
     </VisualStudio>
+    <MonoDevelop>
+      <Properties>
+        <XspParameters Port="8080" Address="127.0.0.1" SslMode="None" SslProtocol="Default" KeyType="None" CertFile="" KeyFile="" PasswordOptions="None" Password="" Verbose="True" />
+      </Properties>
+    </MonoDevelop>
   </ProjectExtensions>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/OptimizelySDK.DemoApp/Web.config
+++ b/OptimizelySDK.DemoApp/Web.config
@@ -23,7 +23,11 @@
       </system.Web>
   -->
   <system.web>
-    <compilation debug="true" targetFramework="4.5" />
+    <compilation debug="true" targetFramework="4.5">
+      <assemblies>
+        <add assembly="System.Net.Http.WebRequest, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+      </assemblies>
+    </compilation>
     <httpRuntime targetFramework="4.5" />
   </system.web>
   <runtime>

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -41,6 +41,7 @@ namespace OptimizelySDK.Tests
         private const string TestUserId = "testUserId";
         private OptimizelyHelper Helper;
 
+        #region Test Life Cycle
         [SetUp]
         public void Initialize()
         {
@@ -83,7 +84,9 @@ namespace OptimizelySDK.Tests
             Config = null;
             EventBuilderMock = null;
         }
-        
+        #endregion
+
+        #region OptimizelyHelper
         private class OptimizelyHelper
         {
             static Type[] ParameterTypes = new[]
@@ -128,7 +131,9 @@ namespace OptimizelySDK.Tests
                     });
             }
         }
+        #endregion
 
+        #region Test Validate
         [Test]
         public void TestValidateInputsInvalidFileJsonValidationNotSkipped()
         {
@@ -293,7 +298,9 @@ namespace OptimizelySDK.Tests
 
             Assert.AreEqual("group_exp_1_var_2", variationkey);
         }
+        #endregion
 
+        #region Test Activate
         [Test]
         public void TestActivateAudienceNoAttributes()
         {
@@ -353,7 +360,9 @@ namespace OptimizelySDK.Tests
 
             Assert.IsNull(variationkey);
         }
+        #endregion
 
+        #region Test GetVariation
         [Test]
         public void TestGetVariationInvalidOptimizelyObject()
         {
@@ -379,7 +388,6 @@ namespace OptimizelySDK.Tests
 
             Assert.IsNull(result);
         } */
-
         [Test]
         public void TestGetVariationAudienceMatch()
         {
@@ -423,7 +431,9 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(2));
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'track'."), Times.Once);
         }
+        #endregion
 
+        #region Test Track
         [Test]
         public void TestTrackInvalidAttributes()
         {
@@ -549,7 +559,9 @@ namespace OptimizelySDK.Tests
 
             Assert.AreEqual("control", variationkey);
         }
+        #endregion
 
+        #region Test Invalid Dispatch
         [Test]
         public void TestInvalidDispatchConversionEvent()
         {
@@ -571,7 +583,9 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Tracking event purchase for user test_user."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Dispatching conversion event to URL logx.optimizely.com/track with params {\"param1\":\"val1\"}."), Times.Once);
         }
+        #endregion
 
+        #region Test Misc
         /* Start 1 */
      public void TestTrackNoAttributesWithInvalidEventValue()
      {
@@ -714,5 +728,6 @@ namespace OptimizelySDK.Tests
     }
 
     /* End */
+        #endregion
 }
 }

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -576,7 +576,9 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Tracking event purchase for user test_user."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Dispatching conversion event to URL logx.optimizely.com/track with params {\"param1\":\"val1\"}."), Times.Once);
         }
+        #endregion
 
+        #region Test Invalid Dispatch
         [Test]
         public void TestInvalidDispatchImpressionEvent()
         {
@@ -598,9 +600,7 @@ namespace OptimizelySDK.Tests
 
             Assert.AreEqual("control", variationkey);
         }
-        #endregion
 
-        #region Test Invalid Dispatch
         [Test]
         public void TestInvalidDispatchConversionEvent()
         {

--- a/OptimizelySDK/Entity/EventAttributes.cs
+++ b/OptimizelySDK/Entity/EventAttributes.cs
@@ -14,10 +14,22 @@
  * limitations under the License.
  */
 using System.Collections.Generic;
+using OptimizelySDK.Logger;
 
 namespace OptimizelySDK.Entity
 {
     public class EventTags : Dictionary<string, object>
     {
+        public EventTags FilterNullValues(ILogger logger) {
+            EventTags answer = new EventTags();
+            foreach (KeyValuePair<string, object> pair in this) {
+                if (pair.Value != null) {
+                    answer[pair.Key] = pair.Value;
+                } else {
+                    logger.Log(LogLevel.ERROR, string.Format("[EventTags] Null value for key {0} removed and will not be sent to results.", pair.Key));
+                }
+            }
+            return answer;
+        }
     }
 }

--- a/OptimizelySDK/Entity/UserAttributes.cs
+++ b/OptimizelySDK/Entity/UserAttributes.cs
@@ -14,10 +14,23 @@
  * limitations under the License.
  */
 using System.Collections.Generic;
+using OptimizelySDK.Logger;
 
 namespace OptimizelySDK.Entity
 {
     public class UserAttributes : Dictionary<string, string>
     {
+        public UserAttributes FilterNullValues(ILogger logger)
+        {
+            UserAttributes answer = new UserAttributes();
+            foreach (KeyValuePair<string, string> pair in this) {
+                if (pair.Value != null) {
+                    answer[pair.Key] = pair.Value;
+                } else {
+                    logger.Log(LogLevel.ERROR, string.Format("[UserAttributes] Null value for key {0} removed and will not be sent to results.", pair.Key));
+                }
+            }
+            return answer;
+        }
     }
 }

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -149,6 +149,10 @@ namespace OptimizelySDK
                 return null;
             }
 
+            if (userAttributes != null) {
+                userAttributes = userAttributes.FilterNullValues(Logger);
+            }
+
             var impressionEvent = EventBuilder.CreateImpressionEvent(Config, experiment, variation.Id, userId, userAttributes);
             Logger.Log(LogLevel.INFO, string.Format("Activating user {0} in experiment {1}.", userId, experimentKey));
             Logger.Log(LogLevel.DEBUG, string.Format("Dispatching impression event to URL {0} with params {1}.", 
@@ -221,6 +225,17 @@ namespace OptimizelySDK
 
             if (validExperiments.Count > 0)
             {
+
+                if (userAttributes != null)
+                {
+                    userAttributes = userAttributes.FilterNullValues(Logger);
+                }
+
+                if (eventTags != null)
+                {
+                    eventTags = eventTags.FilterNullValues(Logger);
+                }
+
                 var conversionEvent = EventBuilder.CreateConversionEvent(Config, eventKey, validExperiments,
                     userId, userAttributes, eventTags);
                 Logger.Log(LogLevel.INFO, string.Format("Tracking event {0} for user {1}.", eventKey, userId));


### PR DESCRIPTION
OASIS-1806 [C#] Prune null/nil/None value attributes in track/activate

Don't include JSON null's in any JSON the SDK sends to server.

Among the reasons why is the distinction between actual absence
of a key-value pair and presence of a key-value pair whose value
is "null" gets messy/confused/unsupported depending on the particular
platform or DB . Limit Optimizely JSON's to JSON's built via
booleans, numbers, strings, arrays, and objects (aka dictionaries).
Don't use JSON null's.