### PR TITLE
getvariationforfeature should return DecisionFeature entity

### DIFF
--- a/OptimizelySDK.Net35/OptimizelySDK.Net35.csproj
+++ b/OptimizelySDK.Net35/OptimizelySDK.Net35.csproj
@@ -63,6 +63,9 @@
     <Compile Include="..\OptimizelySDK\Entity\Experiment.cs">
       <Link>Entity\Experiment.cs</Link>
     </Compile>
+	<Compile Include="..\OptimizelySDK\Entity\FeatureDecision.cs">
+      <Link>Entity\FeatureDecision.cs</Link>
+    </Compile>
     <Compile Include="..\OptimizelySDK\Entity\ForcedVariation.cs">
       <Link>Entity\ForcedVariation.cs</Link>
     </Compile>

--- a/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
+++ b/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
@@ -64,6 +64,9 @@
     <Compile Include="..\OptimizelySDK\Entity\Experiment.cs">
       <Link>Entity\Experiment.cs</Link>
     </Compile>
+	<Compile Include="..\OptimizelySDK\Entity\FeatureDecision.cs">
+      <Link>Entity\FeatureDecision.cs</Link>
+    </Compile>
     <Compile Include="..\OptimizelySDK\Entity\ForcedVariation.cs">
       <Link>Entity\ForcedVariation.cs</Link>
     </Compile>

--- a/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
+++ b/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
@@ -14,6 +14,7 @@
         <Compile Include="..\OptimizelySDK\Entity\Event.cs" />
         <Compile Include="..\OptimizelySDK\Entity\EventAttributes.cs" />
         <Compile Include="..\OptimizelySDK\Entity\Experiment.cs" />
+		<Compile Include="..\OptimizelySDK\Entity\FeatureDecision.cs" />
         <Compile Include="..\OptimizelySDK\Entity\ForcedVariation.cs" />
         <Compile Include="..\OptimizelySDK\Entity\Group.cs" />
         <Compile Include="..\OptimizelySDK\Entity\IdKeyEntity.cs" />

--- a/OptimizelySDK.Tests/DecisionServiceTest.cs
+++ b/OptimizelySDK.Tests/DecisionServiceTest.cs
@@ -70,7 +70,6 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetVariationForcedVariationPrecedesAudienceEval()
         {
-            var BucketerMock = new Mock<Bucketer>(LoggerMock.Object);
 
             DecisionService decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, ValidProjectConfig, null, LoggerMock.Object);
             Experiment experiment = ValidProjectConfig.Experiments[0];
@@ -90,7 +89,6 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetVariationEvaluatesUserProfileBeforeAudienceTargeting()
         {
-            var BucketerMock = new Mock<Bucketer>(LoggerMock.Object);
             Experiment experiment = ValidProjectConfig.Experiments[0];
             Variation variation = experiment.Variations[0];
 
@@ -118,8 +116,6 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetForcedVariationReturnsForcedVariation()
         {
-            var BucketerMock = new Mock<Bucketer>(LoggerMock.Object);
-
             DecisionService decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, ValidProjectConfig, null, LoggerMock.Object);
 
             Assert.IsTrue(TestData.CompareObjects(WhitelistedVariation, decisionService.GetWhitelistedVariation(WhitelistedExperiment, WhitelistedUserId)));
@@ -135,7 +131,6 @@ namespace OptimizelySDK.Tests
             string userId = "testUser1";
             string invalidVariationKey = "invalidVarKey";
 
-            var BucketerMock = new Mock<Bucketer>(LoggerMock.Object);
             DecisionService decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, ValidProjectConfig, null, LoggerMock.Object);
 
             var variations = new Variation[]
@@ -187,7 +182,6 @@ namespace OptimizelySDK.Tests
             Experiment experiment = NoAudienceProjectConfig.Experiments[0];
             Variation variation = experiment.Variations[0];
             Decision decision = new Decision(variation.Id);
-            var BucketerMock = new Mock<Bucketer>(LoggerMock.Object);
 
             UserProfile userProfile = new UserProfile(UserProfileId, new Dictionary<string, Decision>
             {
@@ -343,7 +337,6 @@ namespace OptimizelySDK.Tests
             var pausedExperimentKey = "paused_experiment";
             var userId = "test_user";
             var expectedForcedVariationKey = "variation";
-            var expectedVariationKey = "control";
             var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
 
             var userAttributes = new UserAttributes
@@ -387,7 +380,6 @@ namespace OptimizelySDK.Tests
             var testBucketingIdControl = "testBucketingIdControl!";  // generates bucketing number 3741
             var testBucketingIdVariation = "123456789"; // generates bucketing number 4567
             var variationKeyControl = "control";
-            var variationKeyVariation = "variation";
 
             var testUserAttributes = new UserAttributes
             {
@@ -518,7 +510,7 @@ namespace OptimizelySDK.Tests
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("multi_variate_feature");
             var decision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", userAttributes);
 
-            Assert.AreEqual(expectedDecision, decision);
+            Assert.IsTrue(TestData.CompareObjects(expectedDecision, decision));
 
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"user1\" is bucketed into experiment \"test_experiment_multivariate\" of feature \"multi_variate_feature\"."));
         }
@@ -536,9 +528,9 @@ namespace OptimizelySDK.Tests
                 userAttributes)).Returns(variation);
 
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("boolean_feature");
-            var decision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", userAttributes);
+            var actualDecision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", userAttributes);
 
-            Assert.AreEqual(expectedDecision, decision);
+            Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision));
 
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"user1\" is bucketed into experiment \"group_experiment_1\" of feature \"boolean_feature\"."));
         }
@@ -604,7 +596,8 @@ namespace OptimizelySDK.Tests
             var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, ProjectConfig, null, LoggerMock.Object);
 
             var actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, "user_1", userAttributes);
