### PR TITLE
fix(set-forced-variation): Treats empty variation key as invalid and does not reset variation.

### DIFF
--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -778,7 +778,7 @@ namespace OptimizelySDK.Tests
             var experimentKey = "test_experiment";
 
             Assert.False(Config.SetForcedVariation(experimentKey, userId, "variation_not_in_datafile"));
-            Assert.True(Config.SetForcedVariation(experimentKey, userId, ""));
+            Assert.False(Config.SetForcedVariation(experimentKey, userId, ""));
             Assert.True(Config.SetForcedVariation(experimentKey, userId, null));
         }
         

--- a/OptimizelySDK/ProjectConfig.cs
+++ b/OptimizelySDK/ProjectConfig.cs
@@ -526,6 +526,13 @@ namespace OptimizelySDK
                 return false;
             }
 
+            // Empty variation key is invalid.
+            if (variationKey != null && variationKey.Length == 0)
+            {
+                Logger.Log(LogLevel.DEBUG, "Variation key is invalid.");
+                return false;
+            }
+
             var experimentId = GetExperimentFromKey(experimentKey).Id;
 
             // this case is logged in getExperimentFromKey
@@ -533,7 +540,7 @@ namespace OptimizelySDK
                 return false;
 
             // clear the forced variation if the variation key is null
-            if (string.IsNullOrEmpty(variationKey))
+            if (variationKey == null)
             {
                 if (_ForcedVariationMap.ContainsKey(userId) && _ForcedVariationMap[userId].ContainsKey(experimentId))
                     _ForcedVariationMap[userId].Remove(experimentId);


### PR DESCRIPTION
## Summary
- Forced variation key passed as an empty String will be considered as invalid.
- Updated unit tests for empty string variation key.