### PR TITLE
feat (audience match types): Update condition evaluator for new audience match types.

### DIFF
--- a/OptimizelySDK.Net35/OptimizelySDK.Net35.csproj
+++ b/OptimizelySDK.Net35/OptimizelySDK.Net35.csproj
@@ -64,7 +64,7 @@
     <Compile Include="..\OptimizelySDK\Entity\Experiment.cs">
       <Link>Entity\Experiment.cs</Link>
     </Compile>
-	<Compile Include="..\OptimizelySDK\Entity\FeatureDecision.cs">
+    <Compile Include="..\OptimizelySDK\Entity\FeatureDecision.cs">
       <Link>Entity\FeatureDecision.cs</Link>
     </Compile>
     <Compile Include="..\OptimizelySDK\Entity\ForcedVariation.cs">
@@ -127,7 +127,7 @@
     <Compile Include="..\OptimizelySDK\Logger\NoOpLogger.cs">
       <Link>Logger\NoOpLogger.cs</Link>
     </Compile>
-	<Compile Include="..\OptimizelySDK\Notifications\NotificationCenter.cs">
+    <Compile Include="..\OptimizelySDK\Notifications\NotificationCenter.cs">
       <Link>Notifications\NotificationCenter.cs</Link>
     </Compile>
     <Compile Include="..\OptimizelySDK\Optimizely.cs">
@@ -151,8 +151,11 @@
     <Compile Include="..\OptimizelySDK\Utils\Validator.cs">
       <Link>Utils\Validator.cs</Link>
     </Compile>
-	<Compile Include="..\OptimizelySDK\Utils\ControlAttributes.cs">
+    <Compile Include="..\OptimizelySDK\Utils\ControlAttributes.cs">
       <Link>Utils\ControlAttributes.cs</Link>
+    </Compile>
+    <Compile Include="..\OptimizelySDK\Utils\Evaluator.cs">
+      <Link>Utils\Evaluator.cs</Link>
     </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\OptimizelySDK\Bucketing\Bucketer.cs">
@@ -176,16 +179,16 @@
     <Compile Include="..\OptimizelySDK\Bucketing\UserprofileUtil.cs">
       <Link>Bucketing\UserProfileUtil</Link>
     </Compile>
-	<Compile Include="..\OptimizelySDK\Entity\FeatureVariableUsage.cs">
+    <Compile Include="..\OptimizelySDK\Entity\FeatureVariableUsage.cs">
       <Link>Entity\FeatureVariableUsage</Link>
     </Compile>
-	<Compile Include="..\OptimizelySDK\Entity\FeatureFlag.cs">
+    <Compile Include="..\OptimizelySDK\Entity\FeatureFlag.cs">
       <Link>Entity\FeatureFlag</Link>
     </Compile>
-	<Compile Include="..\OptimizelySDK\Entity\FeatureVariable.cs">
+    <Compile Include="..\OptimizelySDK\Entity\FeatureVariable.cs">
       <Link>Entity\FeatureVariable</Link>
     </Compile>
-	<Compile Include="..\OptimizelySDK\Entity\Rollout.cs">
+    <Compile Include="..\OptimizelySDK\Entity\Rollout.cs">
       <Link>Entity\Rollout</Link>
     </Compile>
   </ItemGroup>

--- a/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
+++ b/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
@@ -155,6 +155,9 @@
 	<Compile Include="..\OptimizelySDK\Utils\ControlAttributes.cs">
       <Link>Utils\ControlAttributes.cs</Link>
     </Compile>
+	<Compile Include="..\OptimizelySDK\Utils\Evaluator.cs">
+      <Link>Utils\Evaluator.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\OptimizelySDK\Bucketing\Bucketer.cs">
       <Link>Bucketing\Bucketer.cs</Link>

--- a/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
+++ b/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
@@ -50,15 +50,14 @@
         <Compile Include="..\OptimizelySDK\Utils\ConfigParser.cs" />
         <Compile Include="..\OptimizelySDK\Utils\Schema.cs" />
 		<Compile Include="..\OptimizelySDK\Utils\ControlAttributes.cs" />
-
+		<Compile Include="..\OptimizelySDK\Utils\ExperimentUtils.cs" />
+		<Compile Include="..\OptimizelySDK\Utils\Evaluator.cs" />
         <Compile Include="..\OptimizelySDK\Bucketing\Bucketer.cs" />
         <Compile Include="..\OptimizelySDK\Bucketing\Decision.cs" />
         <Compile Include="..\OptimizelySDK\Bucketing\DecisionService.cs" />
         <Compile Include="..\OptimizelySDK\Bucketing\UserProfile.cs" />
         <Compile Include="..\OptimizelySDK\Bucketing\UserProfileService.cs" />
         <Compile Include="..\OptimizelySDK\Bucketing\UserProfileUtil.cs" />
-		<Compile Include="..\OptimizelySDK\Utils\ExperimentUtils.cs" />
-        
     </ItemGroup>
     <ItemGroup>
         <EmbeddedResource Include="..\OptimizelySDK\Utils\schema.json">

--- a/OptimizelySDK.Tests/UtilsTests/ConditionEvaluatorTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/ConditionEvaluatorTest.cs
@@ -16,6 +16,7 @@
 using NUnit.Framework;
 using OptimizelySDK.Entity;
 using OptimizelySDK.Utils;