-            Assert.AreEqual(expectedDecision, actualDecision);
+
+            Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision));
 
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"Attempting to bucket user \"user_1\" into rollout rule \"{experiment.Key}\"."));
         }
@@ -631,7 +624,8 @@ namespace OptimizelySDK.Tests
             var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, ProjectConfig, null, LoggerMock.Object);
 
             var actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, "user_1", userAttributes);
-            Assert.AreEqual(expectedDecision, actualDecision);
+
+            Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision));
 
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"Attempting to bucket user \"user_1\" into rollout rule \"{experiment.Key}\"."));
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "User \"user_1\" is excluded due to traffic allocation. Checking \"Eveyrone Else\" rule now."));
@@ -682,7 +676,8 @@ namespace OptimizelySDK.Tests
 
             // Provide null attributes so that user does not qualify for audience.
             var actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, "user_1", null);
-            Assert.AreEqual(expectedDecision, actualDecision);
+
+            Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision));
 
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"User \"user_1\" does not meet the conditions to be in rollout rule for audience \"{ProjectConfig.AudienceIdMap[experiment0.AudienceIds[0]].Name}\"."));
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"User \"user_1\" does not meet the conditions to be in rollout rule for audience \"{ProjectConfig.AudienceIdMap[experiment1.AudienceIds[0]].Name}\"."));
@@ -706,7 +701,7 @@ namespace OptimizelySDK.Tests
                 It.IsAny<UserAttributes>())).Returns(expectedDecision);
 
             var actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, "user1", new UserAttributes());
-            Assert.AreEqual(expectedDecision, actualDecision);
+            Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision));
         }
 
         // Should return the bucketed variation when the user is not bucketed in the feature flag experiment, 
@@ -727,7 +722,8 @@ namespace OptimizelySDK.Tests
                 It.IsAny<UserAttributes>())).Returns(expectedDecision);
 
             var actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, "user1", new UserAttributes());
-            Assert.AreEqual(expectedDecision, actualDecision);
+
+            Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision));
 
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"user1\" is bucketed into a rollout for feature flag \"string_single_variable_feature\"."));
         }
@@ -761,10 +757,10 @@ namespace OptimizelySDK.Tests
             };
 
             DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, "user1", userAttributes)).Returns(variation);
-            var experimentDecision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", userAttributes);
+            var actualDecision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", userAttributes);
 
             // The user is bucketed into feature experiment's variation.
-            Assert.AreEqual(expectedDecision, experimentDecision);
+            Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision));
 
             var rollout = ProjectConfig.GetRolloutFromId(featureFlag.RolloutId);
             var rolloutExperiment = rollout.Experiments[0];
@@ -772,15 +768,17 @@ namespace OptimizelySDK.Tests
             var expectedRolloutDecision = new FeatureDecision(rolloutExperiment.Id, rolloutVariation.Id, FeatureDecision.DECISION_SOURCE_ROLLOUT);
 
             BucketerMock.Setup(bm => bm.Bucket(ProjectConfig, rolloutExperiment, It.IsAny<string>(), It.IsAny<string>())).Returns(rolloutVariation);
-            var rolloutDecision = DecisionServiceMock.Object.GetVariationForFeatureRollout(featureFlag, "user1", userAttributes);
+            var actualRolloutDecision = DecisionServiceMock.Object.GetVariationForFeatureRollout(featureFlag, "user1", userAttributes);
 
             // The user is bucketed into feature rollout's variation.
-            Assert.AreEqual(expectedRolloutDecision, rolloutDecision);
 
-            var featureVariation = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, "user1", userAttributes);
+            Assert.IsTrue(TestData.CompareObjects(expectedRolloutDecision, actualRolloutDecision));
+
+            actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, "user1", userAttributes);
 
             // The user is bucketed into feature experiment's variation and not the rollout's variation.
-            Assert.AreEqual(expectedDecision, featureVariation);
+            Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision));
+
         }
 
         #endregion // GetVariationForFeature Tests

--- a/OptimizelySDK.Tests/DecisionServiceTest.cs
+++ b/OptimizelySDK.Tests/DecisionServiceTest.cs
@@ -462,8 +462,9 @@ namespace OptimizelySDK.Tests
         public void TestGetVariationForFeatureExperimentGivenNullExperimentIds()
         {
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("empty_feature");
+            var decision = DecisionService.GetVariationForFeatureExperiment(featureFlag, GenericUserId, new UserAttributes() { });
 
-            Assert.IsNull(DecisionService.GetVariationForFeatureExperiment(featureFlag, GenericUserId, new UserAttributes() { }));
+            Assert.IsNull(decision);
 
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, $"The feature flag \"{featureFlag.Key}\" is not used in any experiments."));
         }
@@ -480,8 +481,9 @@ namespace OptimizelySDK.Tests
                 RolloutId = booleanFeature.RolloutId,
                 ExperimentIds = new List<string> { "29039203" }
             };
-            
-            Assert.IsNull(DecisionService.GetVariationForFeatureExperiment(featureFlag, GenericUserId, new UserAttributes() { }));
+
+            var decision = DecisionService.GetVariationForFeatureExperiment(featureFlag, GenericUserId, new UserAttributes() { });
+            Assert.IsNull(decision);
 
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Experiment ID \"29039203\" is not in datafile."));
         }
@@ -495,7 +497,8 @@ namespace OptimizelySDK.Tests
             DecisionServiceMock.Setup(ds => ds.GetVariation(multiVariateExp, "user1", null)).Returns<Variation>(null);
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("multi_variate_feature");
 
-            Assert.IsNull(DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", new UserAttributes()));
+            var decision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", new UserAttributes());
+            Assert.IsNull(decision);
 
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"user1\" is not bucketed into any of the experiments on the feature \"multi_variate_feature\"."));
         }
