### PR TITLE
fix(versioning): NetStandard16

### DIFF
--- a/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
+++ b/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>netstandard1.6</TargetFramework>
         <ReleaseVersion>1.2.1</ReleaseVersion>
         <AssemblyOriginatorKeyFile>..\keypair.snk</AssemblyOriginatorKeyFile>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -53,6 +54,7 @@
         <Compile Include="..\OptimizelySDK\ProjectConfig.cs" />
         <Compile Include="..\OptimizelySDK\Utils\EventTagUtils.cs" />
         <Compile Include="..\OptimizelySDK\Utils\Validator.cs" />
+        <Compile Include="..\OptimizelySDK\Properties\AssemblyInfo.cs" />
         <Compile Include="..\OptimizelySDK\Utils\ConfigParser.cs" />
         <Compile Include="..\OptimizelySDK\Utils\Schema.cs" />
     		<Compile Include="..\OptimizelySDK\Utils\ControlAttributes.cs" />

--- a/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
+++ b/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
@@ -54,7 +54,7 @@
         <Compile Include="..\OptimizelySDK\ProjectConfig.cs" />
         <Compile Include="..\OptimizelySDK\Utils\EventTagUtils.cs" />
         <Compile Include="..\OptimizelySDK\Utils\Validator.cs" />
-        <Compile Include="..\OptimizelySDK\Properties\AssemblyInfo.cs" />
+        <Compile Include="Properties\AssemblyInfo.cs" />
         <Compile Include="..\OptimizelySDK\Utils\ConfigParser.cs" />
         <Compile Include="..\OptimizelySDK\Utils\Schema.cs" />
     		<Compile Include="..\OptimizelySDK\Utils\ControlAttributes.cs" />

--- a/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
+++ b/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
@@ -54,7 +54,7 @@
         <Compile Include="..\OptimizelySDK\ProjectConfig.cs" />
         <Compile Include="..\OptimizelySDK\Utils\EventTagUtils.cs" />
         <Compile Include="..\OptimizelySDK\Utils\Validator.cs" />
-        <Compile Include="..\OptimizelySDK.NetStandard16\Properties\AssemblyInfo.cs" />
+        <Compile Include=".\Properties\AssemblyInfo.cs" />
         <Compile Include="..\OptimizelySDK\Utils\ConfigParser.cs" />
         <Compile Include="..\OptimizelySDK\Utils\Schema.cs" />
     		<Compile Include="..\OptimizelySDK\Utils\ControlAttributes.cs" />

--- a/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
+++ b/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
@@ -54,7 +54,7 @@
         <Compile Include="..\OptimizelySDK\ProjectConfig.cs" />
         <Compile Include="..\OptimizelySDK\Utils\EventTagUtils.cs" />
         <Compile Include="..\OptimizelySDK\Utils\Validator.cs" />
-        <Compile Include="Properties\AssemblyInfo.cs" />
+        <Compile Include="..\OptimizelySDK.NetStandard16\Properties\AssemblyInfo.cs" />
         <Compile Include="..\OptimizelySDK\Utils\ConfigParser.cs" />
         <Compile Include="..\OptimizelySDK\Utils\Schema.cs" />
     		<Compile Include="..\OptimizelySDK\Utils\ControlAttributes.cs" />

--- a/OptimizelySDK.NetStandard16/Properties/AssemblyInfo.cs
+++ b/OptimizelySDK.NetStandard16/Properties/AssemblyInfo.cs
@@ -1,0 +1,43 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("OptimizelySDK.NetStandard16")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("OptimizelySDK.NetStandard16")]
+[assembly: AssemblyCopyright("Copyright © 2017-2019")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Make types and members with internal scope visible to friend
+// OptimizelySDK.Tests unit tests.
+#pragma warning disable 1700
+[assembly: InternalsVisibleTo("OptimizelySDK.Tests, PublicKey=ThePublicKey")]
+#pragma warning restore 1700
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("40906323-a8be-4a71-8e42-9646b23d56cf")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("3.0.0.0")]
+[assembly: AssemblyFileVersion("3.0.0.0")]
+[assembly: AssemblyInformationalVersion("3.0.0")] // Used by Nuget.


### PR DESCRIPTION
## Summary
.csproj for NetStandard16 previously did not include AssemblyInfo.cs
which contains versioning information. Because of this, it used an
automatically generated one similar to the one described here:
https://github.com/dotnet/cli/issues/4783#issuecomment-382695175
We now provide the AssemblyInfo.cs to include during the build and
explicitly tell it not to autogenerate.

## Test plan
after building, check versioning like this:
```
ikdasm -assembly OptimizelySDK.NetStandard16/bin/Debug/netstandard1.6/OptimizelySDK.NetStandard16.dll
Assembly Table
Name:          OptimizelySDK.NetStandard16
Hash Algoritm: 0x00008004
Version:       3.0.0.0
Flags:         0x00000001
PublicKey:     BlobPtr (0x00000e4e)
...
```