### PR TITLE
fix: Renaming optimizely json to OptimizelyJSON

### DIFF
--- a/OptimizelySDK.Net35/OptimizelySDK.Net35.csproj
+++ b/OptimizelySDK.Net35/OptimizelySDK.Net35.csproj
@@ -97,8 +97,8 @@
     <Compile Include="..\OptimizelySDK\Entity\IdKeyEntity.cs">
       <Link>Entity\IdKeyEntity.cs</Link>
     </Compile>
-	<Compile Include="..\OptimizelySDK\OptimizelyJson.cs">
-      <Link>OptimizelyJson.cs</Link>
+	<Compile Include="..\OptimizelySDK\OptimizelyJSON.cs">
+      <Link>OptimizelyJSON.cs</Link>
     </Compile>
     <Compile Include="..\OptimizelySDK\Entity\TrafficAllocation.cs">
       <Link>Entity\TrafficAllocation.cs</Link>

--- a/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
+++ b/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
@@ -99,8 +99,8 @@
     <Compile Include="..\OptimizelySDK\Entity\IdKeyEntity.cs">
       <Link>Entity\IdKeyEntity.cs</Link>
     </Compile>
-	<Compile Include="..\OptimizelySDK\OptimizelyJson.cs">
-      <Link>OptimizelyJson.cs</Link>
+	<Compile Include="..\OptimizelySDK\OptimizelyJSON.cs">
+      <Link>OptimizelyJSON.cs</Link>
     </Compile>
     <Compile Include="..\OptimizelySDK\Entity\TrafficAllocation.cs">
       <Link>Entity\TrafficAllocation.cs</Link>

--- a/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
+++ b/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
@@ -31,7 +31,7 @@
         <Compile Include="..\OptimizelySDK\Entity\ForcedVariation.cs" />
         <Compile Include="..\OptimizelySDK\Entity\Group.cs" />
         <Compile Include="..\OptimizelySDK\Entity\IdKeyEntity.cs" />
-        <Compile Include="..\OptimizelySDK\OptimizelyJson.cs" />
+        <Compile Include="..\OptimizelySDK\OptimizelyJSON.cs" />
         <Compile Include="..\OptimizelySDK\Entity\TrafficAllocation.cs" />
         <Compile Include="..\OptimizelySDK\Entity\UserAttributes.cs" />
         <Compile Include="..\OptimizelySDK\Entity\Variation.cs" />

--- a/OptimizelySDK.NetStandard20/OptimizelySDK.NetStandard20.csproj
+++ b/OptimizelySDK.NetStandard20/OptimizelySDK.NetStandard20.csproj
@@ -116,7 +116,7 @@
       <Link>Entity\IdKeyEntity.cs</Link>
     </Compile>
 	<Compile Include="..\OptimizelySDK\OptimizelyJSON.cs">
-      <Link>Entity\OptimizelyJSON.cs</Link>
+      <Link>OptimizelyJSON.cs</Link>
     </Compile>
     <Compile Include="..\OptimizelySDK\Entity\Rollout.cs">
       <Link>Entity\Rollout.cs</Link>

--- a/OptimizelySDK.NetStandard20/OptimizelySDK.NetStandard20.csproj
+++ b/OptimizelySDK.NetStandard20/OptimizelySDK.NetStandard20.csproj
@@ -115,8 +115,8 @@
     <Compile Include="..\OptimizelySDK\Entity\IdKeyEntity.cs">
       <Link>Entity\IdKeyEntity.cs</Link>
     </Compile>
-	<Compile Include="..\OptimizelySDK\OptimizelyJson.cs">
-      <Link>Entity\OptimizelyJson.cs</Link>
+	<Compile Include="..\OptimizelySDK\OptimizelyJSON.cs">
+      <Link>Entity\OptimizelyJSON.cs</Link>
     </Compile>
     <Compile Include="..\OptimizelySDK\Entity\Rollout.cs">
       <Link>Entity\Rollout.cs</Link>

