### PR TITLE
Bug fix: Track method was sending bucketer variation in every case

### DIFF
--- a/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
@@ -241,8 +241,12 @@ namespace OptimizelySDK.Tests.EventTests
                 {
                     { "Content-Type", "application/json"}
                 });
+            var experimentToVariationMap = new Dictionary<string, Variation>
+            {
+                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+            };
 
-            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", new Experiment[] { Config.GetExperimentFromKey("test_experiment") }, TestUserId, null, null);
+            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", experimentToVariationMap, TestUserId, null, null);
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
@@ -326,8 +330,11 @@ namespace OptimizelySDK.Tests.EventTests
                 { "device_type", "iPhone" },
                 {"company", "Optimizely" }
             };
-
-            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", new Experiment[] { Config.GetExperimentFromKey("test_experiment") }, TestUserId, userAttributes, null);
+            var experimentToVariationMap = new Dictionary<string, Variation>
+            {
+                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+            };
+            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", experimentToVariationMap, TestUserId, userAttributes, null);
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
@@ -403,8 +410,13 @@ namespace OptimizelySDK.Tests.EventTests
                     { "Content-Type", "application/json"}
                 });
 
+            var experimentToVariationMap = new Dictionary<string, Variation>
+            {
+                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+            };
 
-            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", new Experiment[] { Config.GetExperimentFromKey("test_experiment") }, TestUserId, null,
+
+            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", experimentToVariationMap, TestUserId, null,
                 new EventTags
             {
                     {"revenue", 42 }
@@ -501,7 +513,12 @@ namespace OptimizelySDK.Tests.EventTests
                 {"company", "Optimizely" }
             };
 
-            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", new Experiment[] { Config.GetExperimentFromKey("test_experiment") }, TestUserId, userAttributes,
+            var experimentToVariationMap = new Dictionary<string, Variation>
+            {
+                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+            };
+
+            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", experimentToVariationMap, TestUserId, userAttributes,
                 new EventTags
                 {
                     {"revenue", 42 },
@@ -582,7 +599,12 @@ namespace OptimizelySDK.Tests.EventTests
                     { "Content-Type", "application/json"}
                 });
 
-            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", new Experiment[] { Config.GetExperimentFromKey("test_experiment") }, TestUserId, null,
+            var experimentToVariationMap = new Dictionary<string, Variation>
+            {
+                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+            };
+
+            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", experimentToVariationMap, TestUserId, null,
                 new EventTags
                 {
                     {"revenue", "42" },
@@ -665,8 +687,12 @@ namespace OptimizelySDK.Tests.EventTests
                     { "Content-Type", "application/json"}
                 });
 
+            var experimentToVariationMap = new Dictionary<string, Variation>
+            {
+                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+            };
 
-            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", new Experiment[] { Config.GetExperimentFromKey("test_experiment") }, TestUserId, null,
+            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", experimentToVariationMap, TestUserId, null,
                 new EventTags
             {
                     {"revenue", 42 },

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -57,7 +57,7 @@ namespace OptimizelySDK.Tests
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<UserAttributes>()));
 
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),
-                It.IsAny<IEnumerable<Experiment>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()));
+                It.IsAny<Dictionary<string, Variation>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()));
 
             Config = ProjectConfig.Create(
                 content: TestData.Datafile,
@@ -499,7 +499,7 @@ namespace OptimizelySDK.Tests
         public void TestTrackNoAttributesNoEventValue()
         {
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),
-                It.IsAny<IEnumerable<Experiment>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
+                It.IsAny<Dictionary<string,Variation>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
               .Returns(new LogEvent("logx.optimizely.com/track", OptimizelyHelper.SingleParameter,
                                         "POST", new Dictionary<string, string> { }));
 
@@ -519,7 +519,7 @@ namespace OptimizelySDK.Tests
         public void TestTrackWithAttributesNoEventValue()
         {
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),
-                It.IsAny<IEnumerable<Experiment>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
+                It.IsAny<Dictionary<string, Variation>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
              .Returns(new LogEvent("logx.optimizely.com/track", OptimizelyHelper.SingleParameter,
                                        "POST", new Dictionary<string, string> { }));
 
@@ -537,7 +537,7 @@ namespace OptimizelySDK.Tests
         public void TestTrackNoAttributesWithEventValue()
         {
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),
-                It.IsAny<IEnumerable<Experiment>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
+                It.IsAny<Dictionary<string, Variation>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
              .Returns(new LogEvent("logx.optimizely.com/track", OptimizelyHelper.SingleParameter,
                                        "POST", new Dictionary<string, string> { }));
 
@@ -566,7 +566,7 @@ namespace OptimizelySDK.Tests
             };
 
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),
-                It.IsAny<IEnumerable<Experiment>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
+                It.IsAny<Dictionary<string, Variation>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
              .Returns(new LogEvent("logx.optimizely.com/track", OptimizelyHelper.SingleParameter,
                                        "POST", new Dictionary<string, string> { }));
 
