### PR TITLE
ci(travis): remove building mono 5.18.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,10 @@
-language: csharp
-dist: xenial
-mono:
-  - 5.2.0
-# needed to make travis run the unit tests
-  - 5.18.0
-solution: "./OptimizelySDK.Travis.sln"
-install:
-  - nuget restore ./OptimizelySDK.Travis.sln
-  - nuget install ./OptimizelySDK.Tests/packages.config -OutputDirectory ./packages
-  - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory ./testrunner
-script:
-  - xbuild /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=$TRAVIS_BUILD_DIR/keypair.snk /p:Configuration=Release ./OptimizelySDK.Travis.sln
-  - mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe ./OptimizelySDK.Tests/bin/Release/OptimizelySDK.Tests.dll
-  # strongname signing from xbuild step needs additional re-signing with sn
-  - find . -path './OptimizelySDK*bin/Release/OptimizelySDK*.dll' -not -regex '.*Tests.*' -print0 | while IFS= read -r -d '' file; do sn -R $file ./keypair.snk; done
-after_success:
-  - pip install --user awscli
-  # upload dll build artifacts to s3 with -unsigned suffix
-  - ([ ${TRAVIS_BRANCH} = "master" ] && [ ${TRAVIS_EVENT_TYPE} = "push" ]) && find . -path './OptimizelySDK*bin/Release/OptimizelySDK*.dll' -not -regex '.*Tests.*' -print0 | while IFS= read -r -d '' file; do (AWS_ACCESS_KEY_ID=$OFTA_KEY AWS_SECRET_ACCESS_KEY=$OFTA_SECRET AWS_DEFAULT_REGION=$OFTA_REGION aws s3 cp $file s3://optly-fs-travisci-artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}/$(basename $file)-unsigned); done
+language: minimal
 
 # Integration tests need to run first to reset the PR build status to pending
 stages:
-  - 'Integration tests'
-  - 'Test'
+  - name: 'Integration tests'
+  - name: 'Unit Tests'
+  - name: 'NetStandard16'
 
 jobs:
   include:
@@ -37,6 +19,26 @@ jobs:
       script:
         - "$HOME/travisci-tools/fsc-trigger/trigger_fullstack-sdk-compat.sh"
       after_success: travis_terminate 0
+
+    - stage: 'Unit Tests'
+      language: csharp
+      dist: xenial
+      mono: 5.2.0
+      solution: "./OptimizelySDK.Travis.sln"
+      install:
+        - nuget restore ./OptimizelySDK.Travis.sln
+        - nuget install ./OptimizelySDK.Tests/packages.config -OutputDirectory ./packages
+        - nuget install NUnit.Runners -Version 2.6.4 -OutputDirectory ./testrunner
+      script:
+        - xbuild /p:SignAssembly=true /p:AssemblyOriginatorKeyFile=$TRAVIS_BUILD_DIR/keypair.snk /p:Configuration=Release ./OptimizelySDK.Travis.sln
+        - mono ./testrunner/NUnit.Runners.2.6.4/tools/nunit-console.exe ./OptimizelySDK.Tests/bin/Release/OptimizelySDK.Tests.dll
+        # strongname signing from xbuild step needs additional re-signing with sn
+        - find . -path './OptimizelySDK*bin/Release/OptimizelySDK*.dll' -not -regex '.*Tests.*' -print0 | while IFS= read -r -d '' file; do sn -R $file ./keypair.snk; done
+      after_success:
+        - pip install --user awscli
+        # upload dll build artifacts to s3 with -unsigned suffix
+        - ([ ${TRAVIS_BRANCH} = "master" ] && [ ${TRAVIS_EVENT_TYPE} = "push" ]) && find . -path './OptimizelySDK*bin/Release/OptimizelySDK*.dll' -not -regex '.*Tests.*' -print0 | while IFS= read -r -d '' file; do (AWS_ACCESS_KEY_ID=$OFTA_KEY AWS_SECRET_ACCESS_KEY=$OFTA_SECRET AWS_DEFAULT_REGION=$OFTA_REGION aws s3 cp $file s3://optly-fs-travisci-artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}/$(basename $file)-unsigned); done
+
     - stage: 'NetStandard16'
       language: csharp
       # dotnet only works on trusty https://github.com/travis-ci/travis-ci/issues/5189


### PR DESCRIPTION
move unit tests into their own stage for clarity and allow us to
build with mono 5.2.0 only

## Summary
- The "what"; a concise description of each logical change
- Another change

The "why", or other context.

## Test plan

## Issues
- "THING-1234" or "Fixes #123"
