### PR TITLE
chore: Change release date on v2.2.0 to actual date it was published.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 2.2.0
-October 22, 2018
+October 26, 2018
 
 ### New Features
 * refactor(interface): Adds IOptimizely interface ([#93](https://github.com/optimizely/csharp-sdk/pull/93))


### PR DESCRIPTION
This was merged in but the actual deploy process took longer and lasted until 4 days later.