### PR TITLE
event tag should parse value from dictionary to int.

### DIFF
--- a/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
@@ -564,6 +564,7 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"timestamp", timeStamp },
                                                     {"uuid", guid },
                                                     {"key", "purchase" },
+                                                    {"revenue", 42 },
                                                     {"tags",
                                                         new Dictionary<string, object>
                                                         {

--- a/OptimizelySDK.Tests/UtilsTests/EventTagUtilsTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/EventTagUtilsTest.cs
@@ -35,11 +35,15 @@ namespace OptimizelySDK.Tests.UtilsTests
         {
             var expectedValue = 42;
             var expectedValue2 = 100;
+            var expectedValueString = 123;
             var validTag = new Dictionary<string, object>() {
                 { "revenue", 42 }
             };
             var validTag2 = new Dictionary<string, object>() {
                 { "revenue", 100 }
+            };
+            var validTagStringValue = new Dictionary<string, object>() {
+                { "revenue", "123" }
             };
 
             var invalidTag = new Dictionary<string, object>() {
@@ -51,16 +55,22 @@ namespace OptimizelySDK.Tests.UtilsTests
             var invalidValue = new Dictionary<string, object>() {
                 { "revenue", 42.5 }
             };
+            var invalidTagNonRevenue = new Dictionary<string, object>()
+            {
+                {"non-revenue", 123 }
+            };
 
             // Invalid data.
             Assert.Null(EventTagUtils.GetRevenueValue(null));
             Assert.Null(EventTagUtils.GetRevenueValue(invalidTag));
             Assert.Null(EventTagUtils.GetRevenueValue(nullValue));
             Assert.Null(EventTagUtils.GetRevenueValue(invalidValue));
+            Assert.Null(EventTagUtils.GetRevenueValue(invalidTagNonRevenue));
 
             // Valid data.
             Assert.AreEqual(EventTagUtils.GetRevenueValue(validTag), expectedValue);
             Assert.AreEqual(EventTagUtils.GetRevenueValue(validTag2), expectedValue2);
+            Assert.AreEqual(EventTagUtils.GetRevenueValue(validTagStringValue), expectedValueString);
         }
 
         [Test]

--- a/OptimizelySDK/Utils/EventTagUtils.cs
+++ b/OptimizelySDK/Utils/EventTagUtils.cs
@@ -10,13 +10,14 @@ namespace OptimizelySDK.Utils
 
         public static object GetRevenueValue(Dictionary<string, object> eventTags)
         {
+            int result = 0;
             if (eventTags == null 
                 || !eventTags.ContainsKey(REVENUE_EVENT_METRIC_NAME) 
                 || eventTags[REVENUE_EVENT_METRIC_NAME] == null 
-                || !(eventTags[REVENUE_EVENT_METRIC_NAME] is int))
+                || !int.TryParse(eventTags[REVENUE_EVENT_METRIC_NAME].ToString(), out result))
                 return null;
 
-           return eventTags[REVENUE_EVENT_METRIC_NAME];
+           return  result;
         }
 
         public static object GetNumericValue(Dictionary<string, object> eventTags, ILogger logger  = null)


### PR DESCRIPTION
e2e causing an issue, unable to send conversion event with revenue value. Please check if it works. 