@@ -504,15 +507,18 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetVariationForFeatureExperimentGivenNonMutexGroupAndUserIsBucketed()
         {
-            var expectedVariation = ProjectConfig.GetVariationFromId("test_experiment_multivariate", "122231");
+            var experiment = ProjectConfig.GetExperimentFromKey("test_experiment_multivariate");
+            var variation = ProjectConfig.GetVariationFromId("test_experiment_multivariate", "122231");
+            var expectedDecision = new FeatureDecision(experiment.Id, variation.Id, FeatureDecision.DECISION_SOURCE_EXPERIMENT);
             var userAttributes = new UserAttributes();
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(ProjectConfig.GetExperimentFromKey("test_experiment_multivariate"), "user1", userAttributes)).Returns(expectedVariation);
+            DecisionServiceMock.Setup(ds => ds.GetVariation(ProjectConfig.GetExperimentFromKey("test_experiment_multivariate"), 
+                "user1", userAttributes)).Returns(variation);
 
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("multi_variate_feature");
-            var variation = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", userAttributes);
+            var decision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", userAttributes);
 
-            Assert.AreEqual(expectedVariation, variation);
+            Assert.AreEqual(expectedDecision, decision);
 
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"user1\" is bucketed into experiment \"test_experiment_multivariate\" of feature \"multi_variate_feature\"."));
         }
@@ -522,15 +528,17 @@ namespace OptimizelySDK.Tests
         public void TestGetVariationForFeatureExperimentGivenMutexGroupAndUserIsBucketed()
         {
             var mutexExperiment = ProjectConfig.GetExperimentFromKey("group_experiment_1");
-            var expectedVariation = mutexExperiment.Variations[0];
+            var variation = mutexExperiment.Variations[0];
             var userAttributes = new UserAttributes();
+            var expectedDecision = new FeatureDecision(mutexExperiment.Id, variation.Id, FeatureDecision.DECISION_SOURCE_EXPERIMENT);
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(ProjectConfig.GetExperimentFromKey("group_experiment_1"), "user1", userAttributes)).Returns(expectedVariation);
+            DecisionServiceMock.Setup(ds => ds.GetVariation(ProjectConfig.GetExperimentFromKey("group_experiment_1"), "user1", 
+                userAttributes)).Returns(variation);
 
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("boolean_feature");
-            var variation = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", userAttributes);
+            var decision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", userAttributes);
 
-            Assert.AreEqual(expectedVariation, variation);
+            Assert.AreEqual(expectedDecision, decision);
 
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"user1\" is bucketed into experiment \"group_experiment_1\" of feature \"boolean_feature\"."));
         }
@@ -540,13 +548,13 @@ namespace OptimizelySDK.Tests
         public void TestGetVariationForFeatureExperimentGivenMutexGroupAndUserNotBucketed()
         {
             var mutexExperiment = ProjectConfig.GetExperimentFromKey("group_experiment_1");
-            
-            DecisionServiceMock.Setup(ds => ds.GetVariation(It.IsAny<Experiment>(), It.IsAny<string>(), It.IsAny<UserAttributes>())).Returns<Variation>(null);
+            DecisionServiceMock.Setup(ds => ds.GetVariation(It.IsAny<Experiment>(), It.IsAny<string>(), It.IsAny<UserAttributes>())).
+                Returns<Variation>(null);
 
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("boolean_feature");
-            var actualVariation = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", new UserAttributes());
+            var actualDecision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", new UserAttributes());
 
-            Assert.IsNull(actualVariation);
+            Assert.IsNull(actualDecision);
 
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"user1\" is not bucketed into any of the experiments on the feature \"boolean_feature\"."));
         }
@@ -570,8 +578,8 @@ namespace OptimizelySDK.Tests
 
             DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureExperiment(It.IsAny<FeatureFlag>(), It.IsAny<string>(), It.IsAny<UserAttributes>())).Returns<Variation>(null);
 
-            var actualVariation = DecisionServiceMock.Object.GetVariationForFeatureRollout(featureFlag, "user1", new UserAttributes());
-            Assert.IsNull(actualVariation);
+            var actualDecision = DecisionServiceMock.Object.GetVariationForFeatureRollout(featureFlag, "user1", new UserAttributes());
+            Assert.IsNull(actualDecision);
 
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The feature flag \"boolean_feature\" is not used in a rollout."));
         }
@@ -584,17 +592,19 @@ namespace OptimizelySDK.Tests
             var rolloutId = featureFlag.RolloutId;
             var rollout = ProjectConfig.GetRolloutFromId(rolloutId);
             var experiment = rollout.Experiments[0];
-            var expectedVariation = experiment.Variations[0];
+            var variation = experiment.Variations[0];
+            var expectedDecision = new FeatureDecision(experiment.Id, variation.Id, FeatureDecision.DECISION_SOURCE_ROLLOUT);
 
             var userAttributes = new UserAttributes {
                 { "browser_type", "chrome" }
             };
 
-            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(), It.IsAny<string>())).Returns(expectedVariation);
+            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(), 
+                It.IsAny<string>())).Returns(variation);
             var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, ProjectConfig, null, LoggerMock.Object);
 
-            var actualVariation = decisionService.GetVariationForFeatureRollout(featureFlag, "user_1", userAttributes);
-            Assert.AreEqual(expectedVariation, actualVariation);
+            var actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, "user_1", userAttributes);
+            Assert.AreEqual(expectedDecision, actualDecision);
 
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"Attempting to bucket user \"user_1\" into rollout rule \"{experiment.Key}\"."));
         }
@@ -609,18 +619,19 @@ namespace OptimizelySDK.Tests
             var rollout = ProjectConfig.GetRolloutFromId(rolloutId);
             var experiment = rollout.Experiments[0];
             var everyoneElseRule = rollout.Experiments[rollout.Experiments.Count - 1];
