### PR TITLE
Kroach/oasis 2035 log

### DIFF
--- a/OptimizelySDK.DemoApp/Controllers/DemoController.cs
+++ b/OptimizelySDK.DemoApp/Controllers/DemoController.cs
@@ -47,7 +47,7 @@ namespace OptimizelySDK.DemoApp.Controllers
         private static Config ConfigRepo = new Config();
         private static Optimizely Optimizely = null;
         private static InMemoryHandler InMemoryHandler = new InMemoryHandler();
-        private static Logger.ILogger Logger = new MultiLogger(new[] { (Logger.ILogger)InMemoryHandler, new Log4NetLogger() });
+        private static Logger.ILogger Logger = new MultiLogger(new[] { new Logger.DefaultLogger(), (Logger.ILogger)InMemoryHandler, new Log4NetLogger() });
 
         [HttpGet]
         public ActionResult Index()

--- a/OptimizelySDK.DemoApp/Log4Net.config
+++ b/OptimizelySDK.DemoApp/Log4Net.config
@@ -1,7 +1,7 @@
 ﻿<!-- log4net configuration -->
 <log4net>
   <appender name="FileAppender" type="log4net.Appender.FileAppender">
-    <file value="Logs\DemoApp.log" />
+    <file value="DemoApp.log" />
     <appendToFile value="true" />
     <lockingModel type="log4net.Appender.FileAppender+MinimalLock" />
     <layout type="log4net.Layout.PatternLayout">


### PR DESCRIPTION
OASIS-2035 DemoApp's log goes to file named "Logs\DemoApp.log" on Mac

Small updates to Log4Net.config and DemoController.cs allowing log file
to have a good name on Mac and logging output to be visible in the VS
"Application Output" pane while in Debug configuration.

