### PR TITLE
fix(EP): Event processor fixes

### DIFF
--- a/OptimizelySDK.Tests/EventTests/BatchEventProcessorTest.cs
+++ b/OptimizelySDK.Tests/EventTests/BatchEventProcessorTest.cs
@@ -28,8 +28,7 @@ namespace OptimizelySDK.Tests.EventTests
         private Mock<ILogger> LoggerMock;
         private BlockingCollection<object> eventQueue;
         private BatchEventProcessor EventProcessor;
-        private Mock<IEventDispatcher> EventDispatcherMock;
-        private TestEventDispatcher TestEventDispatcher;
+        private Mock<IEventDispatcher> EventDispatcherMock;        
         private NotificationCenter NotificationCenter = new NotificationCenter();
         private Mock<TestNotificationCallbacks> NotificationCallbackMock;
 

--- a/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
@@ -16,7 +16,8 @@ namespace OptimizelySDK.Tests.EventTests
     {
 
         private string TestUserId = string.Empty;
-        private ProjectConfig Config;        
+        private ProjectConfig Config;
+        private ILogger Logger;
 
         [TestFixtureSetUp]
         public void Setup()

--- a/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
@@ -16,8 +16,7 @@ namespace OptimizelySDK.Tests.EventTests
     {
 
         private string TestUserId = string.Empty;
-        private ProjectConfig Config;
-        private ILogger Logger;
+        private ProjectConfig Config;        
 
         [TestFixtureSetUp]
         public void Setup()

--- a/OptimizelySDK/Event/BatchEventProcessor.cs
+++ b/OptimizelySDK/Event/BatchEventProcessor.cs
@@ -145,6 +145,8 @@ namespace OptimizelySDK.Event
 
         private void FlushQueue()
         {
+            FlushingIntervalDeadline = DateTime.Now.MillisecondsSince1970() + (long)FlushInterval.TotalMilliseconds;
+
             if (CurrentBatch.Count == 0)
             {
                 return;
@@ -350,8 +352,8 @@ namespace OptimizelySDK.Event
                 batchEventProcessor.NotificationCenter = NotificationCenter;
 
                 batchEventProcessor.BatchSize = BatchSize < 1 ? BatchEventProcessor.DEFAULT_BATCH_SIZE : BatchSize;
-                batchEventProcessor.FlushInterval = FlushInterval < TimeSpan.FromSeconds(1) ? BatchEventProcessor.DEFAULT_FLUSH_INTERVAL : FlushInterval;
-                batchEventProcessor.TimeoutInterval = TimeoutInterval < TimeSpan.FromSeconds(1) ? BatchEventProcessor.DEFAULT_TIMEOUT_INTERVAL : TimeoutInterval;
+                batchEventProcessor.FlushInterval = FlushInterval <= TimeSpan.FromSeconds(0) ? BatchEventProcessor.DEFAULT_FLUSH_INTERVAL : FlushInterval;
+                batchEventProcessor.TimeoutInterval = TimeoutInterval <= TimeSpan.FromSeconds(0) ? BatchEventProcessor.DEFAULT_TIMEOUT_INTERVAL : TimeoutInterval;
 
                 if (start)
                     batchEventProcessor.Start();

--- a/OptimizelySDK/Event/Entity/EventContext.cs
+++ b/OptimizelySDK/Event/Entity/EventContext.cs
@@ -48,8 +48,6 @@ namespace OptimizelySDK.Event.Entity
             private string AccountId;
             private string ProjectId;
             private string Revision;
-            private string ClientName;
-            private string ClientVersion;
             private bool AnonymizeIP;
 
             public Builder WithAccountId(string accountId)

--- a/OptimizelySDK/Event/Entity/ImpressionEvent.cs
+++ b/OptimizelySDK/Event/Entity/ImpressionEvent.cs
@@ -36,9 +36,7 @@ namespace OptimizelySDK.Event.Entity
         /// </summary>
         public class Builder
         {
-            private string UserId;            
-            private string UUID;
-            private long Timestamp;
+            private string UserId;
             private EventContext EventContext;
 
             public VisitorAttribute[] VisitorAttributes;


### PR DESCRIPTION
## Summary
- When flush interval is 0, then it should use default otherwise it should use mentioned interval, same for timeout interval.
- Cleanup code.

## Test plan
- Testing with FSC, should pass all tests.
## Issues
- No issue filed.