-            var expectedVariation = everyoneElseRule.Variations[0];
+            var variation = everyoneElseRule.Variations[0];
+            var expectedDecision = new FeatureDecision(everyoneElseRule.Id, variation.Id, FeatureDecision.DECISION_SOURCE_ROLLOUT);
 
             var userAttributes = new UserAttributes {
                 { "browser_type", "chrome" }
             };
 
             BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), experiment, It.IsAny<string>(), It.IsAny<string>())).Returns<Variation>(null);
-            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), everyoneElseRule, It.IsAny<string>(), It.IsAny<string>())).Returns(expectedVariation);
+            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), everyoneElseRule, It.IsAny<string>(), It.IsAny<string>())).Returns(variation);
             var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, ProjectConfig, null, LoggerMock.Object);
 
-            var actualVariation = decisionService.GetVariationForFeatureRollout(featureFlag, "user_1", userAttributes);
-            Assert.AreEqual(expectedVariation, actualVariation);
+            var actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, "user_1", userAttributes);
+            Assert.AreEqual(expectedDecision, actualDecision);
 
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"Attempting to bucket user \"user_1\" into rollout rule \"{experiment.Key}\"."));
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "User \"user_1\" is excluded due to traffic allocation. Checking \"Eveyrone Else\" rule now."));
@@ -644,8 +655,8 @@ namespace OptimizelySDK.Tests
             BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(), It.IsAny<string>())).Returns<Variation>(null);
             var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, ProjectConfig, null, LoggerMock.Object);
 
-            var actualVariation = decisionService.GetVariationForFeatureRollout(featureFlag, "user_1", userAttributes);
-            Assert.IsNull(actualVariation);
+            var actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, "user_1", userAttributes);
+            Assert.IsNull(actualDecision);
 
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"Attempting to bucket user \"user_1\" into rollout rule \"{experiment.Key}\"."));
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "User \"user_1\" is excluded due to traffic allocation. Checking \"Eveyrone Else\" rule now."));
@@ -663,14 +674,15 @@ namespace OptimizelySDK.Tests
             var experiment0 = rollout.Experiments[0];
             var experiment1 = rollout.Experiments[1];
             var everyoneElseRule = rollout.Experiments[rollout.Experiments.Count - 1];
-            var expectedVariation = everyoneElseRule.Variations[0];
+            var variation = everyoneElseRule.Variations[0];
+            var expectedDecision = new FeatureDecision(everyoneElseRule.Id, variation.Id, FeatureDecision.DECISION_SOURCE_ROLLOUT);
 
-            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), everyoneElseRule, It.IsAny<string>(), It.IsAny<string>())).Returns(expectedVariation);
+            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), everyoneElseRule, It.IsAny<string>(), It.IsAny<string>())).Returns(variation);
             var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, ProjectConfig, null, LoggerMock.Object);
 
             // Provide null attributes so that user does not qualify for audience.
-            var actualVariation = decisionService.GetVariationForFeatureRollout(featureFlag, "user_1", null);
-            Assert.AreEqual(expectedVariation, actualVariation);
+            var actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, "user_1", null);
+            Assert.AreEqual(expectedDecision, actualDecision);
 
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"User \"user_1\" does not meet the conditions to be in rollout rule for audience \"{ProjectConfig.AudienceIdMap[experiment0.AudienceIds[0]].Name}\"."));
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"User \"user_1\" does not meet the conditions to be in rollout rule for audience \"{ProjectConfig.AudienceIdMap[experiment1.AudienceIds[0]].Name}\"."));
@@ -687,13 +699,14 @@ namespace OptimizelySDK.Tests
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("string_single_variable_feature");
             var expectedExperimentId = featureFlag.ExperimentIds[0];
             var expectedExperiment = ProjectConfig.GetExperimentFromId(expectedExperimentId);
-            var expectedVariation = expectedExperiment.Variations[0];
+            var variation = expectedExperiment.Variations[0];
+            var expectedDecision = new FeatureDecision(expectedExperimentId, variation.Id, FeatureDecision.DECISION_SOURCE_EXPERIMENT);
 
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureExperiment(It.IsAny<FeatureFlag>(), It.IsAny<string>(), It.IsAny<UserAttributes>())).Returns(expectedVariation);
+            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureExperiment(It.IsAny<FeatureFlag>(), It.IsAny<string>(), 
+                It.IsAny<UserAttributes>())).Returns(expectedDecision);
 
-            var actualVariation = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, "user1", new UserAttributes());
-
-            Assert.AreEqual(expectedVariation, actualVariation);
+            var actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, "user1", new UserAttributes());
+            Assert.AreEqual(expectedDecision, actualDecision);
         }
 
         // Should return the bucketed variation when the user is not bucketed in the feature flag experiment, 
@@ -705,14 +718,16 @@ namespace OptimizelySDK.Tests
             var rolloutId = featureFlag.RolloutId;
             var rollout = ProjectConfig.GetRolloutFromId(rolloutId);
             var expectedExperiment = rollout.Experiments[0];
-            var expectedVariation = expectedExperiment.Variations[0];
+            var variation = expectedExperiment.Variations[0];
+            var expectedDecision = new FeatureDecision(expectedExperiment.Id, variation.Id, FeatureDecision.DECISION_SOURCE_ROLLOUT);
 
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureExperiment(It.IsAny<FeatureFlag>(), It.IsAny<string>(), It.IsAny<UserAttributes>())).Returns<Variation>(null);
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureRollout(It.IsAny<FeatureFlag>(), It.IsAny<string>(), It.IsAny<UserAttributes>())).Returns(expectedVariation);
+            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureExperiment(It.IsAny<FeatureFlag>(), It.IsAny<string>(), 
+                It.IsAny<UserAttributes>())).Returns<Variation>(null);
+            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureRollout(It.IsAny<FeatureFlag>(), It.IsAny<string>(), 
+                It.IsAny<UserAttributes>())).Returns(expectedDecision);
 