+using System.Collections.Generic;
 
 namespace OptimizelySDK.Tests.UtilsTests
 {
@@ -24,20 +25,78 @@ namespace OptimizelySDK.Tests.UtilsTests
     {
         private ConditionEvaluator ConditionEvaluator = null;
         private object[] Conditions = null;
-        private const string ConditionsStr = @"[""and"", [""or"", [""or"", {""name"": ""device_type"", ""type"": ""custom_attribute"", ""value"": ""iPhone""}]], [""or"", [""or"", {""name"": ""location"", ""type"": ""custom_attribute"", ""value"": ""San Francisco""}]], [""or"", [""not"", [""or"", {""name"": ""browser"", ""type"": ""custom_attribute"", ""value"": ""Firefox""}]]]]";
+
+        private object[] AndConditions = null;
+        private object[] OrConditions = null;
+        private object[] NotCondition = null;
+
+        private object[] ExistsCondition = null;
+        private object[] SubstrCondition = null;
+        private object[] GTCondition = null;
+        private object[] LTCondition = null;
+
+        private object[] ExactStrCondition = null;
+        private object[] ExactBoolCondition = null;
+        private object[] ExactDecimalCondition = null;
+        private object[] ExactIntCondition = null;
+        private object[] ExactNullCondition = null;
 
         [TestFixtureSetUp]
         public void Initialize()
         {
-            ConditionEvaluator = new ConditionEvaluator();
+            string ConditionsStr = @"[""and"", [""or"", [""or"", {""name"": ""device_type"", ""type"": ""custom_attribute"", ""value"": ""iPhone""}]], [""or"", [""or"", {""name"": ""location"", ""type"": ""custom_attribute"", ""value"": ""San Francisco""}]], [""or"", [""not"", [""or"", {""name"": ""browser"", ""type"": ""custom_attribute"", ""value"": ""Firefox""}]]]]";
 
+            string NotConditionStr = @"[""not"", [""or"", [""or"", {""name"": ""device_type"", ""type"": ""custom_attribute"", ""value"": ""iPhone"", ""match"": ""exact""}]]]";
+            string AndConditionStr = @"[""and"", 
+                                        [""or"", [""or"", {""name"": ""device_type"", ""type"": ""custom_attribute"", ""value"": ""iPhone"", ""match"": ""substring""}]], 
+                                        [""or"", [""or"", {""name"": ""num_users"", ""type"": ""custom_attribute"", ""value"": 15, ""match"": ""exact""}]], 
+                                        [""or"", [""or"", {""name"": ""decimal_value"", ""type"": ""custom_attribute"", ""value"": 3.14, ""match"": ""gt""}]]
+                                       ]";
+            string OrConditionStr = @"[""or"", 
+                                        [""or"", [""or"", {""name"": ""device_type"", ""type"": ""custom_attribute"", ""value"": ""iPhone"", ""match"": ""substring""}]], 
+                                        [""or"", [""or"", {""name"": ""num_users"", ""type"": ""custom_attribute"", ""value"": 15, ""match"": ""exact""}]], 
+                                        [""or"", [""or"", {""name"": ""decimal_value"", ""type"": ""custom_attribute"", ""value"": 3.14, ""match"": ""gt""}]]
+                                      ]";
+
+            string ExactStrConditionStr = @"[""and"", [""or"", [""or"", {""name"": ""attr_value"", ""type"": ""custom_attribute"", ""value"": ""firefox"", ""match"": ""exact""}]]]";
+            string ExactBoolConditionStr = @"[""and"", [""or"", [""or"", {""name"": ""attr_value"", ""type"": ""custom_attribute"", ""value"": false, ""match"": ""exact""}]]]";
+            string ExactDecimalConditionStr = @"[""and"", [""or"", [""or"", {""name"": ""attr_value"", ""type"": ""custom_attribute"", ""value"": 1.5, ""match"": ""exact""}]]]";
+            string ExactIntConditionStr = @"[""and"", [""or"", [""or"", {""name"": ""attr_value"", ""type"": ""custom_attribute"", ""value"": 10, ""match"": ""exact""}]]]";
+            string ExactNullConditionStr = @"[""and"", [""or"", [""or"", {""name"": ""attr_value"", ""type"": ""custom_attribute"", ""value"": null, ""match"": ""exact""}]]]";
+
+            string ExistsConditionStr = @"[""and"", [""or"", [""or"", {""name"": ""attr_value"", ""type"": ""custom_attribute"", ""match"": ""exists""}]]]";
+
+            string SubstrConditionStr = @"[""and"", [""or"", [""or"", {""name"": ""attr_value"", ""type"": ""custom_attribute"", ""value"": ""firefox"", ""match"": ""substring""}]]]";
+
+            string GTConditionStr = @"[""and"", [""or"", [""or"", {""name"": ""attr_value"", ""type"": ""custom_attribute"", ""value"": 10, ""match"": ""gt""}]]]";
+            string LTConditionStr = @"[""and"", [""or"", [""or"", {""name"": ""attr_value"", ""type"": ""custom_attribute"", ""value"": 10, ""match"": ""lt""}]]]";
+            
+            ConditionEvaluator = new ConditionEvaluator();
             Conditions = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(ConditionsStr);
+
+            AndConditions = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(AndConditionStr);
+            OrConditions = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(OrConditionStr);
+            NotCondition = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(NotConditionStr);
+
+            ExactStrCondition = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(ExactStrConditionStr);
+            ExactBoolCondition = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(ExactBoolConditionStr);
+            ExactDecimalCondition = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(ExactDecimalConditionStr);
+            ExactIntCondition = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(ExactIntConditionStr);
+            ExactNullCondition = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(ExactNullConditionStr);
+
+            ExistsCondition = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(ExistsConditionStr);
+
+            SubstrCondition = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(SubstrConditionStr);
+
+            GTCondition = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(GTConditionStr);
+            LTCondition = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(LTConditionStr);
         }
 
         [TestFixtureTearDown]
         public void TestCleanUp()
         {
             Conditions = null;
+            AndConditions = null;
             ConditionEvaluator = null;
         }
 
