### PR TITLE
fix(framework): Deprecating old frameworks.

### DIFF
--- a/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
+++ b/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
@@ -19,7 +19,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;NET35;NET40</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;NET40</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>

--- a/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
+++ b/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
@@ -10,7 +10,7 @@
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     </PropertyGroup>
 	<PropertyGroup>
-    	<DefineConstants>;$(DefineConstants);<NETSTANDARD>NetStandardIdentifier</NETSTANDARD>
+    	<DefineConstants>;$(DefineConstants);<NETSTANDARD1_6>NetStandardIdentifier</NETSTANDARD1_6>
     	</DefineConstants>
 	</PropertyGroup>
     <ItemGroup>

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -30,6 +30,11 @@ using OptimizelySDK.Event;
 
 namespace OptimizelySDK
 {
+#if NET35
+    [Obsolete("Net3.5 SDK support is deprecated, use NET4.0 or above")]
+#elif NETSTANDARD1_6
+    [Obsolete("Net standard 1.6 SDK support is deprecated, use Net standard 2.0 or above")]
+#endif
     public class Optimizely : IOptimizely, IDisposable
     {
         private Bucketer Bucketer;
@@ -67,7 +72,7 @@ namespace OptimizelySDK
             get
             {
                 // Example output: "2.1.0" .  Should be kept in synch with NuGet package version.
-#if NET35
+#if NET35 || NET40
                 Assembly assembly = Assembly.GetExecutingAssembly();
 #else
                 Assembly assembly = typeof(Optimizely).GetTypeInfo().Assembly;
@@ -423,7 +428,7 @@ namespace OptimizelySDK
             return DecisionService.GetForcedVariation(experimentKey, userId, config);
         }
 
-        #region  FeatureFlag APIs
+#region  FeatureFlag APIs
 
         /// <summary>
         /// Determine whether a feature is enabled.
@@ -719,7 +724,7 @@ namespace OptimizelySDK
             return enabledFeaturesList;
         }
 
-        #endregion // FeatureFlag APIs
+#endregion // FeatureFlag APIs
 
         /// <summary>
         /// Validate all string inputs are not null or empty.

--- a/OptimizelySDK/Utils/Schema.cs
+++ b/OptimizelySDK/Utils/Schema.cs
@@ -26,7 +26,7 @@ namespace OptimizelySDK.Utils
         {
             if (cache != null)
                 return cache;
-#if NET35
+#if NET35 || NET40
             var assembly = Assembly.GetExecutingAssembly();
 #else
             var assembly = typeof(Schema).GetTypeInfo().Assembly;

--- a/OptimizelySDK/Utils/Validator.cs
+++ b/OptimizelySDK/Utils/Validator.cs
@@ -32,7 +32,7 @@ namespace OptimizelySDK.Utils
         /// <param name="configJson">ProjectConfig JSON</param>
         /// <param name="schemaJson">Schema JSON for ProjectConfig.  If none is provided, use the one already in the project</param>
         /// <returns>Whether the ProjectConfig is valid</returns>
-#if !NET35
+#if !NET35 && !NET40
         public static bool ValidateJSONSchema(string configJson, string schemaJson = null)
         {
             try
@@ -49,7 +49,8 @@ namespace OptimizelySDK.Utils
             }
         }
 #endif
-#if NET35
+
+#if NET35 || NET40
         public static bool ValidateJSONSchema(string configJson, string schemaJson = null)
         {
             return true;


### PR DESCRIPTION
## Summary
- added warning for 3.5 framework and .net standard 1.6
- Added proper separate constants for .net framework 4.0 and 3.5.
- Updated unit tests as well

## Test plan
- Unit tests modified. 