-            var actualVariation = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, "user1", new UserAttributes());
-
-            Assert.AreEqual(expectedVariation, actualVariation);
+            var actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, "user1", new UserAttributes());
+            Assert.AreEqual(expectedDecision, actualDecision);
 
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"user1\" is bucketed into a rollout for feature flag \"string_single_variable_feature\"."));
         }
@@ -726,8 +741,8 @@ namespace OptimizelySDK.Tests
             DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureExperiment(It.IsAny<FeatureFlag>(), It.IsAny<string>(), It.IsAny<UserAttributes>())).Returns<Variation>(null);
             DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureRollout(It.IsAny<FeatureFlag>(), It.IsAny<string>(), It.IsAny<UserAttributes>())).Returns<Variation>(null);
 
-            var actualVariation = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, "user1", new UserAttributes());
-            Assert.IsNull(actualVariation);
+            var actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, "user1", new UserAttributes());
+            Assert.IsNull(actualDecision);
 
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"user1\" is not bucketed into a rollout for feature flag \"string_single_variable_feature\"."));
         }
@@ -739,32 +754,33 @@ namespace OptimizelySDK.Tests
         {
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("string_single_variable_feature");
             var experiment = ProjectConfig.GetExperimentFromKey("test_experiment_with_feature_rollout");
-            var expectedVariation = ProjectConfig.GetVariationFromId("test_experiment_with_feature_rollout", "122236");
-
-            var rollout = ProjectConfig.GetRolloutFromId(featureFlag.RolloutId);
-            var rolloutExperiment = rollout.Experiments[0];
-            var expectedRolloutVariation = rolloutExperiment.Variations[0];
-
+            var variation = ProjectConfig.GetVariationFromId("test_experiment_with_feature_rollout", "122236");
+            var expectedDecision = new FeatureDecision(experiment.Id, variation.Id, FeatureDecision.DECISION_SOURCE_EXPERIMENT);
             var userAttributes = new UserAttributes {
                 { "browser_type", "chrome" }
             };
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, "user1", userAttributes)).Returns(expectedVariation);
-            var experimentVariation = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", userAttributes);
+            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, "user1", userAttributes)).Returns(variation);
+            var experimentDecision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, "user1", userAttributes);
 
             // The user is bucketed into feature experiment's variation.
-            Assert.AreEqual(expectedVariation, experimentVariation);
+            Assert.AreEqual(expectedDecision, experimentDecision);
 
-            BucketerMock.Setup(bm => bm.Bucket(ProjectConfig, rolloutExperiment, It.IsAny<string>(), It.IsAny<string>())).Returns(expectedRolloutVariation);
-            var rolloutVariation = DecisionServiceMock.Object.GetVariationForFeatureRollout(featureFlag, "user1", userAttributes);
+            var rollout = ProjectConfig.GetRolloutFromId(featureFlag.RolloutId);
+            var rolloutExperiment = rollout.Experiments[0];
+            var rolloutVariation = rolloutExperiment.Variations[0];
+            var expectedRolloutDecision = new FeatureDecision(rolloutExperiment.Id, rolloutVariation.Id, FeatureDecision.DECISION_SOURCE_ROLLOUT);
+
+            BucketerMock.Setup(bm => bm.Bucket(ProjectConfig, rolloutExperiment, It.IsAny<string>(), It.IsAny<string>())).Returns(rolloutVariation);
+            var rolloutDecision = DecisionServiceMock.Object.GetVariationForFeatureRollout(featureFlag, "user1", userAttributes);
 
             // The user is bucketed into feature rollout's variation.
-            Assert.AreEqual(expectedRolloutVariation, rolloutVariation);
+            Assert.AreEqual(expectedRolloutDecision, rolloutDecision);
 
             var featureVariation = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, "user1", userAttributes);
 
             // The user is bucketed into feature experiment's variation and not the rollout's variation.
-            Assert.AreEqual(expectedVariation, featureVariation);
+            Assert.AreEqual(expectedDecision, featureVariation);
         }
 
         #endregion // GetVariationForFeature Tests

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -1156,12 +1156,12 @@ namespace OptimizelySDK.Tests
             OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType(It.IsAny<string>(), variableKeyNonBoolean, It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), featureVariableType)).Returns("non_boolean_value");
 
-            Assert.AreEqual(null, OptimizelyMock.Object.GetFeatureVariableBoolean(featureKey, variableKeyNonBoolean, TestUserId, null));
+            Assert.Null(OptimizelyMock.Object.GetFeatureVariableBoolean(featureKey, variableKeyNonBoolean, TestUserId, null));
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, $@"Unable to cast variable value ""non_boolean_value"" to type ""{featureVariableType}""."));
 
             OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType(It.IsAny<string>(), variableKeyNull, It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), featureVariableType)).Returns<string>(null);
-            Assert.AreEqual(null, OptimizelyMock.Object.GetFeatureVariableBoolean(featureKey, variableKeyNull, TestUserId, null));
+            Assert.Null(OptimizelyMock.Object.GetFeatureVariableBoolean(featureKey, variableKeyNull, TestUserId, null));
         }
 
         [Test]
@@ -1185,12 +1185,12 @@ namespace OptimizelySDK.Tests
             OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType(It.IsAny<string>(), variableKeyNonDouble, It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), featureVariableType)).Returns("non_double_value");
 
-            Assert.AreEqual(null, OptimizelyMock.Object.GetFeatureVariableDouble(featureKey, variableKeyNonDouble, TestUserId, null));
+            Assert.Null(OptimizelyMock.Object.GetFeatureVariableDouble(featureKey, variableKeyNonDouble, TestUserId, null));
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, $@"Unable to cast variable value ""non_double_value"" to type ""{featureVariableType}""."));
 
             OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType(It.IsAny<string>(), variableKeyNull, It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), featureVariableType)).Returns<string>(null);
