### PR TITLE
fix: error handler not raise exception while using optimizelyfactory

### DIFF
--- a/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
@@ -206,6 +206,4 @@ namespace OptimizelySDK.Tests
             optimizely.Dispose();
         }
     }
-
-
 }

--- a/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
@@ -193,6 +193,19 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(actualEventProcessorProps, expectedEventProcessorProps);
             optimizely.Dispose();
         }
+
+        [Test]
+        public void TestGetFeatureVariableJSONEmptyDatafileTest()
+        {
+            var httpClientMock = new Mock<HttpProjectConfigManager.HttpClient>();
+            var task = TestHttpProjectConfigManagerUtil.MockSendAsync(httpClientMock, TestData.EmptyDatafile, TimeSpan.Zero, System.Net.HttpStatusCode.OK);
+            TestHttpProjectConfigManagerUtil.SetClientFieldValue(httpClientMock.Object);
+
+            var optimizely = OptimizelyFactory.NewDefaultInstance("sdk-key");
+            Assert.Null(optimizely.GetFeatureVariableJSON("no-feature-variable", "no-variable-key", "userId"));
+            optimizely.Dispose();
+        }
     }
+
 
 }

--- a/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
+++ b/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
@@ -120,6 +120,7 @@
     <EmbeddedResource Include="TestData.json" />
     <EmbeddedResource Include="simple_ab_experiments.json" />
     <EmbeddedResource Include="EmptyRolloutRule.json" />
+    <EmbeddedResource Include="emptydatafile.json" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OptimizelySDK\OptimizelySDK.csproj">

--- a/OptimizelySDK.Tests/Utils/TestData.cs
+++ b/OptimizelySDK.Tests/Utils/TestData.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2017-2019, Optimizely
+ * Copyright 2017-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OptimizelySDK.Tests/Utils/TestData.cs
+++ b/OptimizelySDK.Tests/Utils/TestData.cs
@@ -28,6 +28,7 @@ namespace OptimizelySDK.Tests
         private static string unsupportedVersionDatafile = null;
         private static string typedAudienceDatafile = null;
         private static string emptyRolloutDatafile = null;
+        private static string emptyDatafile = null;
 
         public static string Datafile
         {
@@ -56,6 +57,12 @@ namespace OptimizelySDK.Tests
         public static string EmptyRolloutDatafile {
             get {
                 return emptyRolloutDatafile ?? (emptyRolloutDatafile = LoadJsonData("EmptyRolloutRule.json"));
+            }
+        }
+
+        public static string EmptyDatafile {
+            get {
+                return emptyDatafile ?? (emptyDatafile = LoadJsonData("emptydatafile.json"));
             }
         }
 

--- a/OptimizelySDK.Tests/emptydatafile.json
+++ b/OptimizelySDK.Tests/emptydatafile.json
@@ -1,0 +1,15 @@
+﻿{
+  "version": "4",
+  "rollouts": [],
+  "anonymizeIP": true,
+  "projectId": "10431130345",
+  "variables": [],
+  "featureFlags": [],
+  "experiments": [],
+  "audiences": [],
+  "groups": [],
+  "attributes": [],
+  "accountId": "10367498574",
+  "events": [],
+  "revision": "241"
+}

--- a/OptimizelySDK/OptimizelyFactory.cs
+++ b/OptimizelySDK/OptimizelyFactory.cs
@@ -72,7 +72,7 @@ namespace OptimizelySDK
 
             if (httpProjectConfigElement == null) return null;
 
-            var errorHandler = new DefaultErrorHandler();
+            var errorHandler = new DefaultErrorHandler(logger, false);
             var eventDispatcher = new DefaultEventDispatcher(logger);
             var builder = new HttpProjectConfigManager.Builder();
             var notificationCenter = new NotificationCenter();
@@ -119,7 +119,7 @@ namespace OptimizelySDK
         public static Optimizely NewDefaultInstance(string sdkKey, string fallback, string datafileAuthToken)
         {
             var logger = OptimizelyLogger ?? new DefaultLogger();
-            var errorHandler = new DefaultErrorHandler();
+            var errorHandler = new DefaultErrorHandler(logger, false);
             var eventDispatcher = new DefaultEventDispatcher(logger);
             var builder = new HttpProjectConfigManager.Builder();
             var notificationCenter = new NotificationCenter();
@@ -151,7 +151,7 @@ namespace OptimizelySDK
         public static Optimizely NewDefaultInstance(string sdkKey, string fallback)
         {
             var logger = OptimizelyLogger ?? new DefaultLogger();
-            var errorHandler = new DefaultErrorHandler();
+            var errorHandler = new DefaultErrorHandler(logger, false);
             var eventDispatcher = new DefaultEventDispatcher(logger);
             var builder = new HttpProjectConfigManager.Builder();
             var notificationCenter = new NotificationCenter();


### PR DESCRIPTION
## Summary
- NewDefaultInstance shouldn't cause optimizely instance to raise exception while handling error, by default all DefaultErrorHandler shouldn't raise exception.
- Passed logger in default error handler and made raise exception to false.

## Test plan
- Added unit test. 
- FSC with empty datafile scenario must pass.
   https://travis-ci.com/github/optimizely/fullstack-sdk-compatibility-suite/builds/182487252