@@ -51,7 +110,7 @@ namespace OptimizelySDK.Tests.UtilsTests
                 {"browser", "Chrome" }
             };
 
-            Assert.IsTrue(ConditionEvaluator.Evaluate(Conditions, userAttributes));
+            Assert.That(ConditionEvaluator.Evaluate(Conditions, userAttributes), Is.True);
         }
 
         [Test]
@@ -64,7 +123,7 @@ namespace OptimizelySDK.Tests.UtilsTests
                 {"browser", "Firefox" }
             };
 
-            Assert.IsFalse(ConditionEvaluator.Evaluate(Conditions, userAttributes));
+            Assert.That(ConditionEvaluator.Evaluate(Conditions, userAttributes), Is.False);
         }
 
         [Test]
@@ -72,7 +131,7 @@ namespace OptimizelySDK.Tests.UtilsTests
         {
             var userAttributes = new UserAttributes();
 
-            Assert.IsFalse(ConditionEvaluator.Evaluate(Conditions, userAttributes));
+            Assert.That(ConditionEvaluator.Evaluate(Conditions, userAttributes), Is.Null);
         }
 
         [Test]
@@ -80,7 +139,7 @@ namespace OptimizelySDK.Tests.UtilsTests
         {
             UserAttributes userAttributes = null;
 
-            Assert.IsFalse(ConditionEvaluator.Evaluate(Conditions, userAttributes));
+            Assert.That(ConditionEvaluator.Evaluate(Conditions, userAttributes), Is.Null);
         }
 
         [Test]
@@ -89,14 +148,363 @@ namespace OptimizelySDK.Tests.UtilsTests
             var userAttributes = new UserAttributes
             {
                 {"device_type", "iPhone" },
-                {"is_firefox", false },
                 {"num_users", 15 },
-                {"pi_value", 3.14 }
+                {"decimal_value", 3.15678 }
             };
 
-            string typedConditionStr = @"[""and"", [""or"", [""or"", {""name"": ""device_type"", ""type"": ""custom_attribute"", ""value"": ""iPhone""}]], [""or"", [""or"", {""name"": ""is_firefox"", ""type"": ""custom_attribute"", ""value"": false}]], [""or"", [""or"", {""name"": ""num_users"", ""type"": ""custom_attribute"", ""value"": 15}]], [""or"", [""or"", {""name"": ""pi_value"", ""type"": ""custom_attribute"", ""value"": 3.14}]]]";
-            var typedConditions = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(typedConditionStr);
-            Assert.IsTrue(ConditionEvaluator.Evaluate(typedConditions, userAttributes));
+            Assert.That(ConditionEvaluator.Evaluate(AndConditions, userAttributes), Is.True);
         }