@@ -589,7 +589,7 @@ namespace OptimizelySDK.Tests
         public void TestTrackWithNullAttributesWithNullEventValue()
         {
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),
-                It.IsAny<IEnumerable<Experiment>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
+                It.IsAny<Dictionary<string, Variation>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
              .Returns(new LogEvent("logx.optimizely.com/track", OptimizelyHelper.SingleParameter,
                                        "POST", new Dictionary<string, string> { }));
 
@@ -652,7 +652,7 @@ namespace OptimizelySDK.Tests
         public void TestInvalidDispatchConversionEvent()
         {
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),
-                 It.IsAny<IEnumerable<Experiment>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
+                 It.IsAny<Dictionary<string, Variation>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
                .Returns(new LogEvent("logx.optimizely.com/track", OptimizelyHelper.SingleParameter,
                                          "POST", new Dictionary<string, string> { }));
 
@@ -676,7 +676,7 @@ namespace OptimizelySDK.Tests
         public void TestTrackNoAttributesWithInvalidEventValue()
         {
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),
-                 It.IsAny<IEnumerable<Experiment>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
+                 It.IsAny<Dictionary<string, Variation>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
                .Returns(new LogEvent("logx.optimizely.com/track", OptimizelyHelper.SingleParameter,
                                          "POST", new Dictionary<string, string> { }));
 
@@ -697,7 +697,7 @@ namespace OptimizelySDK.Tests
              * In this case, int value can't be casted implicitly into Dictionary */
 
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),
-                 It.IsAny<IEnumerable<Experiment>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
+                 It.IsAny<Dictionary<string, Variation>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
                .Returns(new LogEvent("logx.optimizely.com/track", OptimizelyHelper.SingleParameter,
                                          "POST", new Dictionary<string, string> { }));
 
@@ -1036,7 +1036,7 @@ namespace OptimizelySDK.Tests
             };
 
             EventBuilderMock.Setup(b => b.CreateConversionEvent(It.IsAny<ProjectConfig>(), It.IsAny<string>(),
-                It.IsAny<IEnumerable<Experiment>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
+                It.IsAny<Dictionary<string, Variation>>(), It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<EventTags>()))
                 .Returns(new LogEvent("logx.optimizely.com/track", parameters, "POST", new Dictionary<string, string> { }));
 
             var optly = Helper.CreatePrivateOptimizely();

--- a/OptimizelySDK/Event/Builder/EventBuilder.cs
+++ b/OptimizelySDK/Event/Builder/EventBuilder.cs
@@ -152,13 +152,14 @@ namespace OptimizelySDK.Event.Builder
             return impressionEvent;
         }
 