-            Assert.AreEqual(null, OptimizelyMock.Object.GetFeatureVariableDouble(featureKey, variableKeyNull, TestUserId, null));
+            Assert.Null(OptimizelyMock.Object.GetFeatureVariableDouble(featureKey, variableKeyNull, TestUserId, null));
         }
 
         [Test]
@@ -1210,18 +1210,18 @@ namespace OptimizelySDK.Tests
             OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType(It.IsAny<string>(), variableKeyDouble, It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), featureVariableType)).Returns("100.45");
 
-            Assert.AreEqual(null, OptimizelyMock.Object.GetFeatureVariableInteger(featureKey, variableKeyDouble, TestUserId, null));
+            Assert.Null(OptimizelyMock.Object.GetFeatureVariableInteger(featureKey, variableKeyDouble, TestUserId, null));
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, $@"Unable to cast variable value ""100.45"" to type ""{featureVariableType}""."));
 
             OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType(It.IsAny<string>(), variableNonInt, It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), featureVariableType)).Returns("non_integer_value");
 
-            Assert.AreEqual(null, OptimizelyMock.Object.GetFeatureVariableInteger(featureKey, variableNonInt, TestUserId, null));
+            Assert.Null(OptimizelyMock.Object.GetFeatureVariableInteger(featureKey, variableNonInt, TestUserId, null));
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, $@"Unable to cast variable value ""non_integer_value"" to type ""{featureVariableType}""."));
 
             OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType(It.IsAny<string>(), variableKeyNull, It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), featureVariableType)).Returns<string>(null);
-            Assert.AreEqual(null, OptimizelyMock.Object.GetFeatureVariableInteger(featureKey, variableKeyNull, TestUserId, null));
+            Assert.Null(OptimizelyMock.Object.GetFeatureVariableInteger(featureKey, variableKeyNull, TestUserId, null));
         }
 
         [Test]
@@ -1243,7 +1243,7 @@ namespace OptimizelySDK.Tests
 
             OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType(It.IsAny<string>(), variableKeyNull, It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), featureVariableType)).Returns<string>(null);
-            Assert.AreEqual(null, OptimizelyMock.Object.GetFeatureVariableString(featureKey, variableKeyNull, TestUserId, null));
+            Assert.Null(OptimizelyMock.Object.GetFeatureVariableString(featureKey, variableKeyNull, TestUserId, null));
         }
 
         #endregion // Test GetFeatureVariable<Type> TypeCasting
@@ -1325,7 +1325,7 @@ namespace OptimizelySDK.Tests
             var variableType = FeatureVariable.VariableType.DOUBLE;
             var expectedValue = "14.99";
 
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, null)).Returns<Variation>(null);
+            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, null)).Returns<FeatureDecision>(null);
 
             var optly = Helper.CreatePrivateOptimizely();
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
@@ -1344,13 +1344,15 @@ namespace OptimizelySDK.Tests
         {
             var featureKey = "double_single_variable_feature";
             var featureFlag = Config.GetFeatureFlagFromKey("double_single_variable_feature");
+            var experiment = Config.GetExperimentFromKey("test_experiment_integer_feature");
             var differentVariation = Config.GetVariationFromKey("test_experiment_integer_feature", "control");
+            var expectedDecision = new FeatureDecision(experiment.Id, differentVariation.Id, FeatureDecision.DECISION_SOURCE_EXPERIMENT);
             var variableKey = "double_variable";
             var variableType = FeatureVariable.VariableType.DOUBLE;
             var expectedValue = "14.99";
 
             // Mock GetVariationForFeature method to return variation of different feature.
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, null)).Returns(differentVariation);
+            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, null)).Returns(expectedDecision);
 
             var optly = Helper.CreatePrivateOptimizely();
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
@@ -1372,9 +1374,11 @@ namespace OptimizelySDK.Tests
             var variableKey = "double_variable";
             var variableType = FeatureVariable.VariableType.DOUBLE;
             var expectedValue = "42.42";
-
+            var experiment = Config.GetExperimentFromKey("test_experiment_double_feature");
             var variation = Config.GetVariationFromKey("test_experiment_double_feature", "control");
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, null)).Returns(variation);
+            var decision = new FeatureDecision(experiment.Id, variation.Id, FeatureDecision.DECISION_SOURCE_EXPERIMENT);
+
+            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, null)).Returns(decision);
 
             var optly = Helper.CreatePrivateOptimizely();
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
@@ -1442,7 +1446,7 @@ namespace OptimizelySDK.Tests
             var featureKey = "double_single_variable_feature";
             var featureFlag = Config.GetFeatureFlagFromKey("double_single_variable_feature");
             
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, null)).Returns<Variation>(null);
+            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, null)).Returns<FeatureDecision>(null);
 
             var optly = Helper.CreatePrivateOptimizely();
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
@@ -1464,8 +1468,9 @@ namespace OptimizelySDK.Tests
             var experiment = rollout.Experiments[0];
             var variation = experiment.Variations[0];
             var featureFlag = Config.GetFeatureFlagFromKey(featureKey);
