### PR TITLE
fix(eventtagsutils) : don't exclude falsy values

### DIFF
--- a/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
@@ -971,7 +971,7 @@ namespace OptimizelySDK.Tests.EventTests
         }
 
         [Test]
-        public void TestConversionEventWithFalsyValues()
+        public void TestConversionEventWithFalsyNumericAndRevenueValues()
         {
             var guid = Guid.NewGuid();
             var timeStamp = TestData.SecondsSince1970();
@@ -1081,12 +1081,12 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"timestamp", timeStamp },
                                                     {"uuid", guid },
                                                     {"key", "purchase" },
-                                                    {"revenue", 1 },
+                                                    {"revenue", 10 },
                                                     {"value", 1.0 },
                                                     {"tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", 1 },
+                                                            {"revenue", 10 },
                                                             {"value", 1.0 }
                                                         }
                                                     }
@@ -1137,8 +1137,95 @@ namespace OptimizelySDK.Tests.EventTests
             var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, null,
                 new EventTags
             {
-                    {"revenue", 1 },
+                    {"revenue", 10 },
                     {"value", 1.0 }
+            });
+
+            TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
+
+            Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
+        }
+        [Test]
+        public void TestConversionEventWithRevenueValue1()
+        {
+            var guid = Guid.NewGuid();
+            var timeStamp = TestData.SecondsSince1970();
+            var payloadParams = new Dictionary<string, object>
+            {
+                { "visitors", new object[]
+                    {
+                        new Dictionary<string, object>()
+                        {
+                            { "snapshots", new object[]
+                                {
+                                    new Dictionary<string, object>
+                                    {
+                                        { "events", new object[]
+                                            {
+                                                new Dictionary<string, object>
+                                                {
+                                                    {"entity_id", "7718020063" },
+                                                    {"timestamp", timeStamp },
+                                                    {"uuid", guid },
+                                                    {"key", "purchase" },
+                                                    {"revenue", 1 },
+                                                    {"value", 10.0 },
+                                                    {"tags",
+                                                        new Dictionary<string, object>
+                                                        {
+                                                            {"revenue", 1 },
+                                                            {"value", 10.0 }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            { "attributes", new object[]
+                                {
+                                    new Dictionary<string, object>
+                                    {
+                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
+                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
+                                        {"type", "custom" },
+                                        {"value", true }
+                                    }
+                                }
+                            },
+                            { "visitor_id", TestUserId }
+                        }
+                    }
+                },
+                {"project_id", "7720880029" },
+                {"enrich_decisions", true},
+                {"account_id", "1592310167" },
+                {"client_name", "csharp-sdk" },
+                {"client_version", Optimizely.SDK_VERSION },
+                {"revision", "15" },
+                {"anonymize_ip", false}
+            };
+
+            var expectedEvent = new LogEvent(
+                "https://logx.optimizely.com/v1/events",
+                payloadParams,
+                "POST",
+                new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json"}
+                });
+
+            var experimentToVariationMap = new Dictionary<string, Variation>
+            {
+                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+            };
+
+            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, null,
+                new EventTags
+            {
+                    {"revenue", 1 },
+                    {"value", 10.0 }
             });
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);

--- a/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
@@ -971,6 +971,183 @@ namespace OptimizelySDK.Tests.EventTests
         }
 
         [Test]
+        public void TestConversionEventWithFalsyValues()
+        {
+            var guid = Guid.NewGuid();
+            var timeStamp = TestData.SecondsSince1970();
+            var payloadParams = new Dictionary<string, object>
+            {
+                { "visitors", new object[]
+                    {
+                        new Dictionary<string, object>()
+                        {
+                            { "snapshots", new object[]
+                                {
+                                    new Dictionary<string, object>
+                                    {
+                                        { "events", new object[]
+                                            {
+                                                new Dictionary<string, object>
+                                                {
+                                                    {"entity_id", "7718020063" },
+                                                    {"timestamp", timeStamp },
+                                                    {"uuid", guid },
+                                                    {"key", "purchase" },
+                                                    {"revenue", 0 },
+                                                    {"value", 0.0 },
+                                                    {"tags",
+                                                        new Dictionary<string, object>
+                                                        {
+                                                            {"revenue", 0 },
+                                                            {"value", 0.0 }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            { "attributes", new object[]
+                                {
+                                    new Dictionary<string, object>
+                                    {
+                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
+                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
+                                        {"type", "custom" },
+                                        {"value", true }
+                                    }
+                                }
+                            },
+                            { "visitor_id", TestUserId }
+                        }
+                    }
+                },
+                {"project_id", "7720880029" },
+                {"enrich_decisions", true},
+                {"account_id", "1592310167" },
+                {"client_name", "csharp-sdk" },
+                {"client_version", Optimizely.SDK_VERSION },
+                {"revision", "15" },
+                {"anonymize_ip", false}
+            };
+
+            var expectedEvent = new LogEvent(
+                "https://logx.optimizely.com/v1/events",
+                payloadParams,
+                "POST",
+                new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json"}
+                });
+
+            var experimentToVariationMap = new Dictionary<string, Variation>
+            {
+                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+            };
+
+            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, null,
+                new EventTags
+            {
+                    {"revenue", 0 },
+                    {"value", 0.0 }
+            });
+
+            TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
+
+            Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
+        }
+
+        [Test]
+        public void TestConversionEventWithNumericValue1()
+        {
+            var guid = Guid.NewGuid();
+            var timeStamp = TestData.SecondsSince1970();
+            var payloadParams = new Dictionary<string, object>
+            {
+                { "visitors", new object[]
+                    {
+                        new Dictionary<string, object>()
+                        {
+                            { "snapshots", new object[]
+                                {
+                                    new Dictionary<string, object>
+                                    {
+                                        { "events", new object[]
+                                            {
+                                                new Dictionary<string, object>
+                                                {
+                                                    {"entity_id", "7718020063" },
+                                                    {"timestamp", timeStamp },
+                                                    {"uuid", guid },
+                                                    {"key", "purchase" },
+                                                    {"revenue", 1 },
+                                                    {"value", 1.0 },
+                                                    {"tags",
+                                                        new Dictionary<string, object>
+                                                        {
+                                                            {"revenue", 1 },
+                                                            {"value", 1.0 }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            { "attributes", new object[]
+                                {
+                                    new Dictionary<string, object>
+                                    {
+                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
+                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
+                                        {"type", "custom" },
+                                        {"value", true }
+                                    }
+                                }
+                            },
+                            { "visitor_id", TestUserId }
+                        }
+                    }
+                },
+                {"project_id", "7720880029" },
+                {"enrich_decisions", true},
+                {"account_id", "1592310167" },
+                {"client_name", "csharp-sdk" },
+                {"client_version", Optimizely.SDK_VERSION },
+                {"revision", "15" },
+                {"anonymize_ip", false}
+            };
+
+            var expectedEvent = new LogEvent(
+                "https://logx.optimizely.com/v1/events",
+                payloadParams,
+                "POST",
+                new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json"}
+                });
+
+            var experimentToVariationMap = new Dictionary<string, Variation>
+            {
+                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+            };
+
+            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, null,
+                new EventTags
+            {
+                    {"revenue", 1 },
+                    {"value", 1.0 }
+            });
+
+            TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
+
+            Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
+        }
+
+
+        [Test]
         public void TestCreateConversionEventWithBucketingIDAttribute()
         {
             var guid = Guid.NewGuid();

--- a/OptimizelySDK/Utils/EventTagUtils.cs
+++ b/OptimizelySDK/Utils/EventTagUtils.cs
@@ -92,10 +92,10 @@ namespace OptimizelySDK.Utils
             {
                 logMessage = "Provided numeric value is boolean which is an invalid format.";
                 logLevel = LogLevel.ERROR;
-            }
-            else if (!(eventTags[VALUE_EVENT_METRIC_NAME] is int) && !(eventTags[VALUE_EVENT_METRIC_NAME] is string) && !(eventTags[VALUE_EVENT_METRIC_NAME] is float)
-                && !(eventTags[VALUE_EVENT_METRIC_NAME] is decimal) && !(eventTags[VALUE_EVENT_METRIC_NAME] is double) && !(eventTags[VALUE_EVENT_METRIC_NAME] is float))
-            {
+            } else if (!(eventTags[VALUE_EVENT_METRIC_NAME] is int) && !(eventTags[VALUE_EVENT_METRIC_NAME] is string) && !(eventTags[VALUE_EVENT_METRIC_NAME] is float)
+                && !(eventTags[VALUE_EVENT_METRIC_NAME] is decimal) && !(eventTags[VALUE_EVENT_METRIC_NAME] is double) && !(eventTags[VALUE_EVENT_METRIC_NAME] is long)
+                && !(eventTags[VALUE_EVENT_METRIC_NAME] is short) && !(eventTags[VALUE_EVENT_METRIC_NAME] is uint))
+              {
                 logMessage = "Numeric metric value is not in integer, float, or string form.";
                 logLevel = LogLevel.ERROR;
             }


### PR DESCRIPTION
## Summary
0 and 1 after deserialization converted into long and we were not considering long in the numeric method. just added it. Along with I realized to add short/uint as well. 
The "why", or other context.

## Test plan

## Issues
- "THING-1234" or "Fixes #123"
