### PR TITLE
DispatchEvent() must be sequential and cannot be fire & forget

### DIFF
--- a/OptimizelySDK/Event/Dispatcher/HttpClientEventDispatcher45.cs
+++ b/OptimizelySDK/Event/Dispatcher/HttpClientEventDispatcher45.cs
@@ -68,16 +68,6 @@ namespace OptimizelySDK.Event.Dispatcher
         }
 
         /// <summary>
-        /// Dispatch an event Asynchronously by creating a new task and calls the 
-        /// Async version of DispatchEvent
-        /// This is a "Fire and Forget" option
-        /// </summary>
-        public void DispatchEventSilently(LogEvent logEvent)
-        {
-            Task.Run(() => DispatchEventAsync(logEvent));
-        }
-
-        /// <summary>
         /// Dispatch an event Asynchronously by creating a new task and calls the
         /// Async version of DispatchEvent
         /// This is a "sequential" option

--- a/OptimizelySDK/Event/Dispatcher/HttpClientEventDispatcher45.cs
+++ b/OptimizelySDK/Event/Dispatcher/HttpClientEventDispatcher45.cs
@@ -72,9 +72,19 @@ namespace OptimizelySDK.Event.Dispatcher
         /// Async version of DispatchEvent
         /// This is a "Fire and Forget" option
         /// </summary>
-        public void DispatchEvent(LogEvent logEvent)
+        public void DispatchEventSilently(LogEvent logEvent)
         {
             Task.Run(() => DispatchEventAsync(logEvent));
+        }
+
+        /// <summary>
+        /// Dispatch an event Asynchronously by creating a new task and calls the
+        /// Async version of DispatchEvent
+        /// This is a "sequential" option
+        /// </summary>
+        public void DispatchEvent(LogEvent logEvent)
+        {
+            DispatchEventAsync(logEvent);
         }
     }
 }


### PR DESCRIPTION
When Activate() & Track() are called, Track() can only proceed after
Activate() completes successfully. Hence the fire & forget pattern for
DispatchEvent() will not work.

Original issue:

https://github.com/optimizely/csharp-sdk/issues/51