### PR TITLE
Whitelisted bucketing logic is in DecisionService

### DIFF
--- a/OptimizelySDK.Tests/BucketerTest.cs
+++ b/OptimizelySDK.Tests/BucketerTest.cs
@@ -166,30 +166,6 @@ namespace OptimizelySDK.Tests
         }
 
         [Test]
-        public void TestBucketValidExperimentNotInGroupUserInForcedVariation()
-        {
-            var bucketer = new Bucketer(LoggerMock.Object);
-
-            Assert.AreEqual(new Variation { Id = "7722370027", Key = "control" },
-                bucketer.Bucket(Config, Config.GetExperimentFromKey("test_experiment"), TestBucketingIdControl, "user1"));
-
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [user1] is forced into variation [control]."));
-            LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(1));
-        }
-
-        [Test]
-        public void TestBucketValidExperimentInGroupUserInForcedVariation()
-        {
-            var bucketer = new Bucketer(LoggerMock.Object);
-
-            Assert.AreEqual(new Variation { Id = "7722260071", Key = "group_exp_1_var_1" },
-                bucketer.Bucket(Config, Config.GetExperimentFromKey("group_experiment_1"), TestBucketingIdControl, "user1"));
-
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [user1] is forced into variation [group_exp_1_var_1]."));
-            LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(1));
-        }
-
-        [Test]
         public void TestBucketWithBucketingId()
         {
             var bucketer = new Bucketer(LoggerMock.Object);

--- a/OptimizelySDK/Bucketing/Bucketer.cs
+++ b/OptimizelySDK/Bucketing/Bucketer.cs
@@ -112,20 +112,6 @@ namespace OptimizelySDK.Bucketing
             if (string.IsNullOrEmpty(experiment.Key))
                 return new Variation();
 
-            // Check if user is whitelisted for a variation.
-            var forcedVariations = experiment.ForcedVariations;
-            if (forcedVariations != null && forcedVariations.ContainsKey(userId))
-            {
-                string variationKey = forcedVariations[userId];
-                variation = config.GetVariationFromKey(experiment.Key, variationKey);
-                if (!string.IsNullOrEmpty(variationKey))
-                {
-                    message = string.Format("User [{0}] is forced into variation [{1}].", userId, variationKey);
-                    Logger.Log(LogLevel.INFO, message);
-                }
-                return variation;
-            }
-
             // Determine if experiment is in a mutually exclusive group.
             if (experiment.IsInMutexGroup)
             {


### PR DESCRIPTION
We are checking whitelisted users in decision service, get variation method. This logic was placed when DecisionService class didn't exist. 