### PR TITLE
fix(defaulttiming): issues fixed related to default timings

### DIFF
--- a/OptimizelySDK.Tests/ConfigTest/HttpProjectConfigManagerTest.cs
+++ b/OptimizelySDK.Tests/ConfigTest/HttpProjectConfigManagerTest.cs
@@ -130,7 +130,8 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
                 .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
                 .WithLogger(LoggerMock.Object)
                 .WithPollingInterval(TimeSpan.FromSeconds(2))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromSeconds(0))                                
+                // negligible timeout
+                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(50))                                
                 .WithStartByDefault()
                 .Build(false);
 
@@ -176,6 +177,52 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             NotificationCallbackMock.Verify(nc => nc.TestConfigUpdateCallback(), Times.Never);
             Assert.NotNull(httpManager.GetConfig()); Assert.NotNull(httpManager.GetConfig());
         }
-    #endregion
-}
+
+        [Test]
+        public void TestDefaultBlockingTimeoutWhileProvidingZero()
+        {                        
+            var httpManager = new HttpProjectConfigManager.Builder()
+                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
+                .WithDatafile(TestData.Datafile)
+                .WithLogger(LoggerMock.Object)
+                .WithPollingInterval(TimeSpan.FromMilliseconds(1000))
+                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(0))
+                .WithStartByDefault(true)
+                .Build(true);
+            
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, $"Blocking timeout is not valid, using default blocking timeout {TimeSpan.FromSeconds(15).TotalMilliseconds}ms"));
+        }
+
+        [Test]
+        public void TestDefaultPeriodWhileProvidingZero()
+        {
+            var httpManager = new HttpProjectConfigManager.Builder()
+                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
+                .WithDatafile(TestData.Datafile)
+                .WithLogger(LoggerMock.Object)
+                .WithPollingInterval(TimeSpan.FromMilliseconds(0))
+                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(1000))
+                .WithStartByDefault(true)
+                .Build(true);
+
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, $"Period is not valid for periodic calls, using default period {TimeSpan.FromMinutes(5).TotalMilliseconds}ms"));
+        }
+
+        [Test]
+        public void TestDefaultPeriodWhileProvidingNegative()
+        {
+            var httpManager = new HttpProjectConfigManager.Builder()
+                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
+                .WithDatafile(TestData.Datafile)
+                .WithLogger(LoggerMock.Object)
+                .WithPollingInterval(TimeSpan.FromMilliseconds(-1))
+                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(1000))
+                .WithStartByDefault(true)
+                .Build(true);
+
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, $"Period is not valid for periodic calls, using default period {TimeSpan.FromMinutes(5).TotalMilliseconds}ms"));            
+        }
+
+        #endregion
+    }
 }

--- a/OptimizelySDK/Config/PollingProjectConfigManager.cs
+++ b/OptimizelySDK/Config/PollingProjectConfigManager.cs
@@ -136,15 +136,7 @@ namespace OptimizelySDK.Config
         /// <param name="projectConfig">ProjectConfig</param>
         /// <returns>true if the ProjectConfig saved successfully, false otherwise</returns>
         public bool SetConfig(ProjectConfig projectConfig)
-        {
-            // trigger now, due because of delayed latency response
-            if (scheduleWhenFinished && IsStarted) {
-                // Can't directly call Run, it will be part of previous thread then.
-                // Call immediately, because it's due now.
-                scheduleWhenFinished = false;
-                SchedulerService.Change(TimeSpan.FromSeconds(0), PollingInterval);
-            }
-
+        {            
             if (projectConfig == null)
                 return false;
                 
@@ -191,6 +183,13 @@ namespace OptimizelySDK.Config
                     Logger.Log(LogLevel.ERROR, "Unable to get project config. Error: " + exception.GetAllMessages());
                 } finally {
                     Interlocked.Exchange(ref resourceInUse, 0);
+
+                    // trigger now, due because of delayed latency response
+                    if (scheduleWhenFinished && IsStarted) {                        
+                        // Call immediately, because it's due now.
+                        scheduleWhenFinished = false;
+                        SchedulerService.Change(TimeSpan.FromSeconds(0), PollingInterval);
+                    }
                 }
             }
             else {


### PR DESCRIPTION
## Summary
Polling interval should be default when 0 or -ve value provided
Blocking timeout should be default when 0 or -ve value provided
Due call, should be made after releasing lock. 
The "why", or other context.

## Test plan

## Issues
- "THING-1234" or "Fixes #123"