+
+        #region Invalid input Tests
+
+        [Test]
+        public void TestEvaluateReturnsNullWithInvalidConditionType()
+        {
+            var conditionsStr = @"[""and"", [""or"", [""or"", {""name"": ""device_type"", ""type"": ""invalid"", ""value"": ""iPhone"", ""match"": ""exact""}]]]";
+            var conditions = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(conditionsStr);
+
+            Assert.Null(ConditionEvaluator.Evaluate(conditions, new UserAttributes { { "device_type", "iPhone" } }));
+        }
+
+        [Test]
+        public void TestEvaluateReturnsNullWithInvalidMatchType()
+        {
+            var conditionsStr = @"[""and"", [""or"", [""or"", {""name"": ""device_type"", ""type"": ""custom_attribute"", ""value"": ""iPhone"", ""match"": ""invalid""}]]]";
+            var conditions = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(conditionsStr);
+
+            Assert.Null(ConditionEvaluator.Evaluate(conditions, new UserAttributes { { "device_type", "iPhone" } }));
+        }
+
+        [Test]
+        public void TestEvaluateReturnsNullWithMismatchMatcherType()
+        {
+            var conditionsStr = @"[""and"", [""or"", [""or"", {""name"": ""is_firefox"", ""type"": ""custom_attribute"", ""value"": false, ""match"": ""substring""}]]]";
+            var conditions = Newtonsoft.Json.JsonConvert.DeserializeObject<object[]>(conditionsStr);
+
+            Assert.Null(ConditionEvaluator.Evaluate(conditions, new UserAttributes { { "is_firefox", false } }));
+        }
+
+        #endregion // Invalid input Tests
+
+        #region AND condition Tests
+
+        [Test]
+        public void TestAndEvaluatorReturnsNullWhenAllOperandsReturnNull()
+        {
+            var userAttributes = new UserAttributes
+            {
+                {"device_type", 15 },
+                {"num_users", "test" },
+                {"decimal_value", false }
+            };
+
+            Assert.Null(ConditionEvaluator.Evaluate(AndConditions, userAttributes));
+        }
+
+        [Test]
+        public void TestAndEvaluatorReturnsNullWhenOperandsEvaluateToTrueAndNull()
+        {
+            var userAttributes = new UserAttributes
+            {
+                {"device_type", "my iPhone" },
+                {"num_users", 15 },
+                {"decimal_value", false } // This evaluates to null.
+            };
+
+            Assert.Null(ConditionEvaluator.Evaluate(AndConditions, userAttributes));
+        }
+
+        [Test]
+        public void TestAndEvaluatorReturnsFalseWhenOperandsEvaluateToFalseAndNull()
+        {
+            var userAttributes = new UserAttributes
+            {
+                {"device_type", "Android" }, // Evaluates to false.
+                {"num_users", 20 }, // Evaluates to false.
+                {"decimal_value", false } // Evaluates to null.
+            };
+
+            Assert.That(ConditionEvaluator.Evaluate(AndConditions, userAttributes), Is.False);
+        }
+
+        [Test]
+        public void TestAndEvaluatorReturnsFalseWhenOperandsEvaluateToFalseTrueAndNull()
+        {
+            var userAttributes = new UserAttributes
+            {
+                {"device_type", "Phone" }, // Evaluates to true.
+                {"num_users", 20 }, // Evaluates to false.
+                {"decimal_value", false } // Evaluates to null.
+            };
+
+            Assert.That(ConditionEvaluator.Evaluate(AndConditions, userAttributes), Is.False);
+        }
+
+        [Test]
+        public void TestAndEvaluatorReturnsTrueWhenAllOperandsEvaluateToTrue()
+        {
+            var userAttributes = new UserAttributes
+            {
+                {"device_type", "iPhone X" },
+                {"num_users", 15 },
+                {"decimal_value", 3.1567 }
+            };
+
+            Assert.That(ConditionEvaluator.Evaluate(AndConditions, userAttributes), Is.True);
+        }
+
+        #endregion // AND condition Tests
+
+        #region OR condition Tests
+
+        [Test]
+        public void TestOrEvaluatorReturnsNullWhenAllOperandsReturnNull()
+        {
+            var userAttributes = new UserAttributes
+            {
+                {"device_type", 15 },
+                {"num_users", "test" },
+                {"decimal_value", false }
+            };
+
+            Assert.Null(ConditionEvaluator.Evaluate(OrConditions, userAttributes));
+        }
+
+        [Test]
+        public void TestOrEvaluatorReturnsTrueWhenOperandsEvaluateToTruesAndNulls()
+        {
+            var userAttributes = new UserAttributes
+            {
+                {"device_type", "hone" }, // Evaluates to true.
+                {"num_users", 15 },
+                {"decimal_value", false } // Evaluates to null.
+            };
+
+            Assert.That(ConditionEvaluator.Evaluate(OrConditions, userAttributes), Is.True);
+        }
+
+        [Test]
+        public void TestOrEvaluatorReturnsNullWhenOperandsEvaluateToFalsesAndNulls()
+        {
+            var userAttributes = new UserAttributes
+            {
+                {"device_type", "Android" }, // Evaluates to false.
+                {"num_users", 20 }, // Evaluates to false.
+                {"decimal_value", false } // Evaluates to null.
+            };
+
+            Assert.Null(ConditionEvaluator.Evaluate(OrConditions, userAttributes));
+        }
+
+        [Test]
+        public void TestOrEvaluatorReturnsTrueWhenOperandsEvaluateToFalsesTruesAndNulls()
+        {
+            var userAttributes = new UserAttributes
+            {
+                {"device_type", "iPhone file explorer" }, // Evaluates to true.
+                {"num_users", 20 }, // Evaluates to false.
+                {"decimal_value", false } // Evaluates to null.
+            };
+
+            Assert.That(ConditionEvaluator.Evaluate(OrConditions, userAttributes), Is.True);
+        }
+
+        [Test]
+        public void TestOrEvaluatorReturnsFalseWhenAllOperandsEvaluateToFalse()
+        {
+            var userAttributes = new UserAttributes
+            {
+                {"device_type", "Android" },
+                {"num_users", 17 },
+                {"decimal_value", 3.12 }
+            };
+
+            Assert.That(ConditionEvaluator.Evaluate(OrConditions, userAttributes), Is.False);
+        }
+
+        #endregion // OR condition Tests
+
+        #region NOT condition Tests
+
+        [Test]
+        public void TestNotEvaluatorReturnsNullWhenOperandEvaluateToNull()
+        {
+            Assert.Null(ConditionEvaluator.Evaluate(NotCondition, new UserAttributes { { "device_type", 123 } }));
+        }
+
+        [Test]
+        public void TestNotEvaluatorReturnsTrueWhenOperandEvaluateToFalse()
+        {
+            Assert.That(ConditionEvaluator.Evaluate(NotCondition, new UserAttributes { { "device_type", "Android" } }), Is.True);
+        }
+
+        [Test]
+        public void TestNotEvaluatorReturnsFalseWhenOperandEvaluateToTrue()
+        {
+            Assert.That(ConditionEvaluator.Evaluate(NotCondition, new UserAttributes { { "device_type", "iPhone" } }), Is.False);
+        }
+
+        #endregion // NOT condition Tests
+
+        #region ExactMatcher Tests
+
+        [Test]
+        public void TestExactMatcherReturnsFalseWhenAttributeValueDoesNotMatch()
+        {
+            Assert.That(ConditionEvaluator.Evaluate(ExactStrCondition, new UserAttributes { { "attr_value", "chrome" } }), Is.False);
+            Assert.That(ConditionEvaluator.Evaluate(ExactBoolCondition, new UserAttributes { { "attr_value", true } }), Is.False);
+            Assert.That(ConditionEvaluator.Evaluate(ExactDecimalCondition, new UserAttributes { { "attr_value", 2.5 } }), Is.False);
+            Assert.That(ConditionEvaluator.Evaluate(ExactIntCondition, new UserAttributes { { "attr_value", 55 } }), Is.False);
+        }
+
+        [Test]
+        public void TestExactMatcherReturnsNullWhenTypeMismatch()
+        {
+            Assert.Null(ConditionEvaluator.Evaluate(ExactStrCondition, new UserAttributes { { "attr_value", true } }));
+            Assert.Null(ConditionEvaluator.Evaluate(ExactBoolCondition, new UserAttributes { { "attr_value", "abcd" } }));
+            Assert.Null(ConditionEvaluator.Evaluate(ExactDecimalCondition, new UserAttributes { { "attr_value", false } }));
+            Assert.Null(ConditionEvaluator.Evaluate(ExactBoolCondition, new UserAttributes { { "attr_value", 0 } }));
+        }
+
+        [Test]
+        public void TestExactMatcherReturnsNullForInvalidNumericValue()
+        {
+            var invalidPositiveValue = System.Math.Pow(2, 53) + 2;
+            var invalidNegativeValue = (System.Math.Pow(2, 53) * -1) - 2;
+            
+            Assert.Null(ConditionEvaluator.Evaluate(ExactIntCondition, new UserAttributes { { "attr_value", double.NaN } }));
+            Assert.Null(ConditionEvaluator.Evaluate(ExactIntCondition, new UserAttributes { { "attr_value", double.NegativeInfinity } }));
+            Assert.Null(ConditionEvaluator.Evaluate(ExactIntCondition, new UserAttributes { { "attr_value", double.PositiveInfinity } }));
+            Assert.Null(ConditionEvaluator.Evaluate(ExactIntCondition, new UserAttributes { { "attr_value", invalidPositiveValue } }));
+            Assert.Null(ConditionEvaluator.Evaluate(ExactIntCondition, new UserAttributes { { "attr_value", invalidNegativeValue } }));
+            Assert.Null(ConditionEvaluator.Evaluate(ExactIntCondition, new UserAttributes { { "attr_value", (ulong)invalidPositiveValue } }));
+            Assert.Null(ConditionEvaluator.Evaluate(ExactIntCondition, new UserAttributes { { "attr_value", (long)invalidNegativeValue } }));
+        }
+
+        [Test]
+        public void TestExactMatcherReturnsTrueWhenAttributeValueMatches()
+        {
+            Assert.That(ConditionEvaluator.Evaluate(ExactStrCondition, new UserAttributes { { "attr_value", "firefox" } }), Is.True);
+            Assert.That(ConditionEvaluator.Evaluate(ExactBoolCondition, new UserAttributes { { "attr_value", false } }), Is.True);
+            Assert.That(ConditionEvaluator.Evaluate(ExactDecimalCondition, new UserAttributes { { "attr_value", 1.5 } }), Is.True);
+            Assert.That(ConditionEvaluator.Evaluate(ExactIntCondition, new UserAttributes { { "attr_value", 10 } }), Is.True);
+            Assert.That(ConditionEvaluator.Evaluate(ExactIntCondition, new UserAttributes { { "attr_value", 10.0 } }), Is.True);
+            Assert.That(ConditionEvaluator.Evaluate(ExactNullCondition, new UserAttributes { { "attr_value", null } }), Is.True);
+        }
+
+        #endregion // ExactMatcher Tests
+
+        #region ExistsMatcher Tests
+
+        [Test]
+        public void TestExistsMatcherReturnsFalseWhenAttributeIsNotProvided()
+        {
+            Assert.That(ConditionEvaluator.Evaluate(ExistsCondition, new UserAttributes { }), Is.False);
+        }
+
+        [Test]
+        public void TestExistsMatcherReturnsFalseWhenAttributeIsNull()
+        {
+            Assert.That(ConditionEvaluator.Evaluate(ExistsCondition, new UserAttributes { { "attr_value", null } }), Is.False);
+        }
+
+        [Test]
+        public void TestExistsMatcherReturnsTrueWhenAttributeValueIsProvided()
+        {
+            Assert.That(ConditionEvaluator.Evaluate(ExistsCondition, new UserAttributes { { "attr_value", "" } }), Is.True);
+            Assert.That(ConditionEvaluator.Evaluate(ExistsCondition, new UserAttributes { { "attr_value", "iPhone" } }), Is.True);
+            Assert.That(ConditionEvaluator.Evaluate(ExistsCondition, new UserAttributes { { "attr_value", 10 } }), Is.True);
+            Assert.That(ConditionEvaluator.Evaluate(ExistsCondition, new UserAttributes { { "attr_value", 10.5 } }), Is.True);
+            Assert.That(ConditionEvaluator.Evaluate(ExistsCondition, new UserAttributes { { "attr_value", false } }), Is.True);
+        }
+
+        #endregion // ExistsMatcher Tests
+
+        #region SubstringMatcher Tests
+
+        [Test]
+        public void TestSubstringMatcherReturnsFalseWhenAttributeValueIsNotASubstring()
+        {
+            Assert.That(ConditionEvaluator.Evaluate(SubstrCondition, new UserAttributes { { "attr_value", "chrome" } }), Is.False);
+        }
+
+        [Test]
+        public void TestSubstringMatcherReturnsTrueWhenAttributeValueIsASubstring()
+        {
+            Assert.That(ConditionEvaluator.Evaluate(SubstrCondition, new UserAttributes { { "attr_value", "firefox" } }), Is.True);
+            Assert.That(ConditionEvaluator.Evaluate(SubstrCondition, new UserAttributes { { "attr_value", "chrome vs firefox" } }), Is.True);
+        }
+
+        [Test]
+        public void TestSubstringMatcherReturnsNullWhenAttributeValueIsNotAString()
+        {
+            Assert.Null(ConditionEvaluator.Evaluate(SubstrCondition, new UserAttributes { { "attr_value", 10.5} }));
+        }
+
+        #endregion // SubstringMatcher Tests
+
+        #region GTMatcher Tests
+
+        [Test]
+        public void TestGTMatcherReturnsFalseWhenAttributeValueIsLessThanOrEqualToConditionValue()
+        {
+            Assert.That(ConditionEvaluator.Evaluate(GTCondition, new UserAttributes { { "attr_value", 5 } }), Is.False);
+            Assert.That(ConditionEvaluator.Evaluate(GTCondition, new UserAttributes { { "attr_value", 10 } }), Is.False);
+        }
+
+        [Test]
+        public void TestGTMatcherReturnsNullWhenForInvalidNumericValue()
+        {
+            var invalidPositiveValue = System.Math.Pow(2, 53) + 2;
+            var invalidNegativeValue = (System.Math.Pow(2, 53) * -1) - 2;
+            Assert.Null(ConditionEvaluator.Evaluate(GTCondition, new UserAttributes { { "attr_value", double.NaN } }));
+            Assert.Null(ConditionEvaluator.Evaluate(GTCondition, new UserAttributes { { "attr_value", double.NegativeInfinity } }));
+            Assert.Null(ConditionEvaluator.Evaluate(GTCondition, new UserAttributes { { "attr_value", double.PositiveInfinity } }));
+            Assert.Null(ConditionEvaluator.Evaluate(GTCondition, new UserAttributes { { "attr_value", invalidPositiveValue } }));
+            Assert.Null(ConditionEvaluator.Evaluate(GTCondition, new UserAttributes { { "attr_value", invalidNegativeValue } }));
+            Assert.Null(ConditionEvaluator.Evaluate(GTCondition, new UserAttributes { { "attr_value", "invalid" } }));
+            Assert.Null(ConditionEvaluator.Evaluate(GTCondition, new UserAttributes { { "attr_value", (ulong)invalidPositiveValue } }));
+            Assert.Null(ConditionEvaluator.Evaluate(GTCondition, new UserAttributes { { "attr_value", (long)invalidNegativeValue } }));
+        }
+
+        [Test]
+        public void TestGTMatcherReturnsTrueWhenAttributeValueIsGreaterThanConditionValue()
+        {
+            Assert.That(ConditionEvaluator.Evaluate(GTCondition, new UserAttributes { { "attr_value", 15 } }), Is.True);
+        }
+
+        #endregion // GTMatcher Tests
+
+        #region LTMatcher Tests
+
+        [Test]
+        public void TestLTMatcherReturnsFalseWhenAttributeValueIsGreaterThanOrEqualToConditionValue()
+        {
+            Assert.That(ConditionEvaluator.Evaluate(LTCondition, new UserAttributes { { "attr_value", 15 } }), Is.False);
+            Assert.That(ConditionEvaluator.Evaluate(LTCondition, new UserAttributes { { "attr_value", 10 } }), Is.False);
+        }
+
+        [Test]
+        public void TestLTMatcherReturnsNullForInvalidNumericValue()
+        {
+            var invalidPositiveValue = System.Math.Pow(2, 53) + 2;
+            var invalidNegativeValue = (System.Math.Pow(2, 53) * -1) - 2;
+            Assert.Null(ConditionEvaluator.Evaluate(LTCondition, new UserAttributes { { "attr_value", double.NaN } }));
+            Assert.Null(ConditionEvaluator.Evaluate(LTCondition, new UserAttributes { { "attr_value", double.NegativeInfinity } }));
+            Assert.Null(ConditionEvaluator.Evaluate(LTCondition, new UserAttributes { { "attr_value", double.PositiveInfinity } }));
+            Assert.Null(ConditionEvaluator.Evaluate(LTCondition, new UserAttributes { { "attr_value", invalidPositiveValue } }));
+            Assert.Null(ConditionEvaluator.Evaluate(LTCondition, new UserAttributes { { "attr_value", invalidNegativeValue } }));
+            Assert.Null(ConditionEvaluator.Evaluate(LTCondition, new UserAttributes { { "attr_value", "invalid" } }));
+            Assert.Null(ConditionEvaluator.Evaluate(LTCondition, new UserAttributes { { "attr_value", (ulong)invalidPositiveValue } }));
+            Assert.Null(ConditionEvaluator.Evaluate(LTCondition, new UserAttributes { { "attr_value", (long)invalidNegativeValue } }));
+        }
+
+        [Test]
+        public void TestLTMatcherReturnsTrueWhenAttributeValueIsLessThanConditionValue()
+        {
+            Assert.That(ConditionEvaluator.Evaluate(LTCondition, new UserAttributes { { "attr_value", 5 } }), Is.True);
+        }
+
+        #endregion // LTMatcher Tests
     }
 }