-        private List<object> GetConversionParams(ProjectConfig config, string eventKey, Experiment[] experiments, string userId, Dictionary<string, object> eventTags)
+        private List<object> GetConversionParams(ProjectConfig config, string eventKey, Dictionary<string, Variation> experimentIdVariationMap, string userId, Dictionary<string, object> eventTags)
         {
 
             var conversionEventParams = new List<object>();
-            foreach (var experiment in experiments)
+            foreach (var experimentId in experimentIdVariationMap.Keys)
             {
-                var variation = Bucketer.Bucket(config, experiment, userId);
+                var variation = experimentIdVariationMap[experimentId];
+                var experiment = config.ExperimentIdMap[experimentId];
                 var eventEntity = config.EventKeyMap[eventKey];
 
                 if (string.IsNullOrEmpty(variation.Key)) continue;
@@ -255,17 +256,16 @@ namespace OptimizelySDK.Event.Builder
         /// </summary>
         /// <param name="config">ProjectConfig Configuration for the project.</param>
         /// <param name="eventKey">Event Key representing the event</param>
-        /// <param name="experiments">collection of Experiments for which conversion event needs to be recorded</param>
+        /// <param name="ExperimentIdVariationMap">Map of experiment ID to the variation that the user is bucketed into.</param>
         /// <param name="userId">ID of user</param>
         /// <param name="userAttributes">associative array of Attributes for the user</param>
         /// <param name="eventValue">integer Value associated with the event</param>
         /// <returns>LogEvent object to be sent to dispatcher</returns>
-        public virtual LogEvent CreateConversionEvent(ProjectConfig config, string eventKey, IEnumerable<Experiment> experiments,
-            string userId, UserAttributes userAttributes, EventTags eventTags)
+        public virtual LogEvent CreateConversionEvent(ProjectConfig config, string eventKey, Dictionary<string, Variation> experimentIdVariationMap, string userId, UserAttributes userAttributes, EventTags eventTags)
         {
             var commonParams = GetCommonParams(config, userId, userAttributes ?? new UserAttributes());
 
-            var conversionOnlyParams = GetConversionParams(config, eventKey, experiments.ToArray(), userId, eventTags).ToArray();
+            var conversionOnlyParams = GetConversionParams(config, eventKey, experimentIdVariationMap, userId, eventTags).ToArray();
 
             var conversionParams = GetImpressionOrConversionParamsWithCommonParams(commonParams, conversionOnlyParams);
 

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -206,16 +206,17 @@ namespace OptimizelySDK
             }
 
             // Filter out experiments that are not running or when user(s) do not meet conditions.
-            var validExperiments = new List<Experiment>();
+            var validExperimentIdToVariationMap = new Dictionary<string, Variation>();
             var experimentIds = eevent.ExperimentIds;
             foreach (string id in eevent.ExperimentIds)
             {
                 var experiment = Config.GetExperimentFromId(id);
                 //Validate experiment
                 var variation = DecisionService.GetVariation(experiment, userId, userAttributes);
+
                 if (variation != null)
                 {
-                    validExperiments.Add(experiment);
+                    validExperimentIdToVariationMap[experiment.Id] = variation;
                 }
                 else
                 {
@@ -223,7 +224,7 @@ namespace OptimizelySDK
                 }
             }
 
-            if (validExperiments.Count > 0)
+            if (validExperimentIdToVariationMap.Count > 0)
             {
 
                 if (userAttributes != null)
@@ -236,7 +237,7 @@ namespace OptimizelySDK
                     eventTags = eventTags.FilterNullValues(Logger);
                 }
 
-                var conversionEvent = EventBuilder.CreateConversionEvent(Config, eventKey, validExperiments,
+                var conversionEvent = EventBuilder.CreateConversionEvent(Config, eventKey, validExperimentIdToVariationMap,
                     userId, userAttributes, eventTags);
                 Logger.Log(LogLevel.INFO, string.Format("Tracking event {0} for user {1}.", eventKey, userId));
                 Logger.Log(LogLevel.DEBUG, string.Format("Dispatching conversion event to URL {0} with params {1}.", 


### PR DESCRIPTION
In the Conversion Params, variation was calculated from the Bucket.Bucket, so whitelisted, forcedvariation was not being considered. I have changed the argument type to Map and Track method is getting from variation from DecisionService & passing it to the EventBuilder conversion params.