+            var decision = new FeatureDecision(experiment.Id, variation.Id, FeatureDecision.DECISION_SOURCE_ROLLOUT);
 
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, null)).Returns(variation);
+            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, null)).Returns(decision);
 
             var optly = Helper.CreatePrivateOptimizely();
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
@@ -1487,10 +1492,12 @@ namespace OptimizelySDK.Tests
         public void TestIsFeatureEnabledGivenFeatureFlagIsEnabledAndUserIsBeingExperimented()
         {
             var featureKey = "double_single_variable_feature";
+            var experiment = Config.GetExperimentFromKey("test_experiment_double_feature");
             var variation = Config.GetVariationFromKey("test_experiment_double_feature", "control");
             var featureFlag = Config.GetFeatureFlagFromKey(featureKey);
+            var decision = new FeatureDecision(experiment.Id, variation.Id, FeatureDecision.DECISION_SOURCE_EXPERIMENT);
 
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, null)).Returns(variation);
+            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, null)).Returns(decision);
 
             var optly = Helper.CreatePrivateOptimizely();
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
@@ -1537,6 +1544,7 @@ namespace OptimizelySDK.Tests
             var experiment = Config.GetExperimentFromKey(experimentKey);
             var variation = Config.GetVariationFromKey(experimentKey, variationKey);
             var featureFlag = Config.GetFeatureFlagFromKey(featureKey);
+            var decision = new FeatureDecision(experiment.Id, variation.Id, FeatureDecision.DECISION_SOURCE_EXPERIMENT);
             var logEvent = new LogEvent("https://logx.optimizely.com/v1/events", OptimizelyHelper.SingleParameter,
                 "POST", new Dictionary<string, string> { });
 
@@ -1550,7 +1558,7 @@ namespace OptimizelySDK.Tests
             EventBuilderMock.Setup(ebm => ebm.CreateImpressionEvent(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(),
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<UserAttributes>())).Returns(logEvent);
             DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, TestUserId, userAttributes)).Returns(variation);
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, userAttributes)).Returns(variation);
+            DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, TestUserId, userAttributes)).Returns(decision);
 
             var optly = Helper.CreatePrivateOptimizely();
             var optStronglyTyped = optly.GetObject() as Optimizely;

--- a/OptimizelySDK/Bucketing/DecisionService.cs
+++ b/OptimizelySDK/Bucketing/DecisionService.cs
@@ -256,8 +256,8 @@ namespace OptimizelySDK.Bucketing
         /// <param name = "userId" >User Identifier</param>
         /// <param name = "filteredAttributes" >The user's attributes. This should be filtered to just attributes in the Datafile.</param>
         /// <returns>null if the user is not bucketed into the rollout or if the feature flag was not attached to a rollout.
-        /// otherwise the Variation the user is bucketed into</returns>
-        public virtual Variation GetVariationForFeatureRollout(FeatureFlag featureFlag, string userId, UserAttributes filteredAttributes)
+        /// otherwise the FeatureDecision entity</returns>
+        public virtual FeatureDecision GetVariationForFeatureRollout(FeatureFlag featureFlag, string userId, UserAttributes filteredAttributes)
         {
             if (string.IsNullOrEmpty(featureFlag.RolloutId))
             {
@@ -296,7 +296,7 @@ namespace OptimizelySDK.Bucketing
                         break;
                     }
 
-                    return variation;
+                    return new FeatureDecision(rolloutRule.Id, variation.Id, FeatureDecision.DECISION_SOURCE_ROLLOUT);
                 }
                 else
                 {
@@ -311,9 +311,10 @@ namespace OptimizelySDK.Bucketing
             if (variation == null)
             {
                 Logger.Log(LogLevel.DEBUG, $"User \"{userId}\" is excluded from \"Everyone Else\" rule for feature flag \"{featureFlag.Key}\".");
+                return null;
             }
 
-            return variation;
+            return new FeatureDecision(everyoneElseRolloutRule.Id, variation.Id, FeatureDecision.DECISION_SOURCE_ROLLOUT);
         }
 
         /// <summary>
@@ -323,8 +324,8 @@ namespace OptimizelySDK.Bucketing
         /// <param name = "userId" >User Identifier</param>
         /// <param name = "filteredAttributes" >The user's attributes. This should be filtered to just attributes in the Datafile.</param>
         /// <returns>null if the user is not bucketed into the rollout or if the feature flag was not attached to a rollout.