--- a/OptimizelySDK/OptimizelySDK.csproj
+++ b/OptimizelySDK/OptimizelySDK.csproj
@@ -105,6 +105,7 @@
     <Compile Include="Bucketing\UserProfileUtil.cs" />
     <Compile Include="Utils\ExperimentUtils.cs" />
     <Compile Include="Utils\ControlAttributes.cs" />
+    <Compile Include="Utils\Evaluator.cs" />
     <Compile Include="Utils\Validator.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Utils\ConfigParser.cs" />

--- a/OptimizelySDK/Utils/ConditionEvaluator.cs
+++ b/OptimizelySDK/Utils/ConditionEvaluator.cs
@@ -17,7 +17,6 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OptimizelySDK.Entity;
 using System;
-using System.Linq;
 
 namespace OptimizelySDK.Utils
 {
@@ -38,23 +37,95 @@ namespace OptimizelySDK.Utils
         /// </summary>
         const string NOT_OPERATOR = "not";
 
-        private bool AndEvaluator(JArray conditions, UserAttributes userAttributes)
+        /// <summary>
+        /// String constant representing custome attribute condition type.
+        /// </summary>
+        const string CUSTOM_ATTRIBUTE_CONDITION_TYPE = "custom_attribute";
+
+        /// <summary>
+        /// Evaluates an array of conditions as if the evaluator had been applied
+        /// to each entry and the results AND-ed together.
+        /// </summary>
+        /// <param name="conditions">Array of conditions ex: [operand_1, operand_2]</param>
+        /// <param name="userAttributes">Hash representing user attributes</param>
+        /// <returns>true/false if the user attributes match/don't match the given conditions,
+        /// null if the user attributes and conditions can't be evaluated</returns>
+        private bool? AndEvaluator(JArray conditions, UserAttributes userAttributes)
         {
-            return conditions.All(condition => Evaluate(condition, userAttributes));
+            // According to the matrix:
+            // false and true is false
+            // false and null is false
+            // true and null is null.
+            // true and false is false
+            // true and true is true
+            // null and null is null
+            var foundNull = false;
+            foreach(var condition in conditions)
+            {
+                var result = Evaluate(condition, userAttributes);
+                if (result == null)
+                    foundNull = true;
+                else if (result == false)
+                    return false;
+            }
+
+            if (foundNull)
+                return null;
+
+            return true;
         }
 
-        private bool OrEvaluator(JArray conditions, UserAttributes userAttributes)
+        /// <summary>
+        /// Evaluates an array of conditions as if the evaluator had been applied
+        /// to each entry and the results OR-ed together.
+        /// </summary>
+        /// <param name="conditions">Array of conditions ex: [operand_1, operand_2]</param>
+        /// <param name="userAttributes">Hash representing user attributes</param>
+        /// <returns>true/false if the user attributes match/don't match the given conditions,
+        /// null if the user attributes and conditions can't be evaluated</returns>
+        private bool? OrEvaluator(JArray conditions, UserAttributes userAttributes)
         {
-            return conditions.Any(condition => Evaluate(condition, userAttributes));
+            // According to the matrix:
+            // true returns true
+            // false or null is null
+            // false or false is false
+            // null or null is null
+            var foundNull = false;
+            foreach (var condition in conditions)
+            {
+                var result = Evaluate(condition, userAttributes);
+                if (result == null)
+                    foundNull = true;
+                else if (result == true)
+                    return true;
+            }
+
+            if (foundNull)
+                return null;
+
+            return false;
         }
 
-        private bool NotEvaluator(JArray conditions, UserAttributes userAttributes)
+        /// <summary>
+        /// Evaluates an array of conditions as if the evaluator had been applied
+        /// to a single entry and NOT was applied to the result.
+        /// </summary>
+        /// <param name="conditions">Array of conditions ex: [operand_1, operand_2]</param>
+        /// <param name="userAttributes">Hash representing user attributes</param>
+        /// <returns>true/false if the user attributes match/don't match the given conditions,
+        /// null if the user attributes and conditions can't be evaluated</returns>
+        private bool? NotEvaluator(JArray conditions, UserAttributes userAttributes)
         {
-            return conditions.Count == 1 && !Evaluate(conditions[0], userAttributes);
+            if (conditions.Count == 1)
+            {
+                var result = Evaluate(conditions[0], userAttributes);
+                return result == null ? null : !result;
+            }
 
+            return false;
         }
 
-        public bool Evaluate(JToken conditions, UserAttributes userAttributes)
+        public bool? Evaluate(JToken conditions, UserAttributes userAttributes)
         {
             //Cloning is because it is reference type
             var conditionsArray = conditions.DeepClone() as JArray;
@@ -70,11 +141,23 @@ namespace OptimizelySDK.Utils
                 }
             }
 
