### PR TITLE
fix: Datafile accesstoken is not accessible to .net 3.5 and 4.0

### DIFF
--- a/OptimizelySDK/OptimizelyFactory.cs
+++ b/OptimizelySDK/OptimizelyFactory.cs
@@ -83,7 +83,9 @@ namespace OptimizelySDK
                 .WithFormat(httpProjectConfigElement.Format)
                 .WithPollingInterval(TimeSpan.FromMilliseconds(httpProjectConfigElement.PollingInterval))
                 .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(httpProjectConfigElement.BlockingTimeOutPeriod))
+#if !NET40 && !NET35
                 .WithAccessToken(httpProjectConfigElement.DatafileAccessToken)
+#endif
                 .WithLogger(logger)
                 .WithErrorHandler(errorHandler)
                 .WithNotificationCenter(notificationCenter)
@@ -109,7 +111,7 @@ namespace OptimizelySDK
         }
 #endif
 
-        public static Optimizely NewDefaultInstance(string sdkKey)
+            public static Optimizely NewDefaultInstance(string sdkKey)
         {
             return NewDefaultInstance(sdkKey, null);
         }


### PR DESCRIPTION
## Summary
- DatafileAccessToken is only allowed to 4.0 above, OptimizelyFactory is for all versions, added a condition to set accesstoken only for 4.0 above.

## Test plan
- Unit test must pass 
- FSC must pass.
- Manually checked, build is compiling succesfully.