-        /// otherwise the Variation the user is bucketed into</returns>
-        public virtual Variation GetVariationForFeatureExperiment(FeatureFlag featureFlag, string userId, UserAttributes filteredAttributes)
+        /// Otherwise the FeatureDecision entity</returns>
+        public virtual FeatureDecision GetVariationForFeatureExperiment(FeatureFlag featureFlag, string userId, UserAttributes filteredAttributes)
         {
             if (featureFlag.ExperimentIds == null || featureFlag.ExperimentIds.Count == 0)
             {
@@ -344,7 +345,7 @@ namespace OptimizelySDK.Bucketing
                 if (variation != null)
                 {
                     Logger.Log(LogLevel.INFO, $"The user \"{userId}\" is bucketed into experiment \"{experiment.Key}\" of feature \"{featureFlag.Key}\".");
-                    return variation;
+                    return new FeatureDecision(experimentId, variation.Id, FeatureDecision.DECISION_SOURCE_EXPERIMENT);
                 }
             }
 
@@ -358,25 +359,25 @@ namespace OptimizelySDK.Bucketing
         /// <param name = "featureFlag" >The feature flag the user wants to access.</param>
         /// <param name = "userId" >User Identifier</param>
         /// <param name = "filteredAttributes" >The user's attributes. This should be filtered to just attributes in the Datafile.</param>
-        /// <returns>null if the user is not bucketed into any variation or the Variation the user is bucketed into
-        /// if the user is successfully bucketed.</returns>
-        public virtual Variation GetVariationForFeature(FeatureFlag featureFlag, string userId, UserAttributes filteredAttributes)
+        /// <returns>null if the user is not bucketed into any variation or the FeatureDecision entity if the user is 
+        /// successfully bucketed.</returns>
+        public virtual FeatureDecision GetVariationForFeature(FeatureFlag featureFlag, string userId, UserAttributes filteredAttributes)
         {
             // Check if the feature flag has an experiment and the user is bucketed into that experiment.
-            var variation = GetVariationForFeatureExperiment(featureFlag, userId, filteredAttributes);
+            var decision = GetVariationForFeatureExperiment(featureFlag, userId, filteredAttributes);
 
-            if (variation != null)
-                return variation;
+            if (decision != null)
+                return decision;
 
             // Check if the feature flag has rollout and the the user is bucketed into one of its rules.
-            variation = GetVariationForFeatureRollout(featureFlag, userId, filteredAttributes);
+            decision = GetVariationForFeatureRollout(featureFlag, userId, filteredAttributes);
 
-            if (variation != null)
+            if (decision != null)
                 Logger.Log(LogLevel.INFO, $"The user \"{userId}\" is bucketed into a rollout for feature flag \"{featureFlag.Key}\".");
             else
                 Logger.Log(LogLevel.INFO, $"The user \"{userId}\" is not bucketed into a rollout for feature flag \"{featureFlag.Key}\".");
 
-            return variation;
+            return decision;
         }
 
         /// <summary>

--- a/OptimizelySDK/Bucketing/DecisionService.cs
+++ b/OptimizelySDK/Bucketing/DecisionService.cs
@@ -259,6 +259,12 @@ namespace OptimizelySDK.Bucketing
         /// otherwise the FeatureDecision entity</returns>
         public virtual FeatureDecision GetVariationForFeatureRollout(FeatureFlag featureFlag, string userId, UserAttributes filteredAttributes)
         {
+            if (featureFlag == null)
+            {
+                Logger.Log(LogLevel.ERROR, "Invalid feature flag provided.");
+                return null;
+            }
+
             if (string.IsNullOrEmpty(featureFlag.RolloutId))
             {
                 Logger.Log(LogLevel.INFO, $"The feature flag \"{featureFlag.Key}\" is not used in a rollout.");
@@ -327,6 +333,12 @@ namespace OptimizelySDK.Bucketing
         /// Otherwise the FeatureDecision entity</returns>
         public virtual FeatureDecision GetVariationForFeatureExperiment(FeatureFlag featureFlag, string userId, UserAttributes filteredAttributes)
         {
+            if (featureFlag == null)
+            {
+                Logger.Log(LogLevel.ERROR, "Invalid feature flag provided.");
+                return null;
+            }
+
             if (featureFlag.ExperimentIds == null || featureFlag.ExperimentIds.Count == 0)
             {
                 Logger.Log(LogLevel.INFO, $"The feature flag \"{featureFlag.Key}\" is not used in any experiments.");

--- a/OptimizelySDK/Entity/FeatureDecision.cs
+++ b/OptimizelySDK/Entity/FeatureDecision.cs
@@ -34,19 +34,5 @@ namespace OptimizelySDK.Entity
             VariationId = variationId;
             Source = source;
         }
-
-        public override bool Equals(object obj)
-        {
-            var decision = obj as FeatureDecision;
-            return decision != null &&
-                   ExperimentId == decision.ExperimentId &&
-                   VariationId == decision.VariationId &&
-                   Source == decision.Source;
-        }
-
-        public override int GetHashCode()
-        {
-            return (ExperimentId + VariationId + Source).GetHashCode();
-        }
     }
 }

--- a/OptimizelySDK/Entity/FeatureDecision.cs
+++ b/OptimizelySDK/Entity/FeatureDecision.cs
@@ -1,0 +1,52 @@
+﻿/* 
+ * Copyright 2017, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+using System.Collections.Generic;
+
+namespace OptimizelySDK.Entity
+{
+    public class FeatureDecision : IEquatable<object>
+    {
+        public const string DECISION_SOURCE_EXPERIMENT = "experiment";
+        public const string DECISION_SOURCE_ROLLOUT = "rollout";
+
+        public string ExperimentId { get; set; }
+        public string VariationId { get; set; }
+        public string Source { get; set; }
+
+        public FeatureDecision(string experimentId, string variationId, string source)
+        {
+            ExperimentId = experimentId;
+            VariationId = variationId;
+            Source = source;
+        }
+
+        public override bool Equals(object obj)
+        {
+            var decision = obj as FeatureDecision;
+            return decision != null &&
+                   ExperimentId == decision.ExperimentId &&
+                   VariationId == decision.VariationId &&
+                   Source == decision.Source;
+        }
+
+        public override int GetHashCode()
+        {
+            return (ExperimentId + VariationId + Source).GetHashCode();
+        }
+    }
+}

--- a/OptimizelySDK/Entity/FeatureDecision.cs
+++ b/OptimizelySDK/Entity/FeatureDecision.cs
@@ -19,14 +19,14 @@ using System.Collections.Generic;
 
 namespace OptimizelySDK.Entity
 {
-    public class FeatureDecision : IEquatable<object>
+    public class FeatureDecision
     {
         public const string DECISION_SOURCE_EXPERIMENT = "experiment";
         public const string DECISION_SOURCE_ROLLOUT = "rollout";
 
-        public string ExperimentId { get; set; }
-        public string VariationId { get; set; }
-        public string Source { get; set; }
+        public string ExperimentId { get; }
+        public string VariationId { get; }
+        public string Source { get; }
 
         public FeatureDecision(string experimentId, string variationId, string source)
         {

--- a/OptimizelySDK/OptimizelySDK.csproj
+++ b/OptimizelySDK/OptimizelySDK.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Entity\Event.cs" />
     <Compile Include="Entity\EventAttributes.cs" />
     <Compile Include="Entity\Experiment.cs" />
+    <Compile Include="Entity\FeatureDecision.cs" />
     <Compile Include="Entity\FeatureFlag.cs" />
     <Compile Include="Entity\FeatureVariable.cs" />
     <Compile Include="Entity\FeatureVariableUsage.cs" />


### PR DESCRIPTION
C# SDK should have same implementation as in PHP.
Return DecisionFeature object, instead of variation from getVariationForFeature.