-            string conditionName = conditions["name"].ToString();
-            return userAttributes != null && userAttributes.ContainsKey(conditionName) && CompareValues(userAttributes[conditionName], conditions["value"]);
+            if (conditions["type"] != null && conditions["type"].ToString() != CUSTOM_ATTRIBUTE_CONDITION_TYPE)
+                return null;
+
+            string matchType = conditions["match"]?.ToString();
+            var conditionValue = conditions["value"]?.ToObject<object>();
+            
+            object attributeValue = null;
+            if (userAttributes != null && userAttributes.ContainsKey(conditions["name"].ToString()))
+            {
+                attributeValue = userAttributes[conditions["name"].ToString()];
+            }
+
+            var evaluator = Evaluator.GetEvaluator(matchType);
+            return evaluator != null ? evaluator(conditionValue, attributeValue) : null;
         }
 
-        public bool Evaluate(object[] conditions, UserAttributes userAttributes)
+        public bool? Evaluate(object[] conditions, UserAttributes userAttributes)
         {
             return Evaluate(ConvertObjectArrayToJToken(conditions), userAttributes);
         }
@@ -89,30 +172,6 @@ namespace OptimizelySDK.Utils
         public static JToken DecodeConditions(string conditions)
         {
             return JToken.Parse(conditions);
-        }
-
-        private bool CompareValues(object attribute, JToken condition)
-        {
-            try
-            {
-                switch (condition.Type)
-                {
-                    case JTokenType.Integer:
-                        return (int)condition == Convert.ToInt32(attribute);
-                    case JTokenType.Float:
-                        return (double)condition == Convert.ToDouble(attribute);
-                    case JTokenType.String:
-                        return (string)condition == Convert.ToString(attribute);
-                    case JTokenType.Boolean:
-                        return (bool)condition == Convert.ToBoolean(attribute);
-                    default:
-                        return false;
-                }
-            }
-            catch (Exception)
-            {
-                return false;
-            }
         }
     }
 }

