### PR TITLE
Improve case-insensitive check

### DIFF
--- a/OptimizelySDK/Event/Dispatcher/HttpClientEventDispatcher45.cs
+++ b/OptimizelySDK/Event/Dispatcher/HttpClientEventDispatcher45.cs
@@ -56,7 +56,7 @@ namespace OptimizelySDK.Event.Dispatcher
                 };
 
                 foreach (var h in logEvent.Headers)
-                    if (h.Key.ToLower() != "content-type")
+                    if (!string.Equals(h.Key, "content-type", StringComparison.OrdinalIgnoreCase))
                         request.Content.Headers.Add(h.Key, h.Value);
 
                 var result = await Client.SendAsync(request);


### PR DESCRIPTION
## Summary
- Use `string.Equals(string, string, StringComparison)` to remove the need to allocate an additional string to lower-case the HTTP header's name.

## Test plan

Existing unit tests.
