### PR TITLE
polling config manager should be started by default.

### DIFF
--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -2908,6 +2908,7 @@ namespace OptimizelySDK.Tests
                                                           .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
                                                           .WithLogger(LoggerMock.Object)
                                                           .WithPollingInterval(TimeSpan.FromMilliseconds(1000))
+                                                          .WithStartByDefault(false)
                                                           .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500))
                                                           .WithNotificationCenter(notificationCenter)
                                                           .Build();

--- a/OptimizelySDK/Config/HttpProjectConfigManager.cs
+++ b/OptimizelySDK/Config/HttpProjectConfigManager.cs
@@ -135,7 +135,7 @@ namespace OptimizelySDK.Config
             private TimeSpan Period;
             private TimeSpan BlockingTimeoutSpan;
             private bool AutoUpdate = true;
-            private bool StartByDefault;
+            private bool StartByDefault = true;
             private NotificationCenter NotificationCenter;
 
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ This option enables user to provide a custom URL format to fetch the datafile.
 
 ##### Start by default
 
-This option is used to specify whether to start the config manager on initialization.
+This option is used to specify whether to start the config manager on initialization or not. If no value is provided, by default it is true and will start polling datafile from remote immediately.
 
 ## Development
 


### PR DESCRIPTION
## Summary
`HttpProjectConfigManager` should start polling immediately unless `WithDefaultStart` sets `false` in HttpProjectConfigManager.Builder class instance.

## Test plan
Need to check with FSC. 

