### PR TITLE
murmurhash fix.

### DIFF
--- a/OptimizelySDK.Package/OptimizelySDK.nuspec
+++ b/OptimizelySDK.Package/OptimizelySDK.nuspec
@@ -17,21 +17,21 @@
         <dependencies>
             <group targetFramework=".NETFramework4.5">
                 <dependency id="JsonNet.PrivateSettersContractResolvers.Source" version="0.1.0" />
-                <dependency id="murmurhash" version="1.0.0" />
+                <dependency id="murmurhash-signed" version="1.0.2" />
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
                 <dependency id="NJsonSchema" version="8.30.6304.31883" />
             </group>
             <group targetFramework=".NETFramework3.5">
-                <dependency id="murmurhash" version="1.0.0" />
+                <dependency id="murmurhash-signed" version="1.0.2" />
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
             </group>
             <group targetFramework=".NETFramework4.0">
-                <dependency id="murmurhash" version="1.0.0" />
+                <dependency id="murmurhash-signed" version="1.0.2" />
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
             </group>
             <group targetFramework=".NETStandard1.6">
                 <dependency id="NETStandard.Library" version="1.6.1" />
-                <dependency id="MurmurHash-net-core" version="1.0.0" />
+                <dependency id="murmurhash-signed" version="1.0.2" />
                 <dependency id="Newtonsoft.Json" version="9.0.1" />
                 <dependency id="NJsonSchema" version="8.33.6323.36213" />
             </group>


### PR DESCRIPTION
Optimizely SDK was unable to find the murmurhash.dll which was actually bundled with murmurhash-signed sdk but dependencies had only murmurhash, the main difference was the publickey token was assigned in the murmurhash-signed sdk. 

Repro Steps
Install OptimizelySDK from nuget package. Run the this code in any sample app.
            
var b = new OptimizelySDK.Bucketing.Bucketer(new DefaultLogger());
b.GenerateBucketValue("user1");

It will raise exception.