--- a/OptimizelySDK/Utils/Evaluator.cs
+++ b/OptimizelySDK/Utils/Evaluator.cs
@@ -1,0 +1,102 @@
+﻿/* 
+ * Copyright 2018, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System;
+
+namespace OptimizelySDK.Utils
+{
+    public static class Evaluator
+    {
+        public static class AttributeMatchTypes
+        {
+            public const string EXACT = "exact";
+            public const string EXIST = "exists";
+            public const string GREATER_THAN = "gt";
+            public const string LESS_THAN = "lt";
+            public const string SUBSTRING = "substring";
+        }
+
+        public static Func<object, object, bool?> GetEvaluator(string matchType)
+        {
+            switch (matchType)
+            {
+                case AttributeMatchTypes.EXACT:
+                    return ExactEvaluator;
+                case AttributeMatchTypes.EXIST:
+                    return ExistEvaluator;
+                case AttributeMatchTypes.GREATER_THAN:
+                    return GreaterThanEvaluator;
+                case AttributeMatchTypes.LESS_THAN:
+                    return LessThanEvaluator;
+                case AttributeMatchTypes.SUBSTRING:
+                    return SubstringEvaluator;
+                case null:
+                    return ExactEvaluator;
+            }
+
+            return null;
+        }
+
+        public static bool? ExactEvaluator(object conditionValue, object attributeValue)
+        {
+            if (conditionValue == null && attributeValue == null)
+                return true;
+
+            if (conditionValue is bool && attributeValue is bool)
+                return (bool)conditionValue == (bool)attributeValue;
+
+            if (Validator.IsValidNumericValue(conditionValue) && Validator.IsValidNumericValue(attributeValue))
+                return Convert.ToDouble(conditionValue) == Convert.ToDouble(attributeValue);
+
+            if (conditionValue is string && attributeValue is string)
+                return (string)conditionValue == (string)attributeValue;
+
+            return null;
+        }
+
+        public static bool? ExistEvaluator(object conditionValue, object attributeValue)
+        {
+            return attributeValue != null;
+        }
+
+        public static bool? GreaterThanEvaluator(object conditionValue, object attributeValue)
+        {
+            if (Validator.IsValidNumericValue(conditionValue) && Validator.IsValidNumericValue(attributeValue))
+                return Convert.ToDouble(attributeValue) > Convert.ToDouble(conditionValue);
+
+            return null;
+        }
+
+        public static bool? LessThanEvaluator(object conditionValue, object attributeValue)
+        {
+            if (Validator.IsValidNumericValue(conditionValue) && Validator.IsValidNumericValue(attributeValue))
+                return Convert.ToDouble(attributeValue) < Convert.ToDouble(conditionValue);
+
+            return null;
+        }
+
+        public static bool? SubstringEvaluator(object conditionValue, object attributeValue)
+        {
+            if (conditionValue is string && attributeValue is string)
+            {
+                var value = (string)attributeValue;
+                return value != null && value.Contains((string)conditionValue);
+            }
+
+            return null;
+        }
+    }
+}

--- a/OptimizelySDK/Utils/ExperimentUtils.cs
+++ b/OptimizelySDK/Utils/ExperimentUtils.cs
@@ -1,4 +1,20 @@
-﻿using OptimizelySDK.Entity;
+﻿/* 
+ * Copyright 2017-2018, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using OptimizelySDK.Entity;
 using OptimizelySDK.Logger;
 using System.Linq;
 
@@ -26,8 +42,7 @@ namespace OptimizelySDK.Utils
         /// </summary>
         /// <param name="config">ProjectConfig Configuration for the project</param>
         /// <param name="experiment">Experiment Entity representing the experiment</param>
-        /// <param name="userAttributes">array Attributes of the user</param>
-        /// <returns>whether user meets audience conditions to be in experiment or not</returns>
+        /// <param name="userAttributes">array Attributes of the user</returns>
         public static bool IsUserInExperiment(ProjectConfig config, Experiment experiment, UserAttributes userAttributes)
         {
             var audienceIds = experiment.AudienceIds;
@@ -37,10 +52,9 @@ namespace OptimizelySDK.Utils
 
             if (userAttributes == null || !userAttributes.Any())
                 return false;
-
+            
             var conditionEvaluator = new ConditionEvaluator();
-
-            return audienceIds.Any(id => conditionEvaluator.Evaluate(config.GetAudience(id).ConditionList, userAttributes));
+            return audienceIds.Any(id => conditionEvaluator.Evaluate(config.GetAudience(id).ConditionList, userAttributes).GetValueOrDefault());
         }
     }
 }

--- a/OptimizelySDK/Utils/Validator.cs
+++ b/OptimizelySDK/Utils/Validator.cs
@@ -114,6 +114,37 @@ namespace OptimizelySDK.Utils
                 (attribute.Value is int || attribute.Value is string || attribute.Value is double 
                  || attribute.Value is bool || attribute.Value is float || attribute.Value is long);
         }
+
+        /// <summary>
+        /// Validates if the type of provided value is numeric.
+        /// </summary>
+        /// <param name="value">true if the type of provided value is numeric, false otherwise</param>
+        /// <returns></returns>
+        public static bool IsNumericType(object value)
+        {
+            return value is byte || value is sbyte || value is char || value is short || value is ushort
+                || value is int || value is uint || value is long || value is ulong || value is float
+                || value is double || value is decimal;
+        }
+
+        /// <summary>
+        /// Validates if the provided value is a valid numeric value.
+        /// </summary>
+        /// <param name="value">Input value</param>
+        /// <returns>true if the provided absolute value is not infinite, NAN and greater than 2^53, false otherwise</returns>
+        public static bool IsValidNumericValue(object value)
+        {
+            if (IsNumericType(value))
+            {
+                var doubleValue = Convert.ToDouble(value);
+                if (double.IsInfinity(doubleValue) || double.IsNaN(doubleValue) || Math.Abs(doubleValue) > Math.Pow(2, 53))
+                    return false;
+
+                return true;
+            }
+
+            return false;
+        }
     }
 }
 


### PR DESCRIPTION
### Summary

This adds support for new audience match type conditions to the condition evaluator:
- exact, exists, gt, lt, and substring conditions
- Abort and return null when appropriate in leaf evaluators
- Null handling in and/or/not evaluators

### Test Plan

Added new unit tests.