--- a/OptimizelySDK.Tests/OptimizelyJSONTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyJSONTest.cs
@@ -51,7 +51,7 @@ namespace OptimizelySDK.Tests
 
 
     [TestFixture]
-    public class OptimizelyJsonTest
+    public class OptimizelyJSONTest
     {
         private string Payload;
         private Dictionary<string, object> Map;
@@ -86,8 +86,8 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestOptimizelyJsonObjectIsValid()
         {
-            var optimizelyJSONUsingMap = new OptimizelyJson(Map, ErrorHandlerMock.Object, LoggerMock.Object);
-            var optimizelyJSONUsingString = new OptimizelyJson(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingMap = new OptimizelyJSON(Map, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
 
             Assert.IsNotNull(optimizelyJSONUsingMap);
             Assert.IsNotNull(optimizelyJSONUsingString);
@@ -103,7 +103,7 @@ namespace OptimizelySDK.Tests
                     }
                 }
             };
-            var optimizelyJSONUsingMap = new OptimizelyJson(map, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingMap = new OptimizelyJSON(map, ErrorHandlerMock.Object, LoggerMock.Object);
             string str = optimizelyJSONUsingMap.ToString();
             string expectedStringObj = "{\"strField\":\"john doe\",\"intField\":12,\"objectField\":{\"inner_field_int\":3}}";
             Assert.AreEqual(expectedStringObj, str);
@@ -112,7 +112,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGettingErrorUponInvalidJsonString()
         {
-            var optimizelyJSONUsingString = new OptimizelyJson("{\"invalid\":}", ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString = new OptimizelyJSON("{\"invalid\":}", ErrorHandlerMock.Object, LoggerMock.Object);
             LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Provided string could not be converted to map."), Times.Once);
             ErrorHandlerMock.Verify(er => er.HandleError(It.IsAny<InvalidJsonException>()), Times.Once);
         }
@@ -120,7 +120,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestOptimizelyJsonGetVariablesWhenSetUsingMap()
         {
-            var optimizelyJSONUsingMap = new OptimizelyJson(Map, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingMap = new OptimizelyJSON(Map, ErrorHandlerMock.Object, LoggerMock.Object);
 
             Assert.AreEqual(optimizelyJSONUsingMap.GetValue<string>("strField"), "john doe");
             Assert.AreEqual(optimizelyJSONUsingMap.GetValue<int>("intField"), 12);
@@ -136,7 +136,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestOptimizelyJsonGetVariablesWhenSetUsingString()
         {
-            var optimizelyJSONUsingString = new OptimizelyJson(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
 
             Assert.AreEqual(optimizelyJSONUsingString.GetValue<long>("field1"), 1);
             Assert.AreEqual(optimizelyJSONUsingString.GetValue<double>("field2"), 2.5);
@@ -148,7 +148,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetValueReturnsEntireDictWhenJsonPathIsEmptyAndTypeIsValid()
         {
-            var optimizelyJSONUsingString = new OptimizelyJson(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var actualDict = optimizelyJSONUsingString.ToDictionary();
             var expectedValue = optimizelyJSONUsingString.GetValue<Dictionary<string, object>>("");
             Assert.NotNull(expectedValue);
@@ -159,7 +159,7 @@ namespace OptimizelySDK.Tests
         public void TestGetValueReturnsDefaultValueWhenJsonIsInvalid()
         {
             var payload = "{ \"field1\" : {1:\"Csharp\", 2:\"Java\"} }";
-            var optimizelyJSONUsingString = new OptimizelyJson(payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString = new OptimizelyJSON(payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<Dictionary<float, string>>("field1");
             // Even though above given JSON is not valid, newtonsoft is parsing it so
             Assert.IsNotNull(expectedValue);
@@ -169,7 +169,7 @@ namespace OptimizelySDK.Tests
         public void TestGetValueReturnsDefaultValueWhenTypeIsInvalid()
         {
             var payload = "{ \"field1\" : {\"1\":\"Csharp\",\"2\":\"Java\"} }";
-            var optimizelyJSONUsingString = new OptimizelyJson(payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString = new OptimizelyJSON(payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<Dictionary<float, string>>("field1");
             Assert.IsNotNull(expectedValue);
         }
@@ -177,7 +177,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetValueReturnsNullWhenJsonPathIsEmptyAndTypeIsOfObject()
         {
-            var optimizelyJSONUsingString = new OptimizelyJson(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<object>("");
             Assert.NotNull(expectedValue);
         }
@@ -185,7 +185,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetValueReturnsDefaultValueWhenJsonPathIsEmptyAndTypeIsNotValid()
         {
-            var optimizelyJSONUsingString = new OptimizelyJson(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<string>("");
             Assert.IsNull(expectedValue);
             LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Value for path could not be assigned to provided type."), Times.Once);
@@ -195,7 +195,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetValueReturnsDefaultValueWhenJsonPathIsInvalid()
         {
-            var optimizelyJSONUsingString = new OptimizelyJson(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<string>("field11");
             Assert.IsNull(expectedValue);
             LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Value for JSON key not found."), Times.Once);
@@ -205,7 +205,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetValueReturnsDefaultValueWhenJsonPath1IsInvalid()
         {
-            var optimizelyJSONUsingString = new OptimizelyJson(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<string>("field4.");
             Assert.IsNull(expectedValue);
             LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Value for JSON key not found."), Times.Once);
@@ -215,7 +215,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetValueReturnsDefaultValueWhenJsonPath2IsInvalid()
         {
-            var optimizelyJSONUsingString = new OptimizelyJson(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<string>("field4..inner_field1");
             Assert.IsNull(expectedValue);
             LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Value for JSON key not found."), Times.Once);
@@ -225,7 +225,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetValueObjectNotModifiedIfCalledTwice()
         {
-            var optimizelyJSONUsingString = new OptimizelyJson(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<string>("field4.inner_field1");
             var expectedValue2 = optimizelyJSONUsingString.GetValue<string>("field4.inner_field1");
 
@@ -235,7 +235,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetValueReturnsUsingGivenClassType()
         {
-            var optimizelyJSONUsingString = new OptimizelyJson(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<Field4>("field4");
             
             Assert.AreEqual(expectedValue.inner_field1, 3);
@@ -245,7 +245,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetValueReturnsCastedObject()
         {
-            var optimizelyJson = new OptimizelyJson(Map, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJson = new OptimizelyJSON(Map, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJson.ToDictionary();
             var actualValue = optimizelyJson.GetValue<ParentJson>(null);
             

--- a/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
+++ b/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
@@ -77,7 +77,7 @@
     <Compile Include="ConfigTest\FallbackProjectConfigManagerTest.cs" />
     <Compile Include="DecisionServiceTest.cs" />
     <Compile Include="DefaultErrorHandlerTest.cs" />
-    <Compile Include="OptimizelyJsonTest.cs" />
+    <Compile Include="OptimizelyJSONTest.cs" />
     <Compile Include="EventTests\BatchEventProcessorTest.cs" />
     <Compile Include="EventTests\DefaultEventDispatcherTest.cs" />
     <Compile Include="EventTests\EventBuilderTest.cs" />

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -1360,20 +1360,20 @@ namespace OptimizelySDK.Tests
             var variableKeyNull = "varNull";
             var featureVariableType = "json";
 
-            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJson>(It.IsAny<string>(), variableKeyString, It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJson("{\"string\": \"Test String\"}", ErrorHandlerMock.Object, LoggerMock.Object));
+            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJSON>(It.IsAny<string>(), variableKeyString, It.IsAny<string>(),
+                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJSON("{\"string\": \"Test String\"}", ErrorHandlerMock.Object, LoggerMock.Object));
             Assert.AreEqual("Test String", OptimizelyMock.Object.GetFeatureVariableJSON(featureKey, variableKeyString, TestUserId, null).GetValue<string>("string"));
 
-            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJson>(It.IsAny<string>(), variableKeyIntString, It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJson("{ \"integer\": 123 }", ErrorHandlerMock.Object, LoggerMock.Object));
+            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJSON>(It.IsAny<string>(), variableKeyIntString, It.IsAny<string>(),
+                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJSON("{ \"integer\": 123 }", ErrorHandlerMock.Object, LoggerMock.Object));
             Assert.AreEqual(123, OptimizelyMock.Object.GetFeatureVariableJSON(featureKey, variableKeyIntString, TestUserId, null).GetValue<long>("integer"));
 
-            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJson>(It.IsAny<string>(), variableKeyDouble, It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJson("{ \"double\": 123.28 }", ErrorHandlerMock.Object, LoggerMock.Object));
+            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJSON>(It.IsAny<string>(), variableKeyDouble, It.IsAny<string>(),
+                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJSON("{ \"double\": 123.28 }", ErrorHandlerMock.Object, LoggerMock.Object));
             Assert.AreEqual(123.28, OptimizelyMock.Object.GetFeatureVariableJSON(featureKey, variableKeyDouble, TestUserId, null).GetValue<double>("double"));
 
-            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJson>(It.IsAny<string>(), variableKeyNull, It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), featureVariableType)).Returns<OptimizelyJson>(null);
+            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJSON>(It.IsAny<string>(), variableKeyNull, It.IsAny<string>(),
+                It.IsAny<UserAttributes>(), featureVariableType)).Returns<OptimizelyJSON>(null);
             Assert.Null(OptimizelyMock.Object.GetFeatureVariableJSON(featureKey, variableKeyNull, TestUserId, null));
         }
 
@@ -1393,28 +1393,28 @@ namespace OptimizelySDK.Tests
             var expectedDoubleDict = new Dictionary<string, object>() { { "double", 123.28 } };
             var expectedBooleanDict = new Dictionary<string, object>() { { "boolean", true } };
             
-            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJson>(It.IsAny<string>(), variableKeyString, It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJson(expectedStringDict, ErrorHandlerMock.Object, LoggerMock.Object));
+            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJSON>(It.IsAny<string>(), variableKeyString, It.IsAny<string>(),
+                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJSON(expectedStringDict, ErrorHandlerMock.Object, LoggerMock.Object));
             Assert.IsTrue(TestData.CompareObjects(expectedStringDict, OptimizelyMock.Object.GetFeatureVariableJSON(featureKey, variableKeyString, TestUserId, null).ToDictionary()));
             Assert.AreEqual("Test String", OptimizelyMock.Object.GetFeatureVariableJSON(featureKey, variableKeyString, TestUserId, null).GetValue<string>("string"));
 
-            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJson>(It.IsAny<string>(), variableKeyIntString, It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJson(expectedIntegerDict, ErrorHandlerMock.Object, LoggerMock.Object));
+            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJSON>(It.IsAny<string>(), variableKeyIntString, It.IsAny<string>(),
+                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJSON(expectedIntegerDict, ErrorHandlerMock.Object, LoggerMock.Object));
             Assert.IsTrue(TestData.CompareObjects(expectedIntegerDict, OptimizelyMock.Object.GetFeatureVariableJSON(featureKey, variableKeyIntString, TestUserId, null).ToDictionary()));
             Assert.AreEqual(123, OptimizelyMock.Object.GetFeatureVariableJSON(featureKey, variableKeyIntString, TestUserId, null).GetValue<long>("integer"));
 
-            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJson>(It.IsAny<string>(), variableKeyDouble, It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJson(expectedDoubleDict, ErrorHandlerMock.Object, LoggerMock.Object));
+            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJSON>(It.IsAny<string>(), variableKeyDouble, It.IsAny<string>(),
+                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJSON(expectedDoubleDict, ErrorHandlerMock.Object, LoggerMock.Object));
             Assert.IsTrue(TestData.CompareObjects(expectedDoubleDict, OptimizelyMock.Object.GetFeatureVariableJSON(featureKey, variableKeyDouble, TestUserId, null).ToDictionary()));
             Assert.AreEqual(123.28, OptimizelyMock.Object.GetFeatureVariableJSON(featureKey, variableKeyDouble, TestUserId, null).GetValue<double>("double"));
 
-            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJson>(It.IsAny<string>(), variableKeyBoolean, It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJson(expectedBooleanDict, ErrorHandlerMock.Object, LoggerMock.Object));
+            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJSON>(It.IsAny<string>(), variableKeyBoolean, It.IsAny<string>(),
+                It.IsAny<UserAttributes>(), featureVariableType)).Returns(new OptimizelyJSON(expectedBooleanDict, ErrorHandlerMock.Object, LoggerMock.Object));
             Assert.IsTrue(TestData.CompareObjects(expectedBooleanDict, OptimizelyMock.Object.GetFeatureVariableJSON(featureKey, variableKeyBoolean, TestUserId, null).ToDictionary()));
             Assert.AreEqual(true, OptimizelyMock.Object.GetFeatureVariableJSON(featureKey, variableKeyBoolean, TestUserId, null).GetValue<bool>("boolean"));
 
-            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJson>(It.IsAny<string>(), variableKeyNull, It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), featureVariableType)).Returns<OptimizelyJson>(null);
+            OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJSON>(It.IsAny<string>(), variableKeyNull, It.IsAny<string>(),
+                It.IsAny<UserAttributes>(), featureVariableType)).Returns<OptimizelyJSON>(null);
             Assert.Null(OptimizelyMock.Object.GetFeatureVariableJSON(featureKey, variableKeyNull, TestUserId, null));
         }
 
@@ -1571,7 +1571,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("ProjectConfigManager", ConfigManager);
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
 
-            var variableValue = (OptimizelyJson)optly.Invoke("GetFeatureVariableJSON", featureKey, variableKey, TestUserId, userAttributes);
+            var variableValue = (OptimizelyJSON)optly.Invoke("GetFeatureVariableJSON", featureKey, variableKey, TestUserId, userAttributes);
             Assert.AreEqual(expectedIntValue, variableValue.GetValue<long>("int_var"));
             Assert.AreEqual(expectedStringValue, variableValue.GetValue<string>("string_var"));
 
@@ -1603,7 +1603,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("ProjectConfigManager", ConfigManager);
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
 
-            var variableValue = (OptimizelyJson)optly.Invoke("GetFeatureVariableJSON", featureKey, variableKey, TestUserId, userAttributes);
+            var variableValue = (OptimizelyJSON)optly.Invoke("GetFeatureVariableJSON", featureKey, variableKey, TestUserId, userAttributes);
             Assert.AreEqual(expectedIntValue, variableValue.GetValue<long>("int_var"));
             Assert.AreEqual(expectedStringValue, variableValue.GetValue<string>("string_var"));
 
@@ -1772,7 +1772,7 @@ namespace OptimizelySDK.Tests
             Assert.IsNull(Optimizely.GetFeatureVariableValueForType<bool?>("boolean_single_variable_feature", "boolean_variable", TestUserId, null, variableTypeDouble));
             Assert.IsNull(Optimizely.GetFeatureVariableValueForType<int?>("integer_single_variable_feature", "integer_variable", TestUserId, null, variableTypeString));
             Assert.IsNull(Optimizely.GetFeatureVariableValueForType<string>("string_single_variable_feature", "string_variable", TestUserId, null, variableTypeInt));
-            Assert.IsNull(Optimizely.GetFeatureVariableValueForType<OptimizelyJson>("string_single_variable_feature", "json_var", TestUserId, null, variableTypeInt));
+            Assert.IsNull(Optimizely.GetFeatureVariableValueForType<OptimizelyJSON>("string_single_variable_feature", "json_var", TestUserId, null, variableTypeInt));
 
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR,
                 $@"Variable is of type ""double"", but you requested it as type ""{variableTypeBool}""."));
@@ -2833,7 +2833,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
             optStronglyTyped.NotificationCenter.AddNotification(NotificationCenter.NotificationType.Decision, NotificationCallbackMock.Object.TestDecisionCallback);
 
-            var variableValue = (OptimizelyJson)optly.Invoke("GetFeatureVariableJSON", featureKey, variableKey, TestUserId, userAttributes);
+            var variableValue = (OptimizelyJSON)optly.Invoke("GetFeatureVariableJSON", featureKey, variableKey, TestUserId, userAttributes);
             Assert.IsTrue(TestData.CompareObjects(expectedDict, variableValue.ToDictionary()));
             var decisionInfo = new Dictionary<string, object>
             {
@@ -3234,7 +3234,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
             optStronglyTyped.NotificationCenter.AddNotification(NotificationCenter.NotificationType.Decision, NotificationCallbackMock.Object.TestDecisionCallback);
 
-            var variableValues = (OptimizelyJson)optly.Invoke("GetAllFeatureVariables", featureKey, TestUserId, userAttributes);
+            var variableValues = (OptimizelyJSON)optly.Invoke("GetAllFeatureVariables", featureKey, TestUserId, userAttributes);
             Assert.IsTrue(TestData.CompareObjects(variableValues.ToDictionary(), expectedValue));
             var decisionInfo = new Dictionary<string, object>
             {
@@ -3316,7 +3316,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
             optly.SetFieldOrProperty("ProjectConfigManager", ConfigManager);
 
-            var result = (OptimizelyJson)optly.Invoke("GetAllFeatureVariables", featureKey, TestUserId, userAttributes);
+            var result = (OptimizelyJSON)optly.Invoke("GetAllFeatureVariables", featureKey, TestUserId, userAttributes);
             Assert.NotNull(result);
 
             LoggerMock.Verify(log => log.Log(LogLevel.INFO, "User \"" + TestUserId + "\" was not bucketed into any variation for feature flag \"" + featureKey + "\". " +

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -600,7 +600,7 @@ namespace OptimizelySDK
                 { "featureKey", featureKey },
                 { "featureEnabled", featureEnabled },
                 { "variableKey", variableKey },
-                { "variableValue", typeCastedValue is OptimizelyJson? ((OptimizelyJson)typeCastedValue).ToDictionary() : typeCastedValue },
+                { "variableValue", typeCastedValue is OptimizelyJSON? ((OptimizelyJSON)typeCastedValue).ToDictionary() : typeCastedValue },
                 { "variableType", variableType.ToString().ToLower() },
                 { "source", decision?.Source },
                 { "sourceInfo", sourceInfo },
@@ -671,9 +671,9 @@ namespace OptimizelySDK
         /// <param name="userId">The user ID</param>
         /// <param name="userAttributes">The user's attributes</param>
         /// <returns>OptimizelyJson | Feature variable value or null</returns>
-        public OptimizelyJson GetFeatureVariableJSON(string featureKey, string variableKey, string userId, UserAttributes userAttributes = null)
+        public OptimizelyJSON GetFeatureVariableJSON(string featureKey, string variableKey, string userId, UserAttributes userAttributes = null)
         {
-            return GetFeatureVariableValueForType<OptimizelyJson>(featureKey, variableKey, userId, userAttributes, FeatureVariable.JSON_TYPE);
+            return GetFeatureVariableValueForType<OptimizelyJSON>(featureKey, variableKey, userId, userAttributes, FeatureVariable.JSON_TYPE);
         }
 
         /// <summary>
@@ -746,7 +746,7 @@ namespace OptimizelySDK
         /// <param name="userId">The user ID</param>
         /// <param name="userAttributes">The user's attributes</param>
         /// <returns>string | null An OptimizelyJSON instance for all variable values.</returns>
-        public OptimizelyJson GetAllFeatureVariables(string featureKey, string userId,
+        public OptimizelyJSON GetAllFeatureVariables(string featureKey, string userId,
                                                  UserAttributes userAttributes = null)
         {
             var config = ProjectConfigManager?.GetConfig();
@@ -806,8 +806,8 @@ namespace OptimizelySDK
                 
                 var typeCastedValue = GetTypeCastedVariableValue(variableValue, featureVariable.Type);
                 
-                if (typeCastedValue is OptimizelyJson)
-                    typeCastedValue = ((OptimizelyJson)typeCastedValue).ToDictionary();
+                if (typeCastedValue is OptimizelyJSON)
+                    typeCastedValue = ((OptimizelyJSON)typeCastedValue).ToDictionary();
 
                 valuesMap.Add(featureVariable.Key, typeCastedValue);
             }
@@ -830,7 +830,7 @@ namespace OptimizelySDK
             NotificationCenter.SendNotifications(NotificationCenter.NotificationType.Decision, DecisionNotificationTypes.ALL_FEATURE_VARIABLE, userId,
                 userAttributes ?? new UserAttributes(), decisionInfo);
             
-            return new OptimizelyJson(valuesMap, ErrorHandler, Logger);
+            return new OptimizelyJSON(valuesMap, ErrorHandler, Logger);
         }
 
         /// <summary>
@@ -915,7 +915,7 @@ namespace OptimizelySDK
                     result = value;
                     break;
                 case FeatureVariable.JSON_TYPE:
-                    result = new OptimizelyJson(value, ErrorHandler, Logger);
+                    result = new OptimizelyJSON(value, ErrorHandler, Logger);
                     break;
             }
 

--- a/OptimizelySDK/OptimizelyJSON.cs
+++ b/OptimizelySDK/OptimizelyJSON.cs
@@ -24,7 +24,7 @@ using Newtonsoft.Json;
 
 namespace OptimizelySDK
 {
-    public class OptimizelyJson
+    public class OptimizelyJSON
     {
         private ILogger Logger;
         private IErrorHandler ErrorHandler;
@@ -32,7 +32,7 @@ namespace OptimizelySDK
         private string Payload { get; set; }
         private Dictionary<string, object> Dict { get; set; }
 
-        public OptimizelyJson(string payload, IErrorHandler errorHandler, ILogger logger)
+        public OptimizelyJSON(string payload, IErrorHandler errorHandler, ILogger logger)
         {
             try
             {
@@ -48,7 +48,7 @@ namespace OptimizelySDK
             }
         }
 
-        public OptimizelyJson(Dictionary<string, object> dict, IErrorHandler errorHandler, ILogger logger)
+        public OptimizelyJSON(Dictionary<string, object> dict, IErrorHandler errorHandler, ILogger logger)
         {
             try
             {

--- a/OptimizelySDK/OptimizelySDK.csproj
+++ b/OptimizelySDK/OptimizelySDK.csproj
@@ -86,7 +86,7 @@
     <Compile Include="Entity\ForcedVariation.cs" />
     <Compile Include="Entity\Group.cs" />
     <Compile Include="Entity\IdKeyEntity.cs" />
-    <Compile Include="OptimizelyJson.cs" />
+    <Compile Include="OptimizelyJSON.cs" />
     <Compile Include="Entity\Rollout.cs" />
     <Compile Include="Entity\TrafficAllocation.cs" />
     <Compile Include="Entity\UserAttributes.cs" />


### PR DESCRIPTION
## Summary
- Renamed all references of a class from OptimizelyJson to OptimizelyJSON.
- OptimizelyJSON in .netStandard20 was under entity, while in other projects it was at root. Fixed it.

## Test plan
- All unit tests and FSC tests must be passed.