### PR TITLE
fix: srcclr should be first in a job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
         - ([ ${TRAVIS_BRANCH} = "$RELEASE_BRANCH" ] && [ ${TRAVIS_EVENT_TYPE} = "push" ]) && (AWS_ACCESS_KEY_ID=$OFTA_KEY AWS_SECRET_ACCESS_KEY=$OFTA_SECRET AWS_DEFAULT_REGION=$OFTA_REGION aws s3 cp ./OptimizelySDK.NetStandard20/bin/Release/netstandard2.0/OptimizelySDK.NetStandard20.dll s3://optly-fs-travisci-artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}/OptimizelySDK.NetStandard20.dll-unsigned)        
 
     - stage: 'Source Clear'
-      if: type = cron
+#       if: type = cron
       language: csharp
       # dotnet only works on trusty https://github.com/travis-ci/travis-ci/issues/5189
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,13 +6,13 @@ env:
 
 # Integration tests need to run first to reset the PR build status to pending
 stages:
+  - name: 'Source Clear'
   - name: 'Lint markdown files'
   - name: 'Integration tests'
   - name: 'Production tests'
   - name: 'Unit Tests'
   - name: 'NetStandard16'
   - name: 'NetStandard20'
-  - name: 'Source Clear'
 
 jobs:
   include:
@@ -100,6 +100,11 @@ jobs:
 
     - stage: 'Source Clear'
       if: type = cron
+      language: csharp
+      # dotnet only works on trusty https://github.com/travis-ci/travis-ci/issues/5189
+      dist: trusty
+      mono: none
+      dotnet: 2.1.502      
       addons:
         srcclr: true
       before_install: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -99,7 +99,7 @@ jobs:
         - ([ ${TRAVIS_BRANCH} = "$RELEASE_BRANCH" ] && [ ${TRAVIS_EVENT_TYPE} = "push" ]) && (AWS_ACCESS_KEY_ID=$OFTA_KEY AWS_SECRET_ACCESS_KEY=$OFTA_SECRET AWS_DEFAULT_REGION=$OFTA_REGION aws s3 cp ./OptimizelySDK.NetStandard20/bin/Release/netstandard2.0/OptimizelySDK.NetStandard20.dll s3://optly-fs-travisci-artifacts/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}/OptimizelySDK.NetStandard20.dll-unsigned)        
 
     - stage: 'Source Clear'
-#       if: type = cron
+      if: type = cron
       language: csharp
       # dotnet only works on trusty https://github.com/travis-ci/travis-ci/issues/5189
       dist: trusty


### PR DESCRIPTION
## Summary
- Source clear should be first n stage
- Added dotnet, otherwise source clear was unable to run it's job.

## Test plan
Checked here, and it's working fine. 
https://travis-ci.org/github/optimizely/csharp-sdk/jobs/712722775
