### PR TITLE
added disposed and max wait time.

### DIFF
--- a/OptimizelySDK.Tests/ConfigTest/HttpProjectConfigManagerTest.cs
+++ b/OptimizelySDK.Tests/ConfigTest/HttpProjectConfigManagerTest.cs
@@ -182,7 +182,8 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
                 .WithStartByDefault()
                 .Build();
 
-            httpManager.OnReady().Wait();
+            // OnReady waits until is resolved, need to add time in case of deadlock.
+            httpManager.OnReady().Wait(10000);
 
             Assert.AreEqual("15", httpManager.GetConfig().Revision);
 
@@ -208,7 +209,9 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
                 .WithStartByDefault(true)
                 .Build();
             t.Wait();
-            httpManager.OnReady().Wait();
+
+            // OnReady waits until is resolved, need to add time in case of deadlock.
+            httpManager.OnReady().Wait(10000);
             Assert.NotNull(httpManager.GetConfig());
             httpManager.Dispose();
         }
@@ -244,7 +247,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         #region Notification
         [Test]
         public void TestHttpConfigManagerSendConfigUpdateNotificationWhenProjectConfigGetsUpdated()
-        {
+        {            
             var t = MockSendAsync(TestData.Datafile);
 
             var httpManager = new HttpProjectConfigManager.Builder()
@@ -266,7 +269,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
 
         [Test]
         public void TestHttpConfigManagerDoesNotSendConfigUpdateNotificationWhenDatafileIsProvided()
-        {
+        {            
             var t = MockSendAsync(TestData.Datafile, TimeSpan.FromMilliseconds(100));
 
             var httpManager = new HttpProjectConfigManager.Builder()
@@ -460,7 +463,6 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         [Test]
         public void TestFormatUrlHigherPriorityThanDefaultUrl()
         {
-
             var t = MockSendAsync();
             var httpManager = new HttpProjectConfigManager.Builder()
                 .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
@@ -483,7 +485,6 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         {
             return TestHttpProjectConfigManagerUtil.MockSendAsync(HttpClientMock, datafile, delay, statusCode);
         }
-
         #endregion
     }
 }

--- a/OptimizelySDK.Tests/ConfigTest/PollingProjectConfigManagerTest.cs
+++ b/OptimizelySDK.Tests/ConfigTest/PollingProjectConfigManagerTest.cs
@@ -34,12 +34,12 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
 
         [SetUp]
         public void Setup()
-        {
+        {            
             LoggerMock = new Mock<ILogger>();
             LoggerMock.Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()));
             ProjectConfig = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object, null);
         }
-
+        
         [Test]
         public void TestPollingConfigManagerDoesNotBlockWhenProjectConfigIsAlreadyProvided()
         {
@@ -53,6 +53,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
 
             Assert.True(stopwatch.Elapsed.Seconds == 0);
             Assert.NotNull(config);
+            configManager.Dispose();
         }
 
         [Test]
@@ -66,6 +67,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             stopwatch.Stop();
 
             Assert.True(stopwatch.Elapsed.TotalMilliseconds >= 500);
+            configManager.Dispose();
         }
 
         [Test]
@@ -86,6 +88,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             // Should be called immediately after 1200 seconds. Here checking after 1300 secs.
             //Thread.Sleep(200);
             Assert.AreEqual(2, configManager.Counter);
+            configManager.Dispose();
 
         }
 
@@ -99,7 +102,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             configManager.Start();
             var config = configManager.GetConfig();
             LoggerMock.Verify(l => l.Log(LogLevel.WARN, "Timeout exceeded waiting for ProjectConfig to be set, returning null."));
-
+            configManager.Dispose();
         }
 
         [Test]
@@ -113,6 +116,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             var config = configManager.GetConfig();
             sw.Stop();
             Assert.GreaterOrEqual(sw.Elapsed.TotalMilliseconds, 950);
+            configManager.Dispose();
         }
 
         [Test]
@@ -126,6 +130,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             var config = configManager.GetConfig();
             sw.Stop();
             Assert.GreaterOrEqual(sw.Elapsed.TotalMilliseconds, 1000);
+            configManager.Dispose();
         }
 
         [Test]
@@ -142,6 +147,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             var config = configManager.GetConfig();
             Assert.NotNull(config);
             Assert.AreEqual(1, configManager.Counter);
+            configManager.Dispose();
         }
 
         [Test]
@@ -168,6 +174,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             var config = configManager.GetConfig();
             //Assert.NotNull(config);
             Assert.AreEqual(3, configManager.Counter);
+            configManager.Dispose();
         }
 
 
@@ -186,6 +193,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             var config = configManager.GetConfig();
             Assert.Null(config);
             Assert.AreEqual(3, configManager.Counter);
+            configManager.Dispose();
         }
     }
 }

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -3365,8 +3365,10 @@ namespace OptimizelySDK.Tests
             var optimizely = new Optimizely(httpManager, notificationCenter);
             optimizely.NotificationCenter.AddNotification(NotificationCenter.NotificationType.OptimizelyConfigUpdate, NotificationCallbackMock.Object.TestConfigUpdateCallback);
             httpManager.Start();
+
+            // wait till 10 seconds max, to avoid stale state in worst case.
+            httpManager.OnReady().Wait(10000);
             
-            httpManager.OnReady().Wait(-1);
             t.Wait();
             NotificationCallbackMock.Verify(nc => nc.TestConfigUpdateCallback(), Times.Once);
             httpManager.Dispose();
@@ -3389,7 +3391,9 @@ namespace OptimizelySDK.Tests
 
             var optimizely = new Optimizely(httpManager);
             optimizely.NotificationCenter.AddNotification(NotificationCenter.NotificationType.OptimizelyConfigUpdate, NotificationCallbackMock.Object.TestConfigUpdateCallback);
-            httpManager.OnReady().Wait(-1);
+
+            // added 10 secs max wait to avoid stale state.
+            httpManager.OnReady().Wait(10000);
 
             NotificationCallbackMock.Verify(nc => nc.TestConfigUpdateCallback(), Times.Never);
             httpManager.Dispose();
@@ -3833,6 +3837,7 @@ namespace OptimizelySDK.Tests
             var activateAfterDispose = optimizely.Activate("test_experiment", TestUserId, new UserAttributes() {
                 { "device_type", "iPhone" }, { "location", "San Francisco" } });
             Assert.Null(activateAfterDispose);
+            httpManager.Dispose();
         }
 
         [Test]


### PR DESCRIPTION
## Summary
- Called Dispose method on every HttpConfigManager instance after test, Problem was Continuous polling of older instances were called for new mocked instance which is why test cases were being failed.
- Added maximum wait time to avoid deadlock or stale situation, OnReady wait until gets resolved, if no valid Config is provided, it remains unresolved which causes deadlock.

## Test plan
- All unit test must pass.
