### PR TITLE
refac(ci): switch stage order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,11 @@ script:
   - xbuild /p:Configuration=Release ./OptimizelySDK.Travis.sln
   - mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe ./OptimizelySDK.Tests/bin/Release/OptimizelySDK.Tests.dll 
 
+# Integration tests need to run first to reset the PR build status to pending
+stages:
+  - 'Integration tests'
+  - 'Test'
+
 jobs:
   include:
     - stage: 'Integration tests'


### PR DESCRIPTION
## Summary
- switch the order of stages so that integration tests occur ahead of unit tests. this allows resetting the build status to pending without having to wait for unit tests to finish first.