### PR TITLE
feat(flag-decisions): Add support for sending flag decisions along with decision metadata. 

### DIFF
--- a/OptimizelySDK.Net35/OptimizelySDK.Net35.csproj
+++ b/OptimizelySDK.Net35/OptimizelySDK.Net35.csproj
@@ -266,6 +266,9 @@
 	<Compile Include="..\OptimizelySDK\Event\Entity\Visitor.cs">
 	  <Link>Event\Entity\Visitor.cs</Link>
 	</Compile>
+	<Compile Include="..\OptimizelySDK\Event\Entity\DecisionMetadata.cs">
+	  <Link>Event\Entity\DecisionMetadata.cs</Link>
+	</Compile>
 	<Compile Include="..\OptimizelySDK\Event\Entity\VisitorAttribute.cs">
 	  <Link>Event\Entity\VisitorAttribute.cs</Link>
 	</Compile>

--- a/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
+++ b/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
@@ -280,6 +280,9 @@
 	<Compile Include="..\OptimizelySDK\Event\Entity\VisitorAttribute.cs">
 	  <Link>Event\Entity\VisitorAttribute.cs</Link>
 	</Compile>
+	<Compile Include="..\OptimizelySDK\Event\Entity\DecisionMetadata.cs">
+	  <Link>Event\Entity\DecisionMetadata.cs</Link>
+	</Compile>
 	<Compile Include="..\OptimizelySDK\Event\EventFactory.cs">
 	  <Link>Event\EventFactory.cs</Link>
 	</Compile>

--- a/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
+++ b/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
@@ -24,6 +24,7 @@
 		<Compile Include="..\OptimizelySDK\AudienceConditions\OrCondition.cs" />
 		<Compile Include="..\OptimizelySDK\Entity\Attribute.cs" />
         <Compile Include="..\OptimizelySDK\Entity\Audience.cs" />
+        <Compile Include="..\OptimizelySDK\Entity\DecisionMetadata.cs" />
         <Compile Include="..\OptimizelySDK\Entity\Entity.cs" />
         <Compile Include="..\OptimizelySDK\Entity\Event.cs" />
         <Compile Include="..\OptimizelySDK\Entity\EventTags.cs" />
@@ -120,6 +121,9 @@
 		</Compile>
 		<Compile Include="..\OptimizelySDK\Event\Entity\VisitorAttribute.cs">
 		  <Link>VisitorAttribute.cs</Link>
+		</Compile>
+		<Compile Include="..\OptimizelySDK\Event\Entity\DecisionMetadata.cs">
+		  <Link>DecisionMetadata.cs</Link>
 		</Compile>
 		<Compile Include="..\OptimizelySDK\Event\Entity\Decision.cs">
 		  <Link>DecisionEvent.cs</Link>

--- a/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
+++ b/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
@@ -24,7 +24,6 @@
 		<Compile Include="..\OptimizelySDK\AudienceConditions\OrCondition.cs" />
 		<Compile Include="..\OptimizelySDK\Entity\Attribute.cs" />
         <Compile Include="..\OptimizelySDK\Entity\Audience.cs" />
-        <Compile Include="..\OptimizelySDK\Entity\DecisionMetadata.cs" />
         <Compile Include="..\OptimizelySDK\Entity\Entity.cs" />
         <Compile Include="..\OptimizelySDK\Entity\Event.cs" />
         <Compile Include="..\OptimizelySDK\Entity\EventTags.cs" />

--- a/OptimizelySDK.NetStandard20/OptimizelySDK.NetStandard20.csproj
+++ b/OptimizelySDK.NetStandard20/OptimizelySDK.NetStandard20.csproj
@@ -175,6 +175,9 @@
     <Compile Include="..\OptimizelySDK\Event\Entity\Decision.cs">
       <Link>Event\Entity\Decision.cs</Link>
     </Compile>
+	<Compile Include="..\OptimizelySDK\Event\Entity\DecisionMetadata.cs">
+      <Link>Event\Entity\DecisionMetadata.cs</Link>
+    </Compile>
     <Compile Include="..\OptimizelySDK\Event\Entity\EventBatch.cs">
       <Link>Event\Entity\EventBatch.cs</Link>
     </Compile>

--- a/OptimizelySDK.Tests/EventTests/EventEntitiesTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventEntitiesTest.cs
@@ -1,4 +1,22 @@
-﻿using System;
+﻿/**
+ *
+ *    Copyright 2019-2020, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Schema;

--- a/OptimizelySDK.Tests/EventTests/EventEntitiesTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventEntitiesTest.cs
@@ -104,7 +104,7 @@ namespace OptimizelySDK.Tests.EventTests
                 .WithTimeStamp(timeStamp)
                 .WithEventTags(null)
                 .Build();
-            
+            var metadata = new DecisionMetadata("experiment", "7716830082");
             var decision = new Decision("7719770039", "7716830082", "77210100090");
             var snapshot = new Snapshot(events: new SnapshotEvent[] { snapshotEvent }, decisions: new Decision[] { decision });
 

--- a/OptimizelySDK.Tests/EventTests/EventEntitiesTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventEntitiesTest.cs
@@ -122,7 +122,7 @@ namespace OptimizelySDK.Tests.EventTests
                 .WithTimeStamp(timeStamp)
                 .WithEventTags(null)
                 .Build();
-            var metadata = new DecisionMetadata("experiment", "7716830082");
+            var metadata = new DecisionMetadata("experiment", "experiment_key", "7716830082");
             var decision = new Decision("7719770039", "7716830082", "77210100090");
             var snapshot = new Snapshot(events: new SnapshotEvent[] { snapshotEvent }, decisions: new Decision[] { decision });
 

--- a/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
@@ -1,4 +1,21 @@
-﻿using System;
+﻿/**
+ *
+ *    Copyright 2019-2020, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+using System;
 using System.Collections.Generic;
 using Moq;
 using NUnit.Framework;

--- a/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
@@ -509,7 +509,7 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", null },
                                                     {"variation_id", null },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "rule_type", "" },
+                                                            { "rule_type", "rollout" },
                                                             { "rule_key", "" },
                                                             { "flag_key", "test_feature" },
                                                             { "variation_key", "" }

--- a/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
@@ -57,8 +57,9 @@ namespace OptimizelySDK.Tests.EventTests
         public void TestCreateImpressionEventReturnsNullWhenSendFlagDecisionsIsFalseAndVariationIsNull()
         {
             Config.SendFlagDecisions = false;
+            Variation variation = null;
             var impressionEvent = UserEventFactory.CreateImpressionEvent(
-                Config, Config.GetExperimentFromKey("test_experiment"), variation: null, TestUserId, null, "test_experiment", "experiment");
+                Config, Config.GetExperimentFromKey("test_experiment"), variation, TestUserId, null, "test_experiment", "experiment");
             Assert.IsNull(impressionEvent);
         }
 
@@ -592,7 +593,9 @@ namespace OptimizelySDK.Tests.EventTests
                 { "nan", double.NaN },
                 { "invalid_num_value", Math.Pow(2, 53) + 2 },
             };
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, null, variation: null, TestUserId, userAttributes, "test_feature", "rollout");
+            Variation variation = null;
+
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, null, variation, TestUserId, userAttributes, "test_feature", "rollout");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
             
             TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));

--- a/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
@@ -28,6 +28,24 @@ namespace OptimizelySDK.Tests.EventTests
         }
 
         [Test]
+        public void TestCreateImpressionEventReturnsNullWhenSendFlagDecisionsIsFalseAndIsRollout()
+        {
+            Config.SendFlagDecisions = false;
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(
+                Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, null, "test_feature", "rollout");
+            Assert.IsNull(impressionEvent);
+        }
+
+        [Test]
+        public void TestCreateImpressionEventReturnsNullWhenSendFlagDecisionsIsFalseAndVariationIsNull()
+        {
+            Config.SendFlagDecisions = false;
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(
+                Config, Config.GetExperimentFromKey("test_experiment"), variation: null, TestUserId, null, "test_experiment", "experiment");
+            Assert.IsNull(impressionEvent);
+        }
+
+        [Test]
         public void TestCreateImpressionEventNoAttributes()
         {
             var guid = Guid.NewGuid();
@@ -45,7 +63,12 @@ namespace OptimizelySDK.Tests.EventTests
                                                     new Dictionary<string, object> {
                                                         { "campaign_id", "7719770039" },
                                                         { "experiment_id", "7716830082" },
-                                                        { "variation_id", "7722370027" }
+                                                        { "variation_id", "7722370027" },
+                                                        { "metadata", new Dictionary<string, object> {
+                                                            { "FlagType", "experiment" },
+                                                            { "FlagKey", "test_experiment" },
+                                                            { "VariationKey", "control" }
+                                                        } }
                                                     }
                                                 }
                                             },
@@ -93,7 +116,7 @@ namespace OptimizelySDK.Tests.EventTests
                     { "Content-Type", "application/json" }
                 });
             var impressionEvent = UserEventFactory.CreateImpressionEvent(
-                Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, null);
+                Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, null, "test_experiment", "experiment");
 
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
 
@@ -120,7 +143,13 @@ namespace OptimizelySDK.Tests.EventTests
                                                 new Dictionary<string, object> {
                                                     {"campaign_id", "7719770039" },
                                                     {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" }
+                                                    {"variation_id", "7722370027" },
+                                                    { "metadata", new Dictionary<string, object> {
+                                                            { "FlagType", "experiment" },
+                                                            { "FlagKey", "test_experiment" },
+                                                            { "VariationKey", "control" }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         },
@@ -183,7 +212,7 @@ namespace OptimizelySDK.Tests.EventTests
                 { "company", "Optimizely" }
             };
             //
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), variationId, TestUserId, userAttributes);
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), variationId, TestUserId, userAttributes, "test_experiment", "experiment");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
 
             TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
@@ -213,7 +242,13 @@ namespace OptimizelySDK.Tests.EventTests
                                                 {
                                                     {"campaign_id", "7719770039" },
                                                     {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" }
+                                                    {"variation_id", "7722370027" },
+                                                    { "metadata", new Dictionary<string, object> {
+                                                            { "FlagType", "experiment" },
+                                                            { "FlagKey", "test_experiment" },
+                                                            { "VariationKey", "control" }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         },
@@ -298,7 +333,7 @@ namespace OptimizelySDK.Tests.EventTests
                 {"integer_key", 15 },
                 {"double_key", 3.14 }
             };
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, userAttributes);
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, userAttributes, "test_experiment", "experiment");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
 
             TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
@@ -328,7 +363,13 @@ namespace OptimizelySDK.Tests.EventTests
                                                 {
                                                     {"campaign_id", "7719770039" },
                                                     {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" }
+                                                    {"variation_id", "7722370027" },
+                                                    { "metadata", new Dictionary<string, object> {
+                                                            { "FlagType", "experiment" },
+                                                            { "FlagKey", "test_experiment" },
+                                                            { "VariationKey", "control" }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         },
@@ -413,7 +454,128 @@ namespace OptimizelySDK.Tests.EventTests
                 { "nan", double.NaN },
                 { "invalid_num_value", Math.Pow(2, 53) + 2 },
             };
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, userAttributes);
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, userAttributes, "test_experiment", "experiment");
+            var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
+
+            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
+
+            Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
+        }
+
+        [Test]
+        public void TestCreateImpressionEventRemovesInvalidAttributesFromPayloadRollout()
+        {
+            var guid = Guid.NewGuid();
+            var timeStamp = TestData.SecondsSince1970();
+
+            var payloadParams = new Dictionary<string, object>
+            {
+                { "visitors", new object[]
+                    {
+                        new Dictionary<string, object>()
+                        {
+                            { "snapshots", new object[]
+                                {
+                                    new Dictionary<string, object>
+                                    {
+                                        { "decisions", new object[]
+                                            {
+                                                new Dictionary<string, object>
+                                                {
+                                                    {"campaign_id", null },
+                                                    {"experiment_id", null },
+                                                    {"variation_id", null },
+                                                    { "metadata", new Dictionary<string, object> {
+                                                            { "FlagType", "rollout" },
+                                                            { "FlagKey", "test_feature" },
+                                                            { "VariationKey", null }
+                                                        } 
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        { "events", new object[]
+                                            {
+                                                new Dictionary<string, object>
+                                                {
+                                                    {"entity_id", null },
+                                                    {"timestamp", timeStamp },
+                                                    {"uuid", guid },
+                                                    {"key", "campaign_activated" }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {"attributes", new object[]
+                                {
+                                    new Dictionary<string, object>
+                                    {
+                                        {"entity_id", "7723280020" },
+                                        {"key", "device_type" },
+                                        {"type", "custom" },
+                                        {"value", "iPhone"}
+                                    },
+                                    new Dictionary<string, object>
+                                    {
+                                        {"entity_id", "323434545" },
+                                        {"key", "boolean_key" },
+                                        {"type", "custom" },
+                                        {"value", true}
+                                    },
+                                    new Dictionary<string, object>
+                                    {
+                                        {"entity_id", "808797686" },
+                                        {"key", "double_key" },
+                                        {"type", "custom" },
+                                        {"value", 3.14}
+                                    },
+                                    new Dictionary<string, object>
+                                    {
+                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
+                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
+                                        {"type", "custom" },
+                                        {"value", true }
+                                    }
+                                }
+                            },
+                            { "visitor_id", TestUserId }
+                        }
+                    }
+                },
+                {"project_id", "7720880029" },
+                {"account_id", "1592310167" },
+                {"enrich_decisions", true} ,
+                {"client_name", "csharp-sdk" },
+                {"client_version", Optimizely.SDK_VERSION },
+                {"revision", "15" },
+                {"anonymize_ip", false}
+            };
+
+            var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
+                payloadParams,
+                "POST",
+                new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" }
+                });
+
+            var userAttributes = new UserAttributes
+            {
+                { "device_type", "iPhone" },
+                { "boolean_key", true },
+                { "double_key", 3.14 },
+                { "", "Android" },
+                { "null", null },
+                { "objects", new object() },
+                { "arrays", new string[] { "a", "b", "c" } },
+                { "negative_infinity", double.NegativeInfinity },
+                { "positive_infinity", double.PositiveInfinity },
+                { "nan", double.NaN },
+                { "invalid_num_value", Math.Pow(2, 53) + 2 },
+            };
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, null, variation: null, TestUserId, userAttributes, "test_feature", "rollout");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
             
             TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
@@ -1333,7 +1495,13 @@ namespace OptimizelySDK.Tests.EventTests
                                                 {
                                                     {"campaign_id", "7719770039" },
                                                     {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" }
+                                                    {"variation_id", "7722370027" },
+                                                    { "metadata", new Dictionary<string, object> {
+                                                            { "FlagType", "experiment" },
+                                                            { "FlagKey", "test_experiment" },
+                                                            { "VariationKey", "control" }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         },
@@ -1403,7 +1571,7 @@ namespace OptimizelySDK.Tests.EventTests
                 { "company", "Optimizely" },
                 {ControlAttributes.BUCKETING_ID_ATTRIBUTE, "variation" }
             };
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, userAttributes);
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, userAttributes, "test_experiment", "experiment");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
 
             TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
@@ -1433,7 +1601,13 @@ namespace OptimizelySDK.Tests.EventTests
                                                 {
                                                     {"campaign_id", "7719770039" },
                                                     {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" }
+                                                    {"variation_id", "7722370027" },
+                                                    { "metadata", new Dictionary<string, object> {
+                                                            { "FlagType", "experiment" },
+                                                            { "FlagKey", "test_experiment" },
+                                                            { "VariationKey", "control" }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         },
@@ -1499,7 +1673,7 @@ namespace OptimizelySDK.Tests.EventTests
             botFilteringEnabledConfig.BotFiltering = true;
             var experiment = botFilteringEnabledConfig.GetExperimentFromKey("test_experiment");
 
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(botFilteringEnabledConfig, experiment, "7722370027", TestUserId, userAttributes);
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(botFilteringEnabledConfig, experiment, "7722370027", TestUserId, userAttributes, "test_experiment", "experiment");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
             
             TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
@@ -1529,7 +1703,13 @@ namespace OptimizelySDK.Tests.EventTests
                                                 {
                                                     {"campaign_id", "7719770039" },
                                                     {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" }
+                                                    {"variation_id", "7722370027" },
+                                                    { "metadata", new Dictionary<string, object> {
+                                                            { "FlagType", "experiment" },
+                                                            { "FlagKey", "test_experiment" },
+                                                            { "VariationKey", "control" }
+                                                        }
+                                                    }
                                                 }
                                             }
                                         },
@@ -1588,7 +1768,7 @@ namespace OptimizelySDK.Tests.EventTests
             botFilteringDisabledConfig.BotFiltering = null;
             var experiment = botFilteringDisabledConfig.GetExperimentFromKey("test_experiment");
 
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(botFilteringDisabledConfig, experiment, "7722370027", TestUserId, userAttributes);
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(botFilteringDisabledConfig, experiment, "7722370027", TestUserId, userAttributes, "test_experiment", "experiment");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
             
             TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));

--- a/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
@@ -82,10 +82,11 @@ namespace OptimizelySDK.Tests.EventTests
                                                         { "campaign_id", "7719770039" },
                                                         { "experiment_id", "7716830082" },
                                                         { "variation_id", "7722370027" },
-                                                        { "metadata", new Dictionary<string, object> {
-                                                            { "FlagType", "experiment" },
-                                                            { "FlagKey", "test_experiment" },
-                                                            { "VariationKey", "control" }
+                                                        { "metadata",
+                                                            new Dictionary<string, object> {
+                                                            { "flag_type", "experiment" },
+                                                            { "flag_key", "test_experiment" },
+                                                            { "variation_key", "control" }
                                                         } }
                                                     }
                                                 }
@@ -163,9 +164,9 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", "7716830082" },
                                                     {"variation_id", "7722370027" },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "FlagType", "experiment" },
-                                                            { "FlagKey", "test_experiment" },
-                                                            { "VariationKey", "control" }
+                                                            { "flag_type", "experiment" },
+                                                            { "flag_key", "test_experiment" },
+                                                            { "variation_key", "control" }
                                                         }
                                                     }
                                                 }
@@ -262,9 +263,9 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", "7716830082" },
                                                     {"variation_id", "7722370027" },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "FlagType", "experiment" },
-                                                            { "FlagKey", "test_experiment" },
-                                                            { "VariationKey", "control" }
+                                                            { "flag_type", "experiment" },
+                                                            { "flag_key", "test_experiment" },
+                                                            { "variation_key", "control" }
                                                         }
                                                     }
                                                 }
@@ -383,9 +384,9 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", "7716830082" },
                                                     {"variation_id", "7722370027" },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "FlagType", "experiment" },
-                                                            { "FlagKey", "test_experiment" },
-                                                            { "VariationKey", "control" }
+                                                            { "flag_type", "experiment" },
+                                                            { "flag_key", "test_experiment" },
+                                                            { "variation_key", "control" }
                                                         }
                                                     }
                                                 }
@@ -504,10 +505,10 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", null },
                                                     {"variation_id", null },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "FlagType", "rollout" },
-                                                            { "FlagKey", "test_feature" },
-                                                            { "VariationKey", null }
-                                                        } 
+                                                            { "flag_type", "rollout" },
+                                                            { "flag_key", "test_feature" },
+                                                            { "variation_key", null }
+                                                        }
                                                     }
                                                 }
                                             }
@@ -597,7 +598,7 @@ namespace OptimizelySDK.Tests.EventTests
 
             var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, null, variation, TestUserId, userAttributes, "test_feature", "rollout");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
-            
+
             TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
@@ -1517,9 +1518,9 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", "7716830082" },
                                                     {"variation_id", "7722370027" },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "FlagType", "experiment" },
-                                                            { "FlagKey", "test_experiment" },
-                                                            { "VariationKey", "control" }
+                                                            { "flag_type", "experiment" },
+                                                            { "flag_key", "test_experiment" },
+                                                            { "variation_key", "control" }
                                                         }
                                                     }
                                                 }
@@ -1623,9 +1624,9 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", "7716830082" },
                                                     {"variation_id", "7722370027" },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "FlagType", "experiment" },
-                                                            { "FlagKey", "test_experiment" },
-                                                            { "VariationKey", "control" }
+                                                            { "flag_type", "experiment" },
+                                                            { "flag_key", "test_experiment" },
+                                                            { "variation_key", "control" }
                                                         }
                                                     }
                                                 }
@@ -1695,7 +1696,7 @@ namespace OptimizelySDK.Tests.EventTests
 
             var impressionEvent = UserEventFactory.CreateImpressionEvent(botFilteringEnabledConfig, experiment, "7722370027", TestUserId, userAttributes, "test_experiment", "experiment");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
-            
+
             TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
@@ -1725,9 +1726,9 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", "7716830082" },
                                                     {"variation_id", "7722370027" },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "FlagType", "experiment" },
-                                                            { "FlagKey", "test_experiment" },
-                                                            { "VariationKey", "control" }
+                                                            { "flag_type", "experiment" },
+                                                            { "flag_key", "test_experiment" },
+                                                            { "variation_key", "control" }
                                                         }
                                                     }
                                                 }
@@ -1790,7 +1791,7 @@ namespace OptimizelySDK.Tests.EventTests
 
             var impressionEvent = UserEventFactory.CreateImpressionEvent(botFilteringDisabledConfig, experiment, "7722370027", TestUserId, userAttributes, "test_experiment", "experiment");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
-            
+
             TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
@@ -1880,7 +1881,7 @@ namespace OptimizelySDK.Tests.EventTests
 
             var conversionEvent = UserEventFactory.CreateConversionEvent(botFilteringEnabledConfig, "purchase", TestUserId, userAttributes, null);
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
-            
+
             TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
@@ -1962,7 +1963,7 @@ namespace OptimizelySDK.Tests.EventTests
             botFilteringDisabledConfig.BotFiltering = null;
 
             var conversionEvent = UserEventFactory.CreateConversionEvent(botFilteringDisabledConfig, "purchase", TestUserId, userAttributes, null);
-            var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);            
+            var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
             TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
 
@@ -1986,7 +1987,7 @@ namespace OptimizelySDK.Tests.EventTests
                     "111130", new Variation{Id="111131", Key="variation"}
                 }
             };
-            
+
             var payloadParams = new Dictionary<string, object>
                 {
                 {"client_version", Optimizely.SDK_VERSION},
@@ -2187,7 +2188,7 @@ namespace OptimizelySDK.Tests.EventTests
                 {"7716830082", new Variation{Id="7722370027", Key="control"} }
             };
             var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase", TestUserId, userAttributes, null);
-            var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);            
+            var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
             TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));

--- a/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
@@ -84,7 +84,8 @@ namespace OptimizelySDK.Tests.EventTests
                                                         { "variation_id", "7722370027" },
                                                         { "metadata",
                                                             new Dictionary<string, object> {
-                                                            { "flag_type", "experiment" },
+                                                            { "rule_type", "experiment" },
+                                                            { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
                                                             { "variation_key", "control" }
                                                         } }
@@ -164,7 +165,8 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", "7716830082" },
                                                     {"variation_id", "7722370027" },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "flag_type", "experiment" },
+                                                            { "rule_type", "experiment" },
+                                                            { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
                                                             { "variation_key", "control" }
                                                         }
@@ -263,7 +265,8 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", "7716830082" },
                                                     {"variation_id", "7722370027" },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "flag_type", "experiment" },
+                                                            { "rule_type", "experiment" },
+                                                            { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
                                                             { "variation_key", "control" }
                                                         }
@@ -384,9 +387,10 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", "7716830082" },
                                                     {"variation_id", "7722370027" },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "flag_type", "experiment" },
-                                                            { "flag_key", "test_experiment" },
-                                                            { "variation_key", "control" }
+                                                           { "rule_type", "experiment" },
+                                                           { "rule_key", "test_experiment" },
+                                                           { "flag_key", "test_experiment" },
+                                                           { "variation_key", "control" }
                                                         }
                                                     }
                                                 }
@@ -505,9 +509,10 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", null },
                                                     {"variation_id", null },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "flag_type", "rollout" },
+                                                            { "rule_type", "" },
+                                                            { "rule_key", "" },
                                                             { "flag_key", "test_feature" },
-                                                            { "variation_key", null }
+                                                            { "variation_key", "" }
                                                         }
                                                     }
                                                 }
@@ -1518,7 +1523,8 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", "7716830082" },
                                                     {"variation_id", "7722370027" },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "flag_type", "experiment" },
+                                                            { "rule_type", "experiment" },
+                                                            { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
                                                             { "variation_key", "control" }
                                                         }
@@ -1624,7 +1630,8 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", "7716830082" },
                                                     {"variation_id", "7722370027" },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "flag_type", "experiment" },
+                                                            { "rule_type", "experiment" },
+                                                            { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
                                                             { "variation_key", "control" }
                                                         }
@@ -1726,7 +1733,8 @@ namespace OptimizelySDK.Tests.EventTests
                                                     {"experiment_id", "7716830082" },
                                                     {"variation_id", "7722370027" },
                                                     { "metadata", new Dictionary<string, object> {
-                                                            { "flag_type", "experiment" },
+                                                            { "rule_type", "experiment" },
+                                                            { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
                                                             { "variation_key", "control" }
                                                         }

--- a/OptimizelySDK.Tests/EventTests/UserEventFactoryTest.cs
+++ b/OptimizelySDK.Tests/EventTests/UserEventFactoryTest.cs
@@ -32,7 +32,7 @@ namespace OptimizelySDK.Tests.EventTests
             var variation = Config.GetVariationFromId(experiment.Key, "77210100090");
             var userId = TestUserId;
 
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(projectConfig, experiment, variation, userId, null);
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(projectConfig, experiment, variation, userId, null, "test_experiment", "experiment");
 
             Assert.AreEqual(Config.ProjectId, impressionEvent.Context.ProjectId);
             Assert.AreEqual(Config.Revision, impressionEvent.Context.Revision);
@@ -58,7 +58,7 @@ namespace OptimizelySDK.Tests.EventTests
                 { "company", "Optimizely" }
             };
 
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(projectConfig, experiment, variation, userId, userAttributes);
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(projectConfig, experiment, variation, userId, userAttributes, "test_experiment", "experiment");
 
             Assert.AreEqual(Config.ProjectId, impressionEvent.Context.ProjectId);
             Assert.AreEqual(Config.Revision, impressionEvent.Context.Revision);

--- a/OptimizelySDK.Tests/EventTests/UserEventFactoryTest.cs
+++ b/OptimizelySDK.Tests/EventTests/UserEventFactoryTest.cs
@@ -1,4 +1,21 @@
-﻿using Moq;
+﻿/**
+ *
+ *    Copyright 2019-2020, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+using Moq;
 using NUnit.Framework;
 using OptimizelySDK.Config;
 using OptimizelySDK.Entity;

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -395,7 +395,6 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [user_1] is in experiment [group_experiment_1] of group [7722400015]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [9525] to user [user_1] with bucketing ID [user_1]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [user_1] is in variation [group_exp_1_var_2] of experiment [group_experiment_1]."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Activating user user_1 in experiment group_experiment_1."), Times.Once);            
 
             Assert.IsTrue(TestData.CompareObjects(GroupVariation, variation));
         }
@@ -430,7 +429,6 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [3037] to user [test_user] with bucketing ID [test_user]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [test_user] is in variation [control] of experiment [test_experiment]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "This decision will not be saved since the UserProfileService is null."));
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Activating user test_user in experiment test_experiment."), Times.Once);                        
 
             Assert.IsTrue(TestData.CompareObjects(VariationWithKeyControl, variation));
         }
@@ -450,7 +448,6 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "User \"test_user\" is not in the forced variation map."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [3037] to user [test_user] with bucketing ID [test_user]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [test_user] is in variation [control] of experiment [test_experiment]."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Activating user test_user in experiment test_experiment."), Times.Once);
 
             Assert.IsTrue(TestData.CompareObjects(VariationWithKeyControl, variation));
         }
@@ -490,7 +487,6 @@ namespace OptimizelySDK.Tests
 
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [3037] to user [test_user] with bucketing ID [test_user]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [test_user] is in variation [control] of experiment [test_experiment]."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Activating user test_user in experiment test_experiment."), Times.Once);            
 
             Assert.IsTrue(TestData.CompareObjects(VariationWithKeyControl, variation));
         }
@@ -683,7 +679,6 @@ namespace OptimizelySDK.Tests
 
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [3037] to user [test_user] with bucketing ID [test_user]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [test_user] is in variation [control] of experiment [test_experiment]."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Activating user test_user in experiment test_experiment."), Times.Once);
             
             // Need to see how error handler can be verified.
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, It.IsAny<string>()), Times.Once);
@@ -1079,7 +1074,6 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [9525] to user [user_1] with bucketing ID [user_1]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [user_1] is in variation [group_exp_1_var_2] of experiment [group_experiment_1]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "This decision will not be saved since the UserProfileService is null."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Activating user user_1 in experiment group_experiment_1."), Times.Once);            
 
             Assert.IsTrue(TestData.CompareObjects(GroupVariation, variation));
         }

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -395,6 +395,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [user_1] is in experiment [group_experiment_1] of group [7722400015]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [9525] to user [user_1] with bucketing ID [user_1]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [user_1] is in variation [group_exp_1_var_2] of experiment [group_experiment_1]."), Times.Once);
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Activating user user_1 in experiment group_experiment_1."), Times.Once);
 
             Assert.IsTrue(TestData.CompareObjects(GroupVariation, variation));
         }
@@ -429,6 +430,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [3037] to user [test_user] with bucketing ID [test_user]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [test_user] is in variation [control] of experiment [test_experiment]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "This decision will not be saved since the UserProfileService is null."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Activating user test_user in experiment test_experiment."), Times.Once);
 
             Assert.IsTrue(TestData.CompareObjects(VariationWithKeyControl, variation));
         }
@@ -448,6 +450,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "User \"test_user\" is not in the forced variation map."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [3037] to user [test_user] with bucketing ID [test_user]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [test_user] is in variation [control] of experiment [test_experiment]."), Times.Once);
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Activating user test_user in experiment test_experiment."), Times.Once);
 
             Assert.IsTrue(TestData.CompareObjects(VariationWithKeyControl, variation));
         }
@@ -487,6 +490,7 @@ namespace OptimizelySDK.Tests
 
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [3037] to user [test_user] with bucketing ID [test_user]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [test_user] is in variation [control] of experiment [test_experiment]."), Times.Once);
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Activating user test_user in experiment test_experiment."), Times.Once);
 
             Assert.IsTrue(TestData.CompareObjects(VariationWithKeyControl, variation));
         }
@@ -680,6 +684,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [3037] to user [test_user] with bucketing ID [test_user]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [test_user] is in variation [control] of experiment [test_experiment]."), Times.Once);
             
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Activating user test_user in experiment test_experiment."), Times.Once);
             // Need to see how error handler can be verified.
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, It.IsAny<string>()), Times.Once);
 
@@ -1074,6 +1079,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [9525] to user [user_1] with bucketing ID [user_1]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [user_1] is in variation [group_exp_1_var_2] of experiment [group_experiment_1]."), Times.Once);
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "This decision will not be saved since the UserProfileService is null."), Times.Once);
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "Activating user user_1 in experiment group_experiment_1."), Times.Once);
 
             Assert.IsTrue(TestData.CompareObjects(GroupVariation, variation));
         }

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -417,6 +417,14 @@ namespace OptimizelySDK.Tests
             Assert.IsTrue(TestData.CompareObjects(expectedRolloutIdMap, Config.RolloutIdMap));
         }
 
+
+        [Test]
+        public void TestIfSendFlagDecisionKeyIsMissingItShouldReturnFalse()
+        {
+            var tempConfig = DatafileProjectConfig.Create(TestData.SimpleABExperimentsDatafile, LoggerMock.Object, ErrorHandlerMock.Object);
+            Assert.IsFalse(tempConfig.SendFlagDecisions);
+        }
+
         [Test]
         public void TestGetAccountId()
         {

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -63,6 +63,8 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual("7720880029", Config.ProjectId);
             // Check Revision 
             Assert.AreEqual("15", Config.Revision);
+            // Check SendFlagDecision
+            Assert.IsTrue(Config.SendFlagDecisions);
 
             // Check Group ID Map
             var expectedGroupId = CreateDictionary("7722400015", Config.GetGroup("7722400015"));

--- a/OptimizelySDK.Tests/TestData.json
+++ b/OptimizelySDK.Tests/TestData.json
@@ -565,7 +565,7 @@
 					"key": "integer_variable",
 					"type": "integer",
 					"defaultValue": "7"
-				}				
+				}
 			]
 		},
 		{
@@ -940,5 +940,6 @@
 	],
 	"revision": "15",
 	"anonymizeIP": false,
+	"sendFlagDecisions": true,
 	"botFiltering": true
 }

--- a/OptimizelySDK.Tests/TestData.json
+++ b/OptimizelySDK.Tests/TestData.json
@@ -565,7 +565,7 @@
 					"key": "integer_variable",
 					"type": "integer",
 					"defaultValue": "7"
-				}
+				}					
 			]
 		},
 		{

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -70,6 +70,11 @@ namespace OptimizelySDK.Config
         public string Revision { get; set; }
 
         /// <summary>
+        /// SendFlagDecisions determines whether impressions events are sent for ALL decision types.
+        /// </summary>
+        public bool SendFlagDecisions { get; set; }
+        
+        /// <summary>
         /// Allow Anonymize IP by truncating the last block of visitors' IP address.
         /// </summary>
         public bool AnonymizeIP { get; set; }

--- a/OptimizelySDK/Event/Builder/EventBuilder.cs
+++ b/OptimizelySDK/Event/Builder/EventBuilder.cs
@@ -15,6 +15,7 @@
  */
 using OptimizelySDK.Bucketing;
 using OptimizelySDK.Entity;
+using OptimizelySDK.Event.Entity;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Utils;
 using System;
@@ -121,10 +122,16 @@ namespace OptimizelySDK.Event.Builder
             return comonParams;
         }
 
-        private Dictionary<string, object> GetImpressionParams(Experiment experiment, string variationId)
+        private Dictionary<string, object> GetImpressionParams(Experiment experiment,
+            string variationId,
+            string flagKey,
+            string flagType)
         {
 
             var impressionEvent = new Dictionary<string, object>();
+            
+            string variationKey = variationId != null ? experiment.VariationIdToVariationMap[variationId].Key : null;
+            var metadata = new DecisionMetadata(flagKey, flagType, variationKey);
 
             var decisions = new object[]
             {
@@ -132,7 +139,8 @@ namespace OptimizelySDK.Event.Builder
                     {
                         { Params.CAMPAIGN_ID,   experiment.LayerId },
                         { Params.EXPERIMENT_ID, experiment.Id },
-                        { Params.VARIATION_ID,  variationId }
+                        { Params.VARIATION_ID,  variationId },
+                        { Params.METADATA,  metadata }
                     }
             };
 
@@ -216,11 +224,11 @@ namespace OptimizelySDK.Event.Builder
         /// <param name="userAttributes">associative array of attributes for the user</param>
         /// <returns>LogEvent object to be sent to dispatcher</returns>
         public virtual LogEvent CreateImpressionEvent(ProjectConfig config, Experiment experiment, string variationId,
-            string userId, UserAttributes userAttributes)
+            string userId, UserAttributes userAttributes, string flagKey, string flagType)
         {
 
             var commonParams = GetCommonParams(config, userId, userAttributes ?? new UserAttributes());
-            var impressionOnlyParams = GetImpressionParams(experiment, variationId);
+            var impressionOnlyParams = GetImpressionParams(experiment, variationId, flagKey, flagType);
 
             var impressionParams = GetImpressionOrConversionParamsWithCommonParams(commonParams, new object[] { impressionOnlyParams });
 

--- a/OptimizelySDK/Event/Builder/EventBuilder.cs
+++ b/OptimizelySDK/Event/Builder/EventBuilder.cs
@@ -123,16 +123,11 @@ namespace OptimizelySDK.Event.Builder
         }
 
         private Dictionary<string, object> GetImpressionParams(Experiment experiment,
-            string variationId,
-            string flagKey,
-            string flagType)
+            string variationId)
         {
 
             var impressionEvent = new Dictionary<string, object>();
             
-            string variationKey = variationId != null ? experiment.VariationIdToVariationMap[variationId].Key : null;
-            var metadata = new DecisionMetadata(flagKey, flagType, variationKey);
-
             var decisions = new object[]
             {
                     new Dictionary<string, object>
@@ -140,7 +135,6 @@ namespace OptimizelySDK.Event.Builder
                         { Params.CAMPAIGN_ID,   experiment.LayerId },
                         { Params.EXPERIMENT_ID, experiment.Id },
                         { Params.VARIATION_ID,  variationId },
-                        { Params.METADATA,  metadata }
                     }
             };
 
@@ -224,11 +218,11 @@ namespace OptimizelySDK.Event.Builder
         /// <param name="userAttributes">associative array of attributes for the user</param>
         /// <returns>LogEvent object to be sent to dispatcher</returns>
         public virtual LogEvent CreateImpressionEvent(ProjectConfig config, Experiment experiment, string variationId,
-            string userId, UserAttributes userAttributes, string flagKey, string flagType)
+            string userId, UserAttributes userAttributes)
         {
 
             var commonParams = GetCommonParams(config, userId, userAttributes ?? new UserAttributes());
-            var impressionOnlyParams = GetImpressionParams(experiment, variationId, flagKey, flagType);
+            var impressionOnlyParams = GetImpressionParams(experiment, variationId);
 
             var impressionParams = GetImpressionOrConversionParamsWithCommonParams(commonParams, new object[] { impressionOnlyParams });
 

--- a/OptimizelySDK/Event/Builder/EventBuilder.cs
+++ b/OptimizelySDK/Event/Builder/EventBuilder.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2017-2019, Optimizely
+ * Copyright 2017-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OptimizelySDK/Event/Builder/EventBuilder.cs
+++ b/OptimizelySDK/Event/Builder/EventBuilder.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2017-2020, Optimizely
+ * Copyright 2017-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,6 @@
  */
 using OptimizelySDK.Bucketing;
 using OptimizelySDK.Entity;
-using OptimizelySDK.Event.Entity;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Utils;
 using System;
@@ -122,19 +121,18 @@ namespace OptimizelySDK.Event.Builder
             return comonParams;
         }
 
-        private Dictionary<string, object> GetImpressionParams(Experiment experiment,
-            string variationId)
+        private Dictionary<string, object> GetImpressionParams(Experiment experiment, string variationId)
         {
 
             var impressionEvent = new Dictionary<string, object>();
-            
+
             var decisions = new object[]
             {
                     new Dictionary<string, object>
                     {
                         { Params.CAMPAIGN_ID,   experiment.LayerId },
                         { Params.EXPERIMENT_ID, experiment.Id },
-                        { Params.VARIATION_ID,  variationId },
+                        { Params.VARIATION_ID,  variationId }
                     }
             };
 

--- a/OptimizelySDK/Event/Builder/Params.cs
+++ b/OptimizelySDK/Event/Builder/Params.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using OptimizelySDK.Event.Entity;
 using System;
 
 namespace OptimizelySDK.Event.Builder
@@ -30,6 +31,7 @@ namespace OptimizelySDK.Event.Builder
         public const string ENTITY_ID           = "entity_id";
         public const string EVENTS              = "events";
         public const string EXPERIMENT_ID       = "experiment_id";
+        public const string METADATA            = "metadata";
         public const string PROJECT_ID          = "project_id";
         public const string REVISION            = "revision";
         public const string TIME                = "timestamp";

--- a/OptimizelySDK/Event/Builder/Params.cs
+++ b/OptimizelySDK/Event/Builder/Params.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2017, 2019, Optimizely
+ * Copyright 2017, 2019-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OptimizelySDK/Event/Entity/Decision.cs
+++ b/OptimizelySDK/Event/Entity/Decision.cs
@@ -23,15 +23,17 @@ namespace OptimizelySDK.Event.Entity
         public string CampaignId { get; private set; }
         [JsonProperty("experiment_id")]
         public string ExperimentId { get; private set; }
+        [JsonProperty("metadata")]
+        public DecisionMetadata Metadata { get; private set; }
         [JsonProperty("variation_id")]
         public string VariationId { get; private set; }
-
         public Decision() {}
 
-        public Decision(string campaignId, string experimentId, string variationId)
+        public Decision(string campaignId, string experimentId, string variationId, DecisionMetadata metadata)
         {
             CampaignId = campaignId;
             ExperimentId = experimentId;
+            Metadata = metadata;
             VariationId = variationId;
         }
     }

--- a/OptimizelySDK/Event/Entity/Decision.cs
+++ b/OptimizelySDK/Event/Entity/Decision.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2019, Optimizely
+ * Copyright 2019-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OptimizelySDK/Event/Entity/Decision.cs
+++ b/OptimizelySDK/Event/Entity/Decision.cs
@@ -29,7 +29,7 @@ namespace OptimizelySDK.Event.Entity
         public string VariationId { get; private set; }
         public Decision() {}
 
-        public Decision(string campaignId, string experimentId, string variationId, DecisionMetadata metadata)
+        public Decision(string campaignId, string experimentId, string variationId, DecisionMetadata metadata = null)
         {
             CampaignId = campaignId;
             ExperimentId = experimentId;

--- a/OptimizelySDK/Event/Entity/DecisionMetadata.cs
+++ b/OptimizelySDK/Event/Entity/DecisionMetadata.cs
@@ -1,0 +1,20 @@
+﻿
+namespace OptimizelySDK.Event.Entity
+{
+    /// <summary>
+    /// DecisionMetadata captures additional information regarding the decision
+    /// </summary>
+    public class DecisionMetadata
+    {
+        public string FlagType { get; private set; }
+        public string FlagKey { get; private set; }
+        public string VariationKey { get; private set; }
+
+        public DecisionMetadata(string flagKey, string flagType, string variationKey = null) 
+        {
+            FlagType = flagType;
+            FlagKey = flagKey;
+            VariationKey = variationKey;
+        }
+    }
+}

--- a/OptimizelySDK/Event/Entity/DecisionMetadata.cs
+++ b/OptimizelySDK/Event/Entity/DecisionMetadata.cs
@@ -1,4 +1,22 @@
-﻿
+﻿/**
+ *
+ *    Copyright 2020, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+using Newtonsoft.Json;
+
 namespace OptimizelySDK.Event.Entity
 {
     /// <summary>
@@ -6,8 +24,11 @@ namespace OptimizelySDK.Event.Entity
     /// </summary>
     public class DecisionMetadata
     {
+        [JsonProperty("flag_type")]
         public string FlagType { get; private set; }
+        [JsonProperty("flag_key")]
         public string FlagKey { get; private set; }
+        [JsonProperty("variation_key")]
         public string VariationKey { get; private set; }
 
         public DecisionMetadata(string flagKey, string flagType, string variationKey = null) 

--- a/OptimizelySDK/Event/Entity/DecisionMetadata.cs
+++ b/OptimizelySDK/Event/Entity/DecisionMetadata.cs
@@ -24,17 +24,20 @@ namespace OptimizelySDK.Event.Entity
     /// </summary>
     public class DecisionMetadata
     {
-        [JsonProperty("flag_type")]
-        public string FlagType { get; private set; }
         [JsonProperty("flag_key")]
         public string FlagKey { get; private set; }
+        [JsonProperty("rule_key")]
+        public string RuleKey { get; private set; }
+        [JsonProperty("rule_type")]
+        public string RuleType { get; private set; }
         [JsonProperty("variation_key")]
         public string VariationKey { get; private set; }
 
-        public DecisionMetadata(string flagKey, string flagType, string variationKey = null) 
+        public DecisionMetadata(string flagKey, string ruleKey, string ruleType, string variationKey = "") 
         {
-            FlagType = flagType;
             FlagKey = flagKey;
+            RuleKey = ruleKey;
+            RuleType = ruleType;
             VariationKey = variationKey;
         }
     }

--- a/OptimizelySDK/Event/Entity/ImpressionEvent.cs
+++ b/OptimizelySDK/Event/Entity/ImpressionEvent.cs
@@ -28,6 +28,7 @@ namespace OptimizelySDK.Event.Entity
         public VisitorAttribute[] VisitorAttributes { get; private set; }
 
         public Experiment Experiment { get; set; }
+        public DecisionMetadata Metadata { get; set; }
         public Variation Variation { get; set; }
         public bool? BotFiltering { get; set; }
 
@@ -42,6 +43,7 @@ namespace OptimizelySDK.Event.Entity
             public VisitorAttribute[] VisitorAttributes;
             private Experiment Experiment;
             private Variation Variation;
+            private DecisionMetadata Metadata;
             private bool? BotFiltering;
 
             public Builder WithUserId(string userId)
@@ -61,6 +63,13 @@ namespace OptimizelySDK.Event.Entity
             public Builder WithExperiment(Experiment experiment)
             {
                 Experiment = experiment;
+
+                return this;
+            }
+
+            public Builder WithMetadata(DecisionMetadata metadata)
+            {
+                Metadata = metadata;
 
                 return this;
             }
@@ -102,6 +111,7 @@ namespace OptimizelySDK.Event.Entity
                 impressionEvent.VisitorAttributes = VisitorAttributes;
                 impressionEvent.UserId = UserId;
                 impressionEvent.Variation = Variation;
+                impressionEvent.Metadata = Metadata;
                 impressionEvent.BotFiltering = BotFiltering;
 
                 return impressionEvent;

--- a/OptimizelySDK/Event/Entity/ImpressionEvent.cs
+++ b/OptimizelySDK/Event/Entity/ImpressionEvent.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2019, Optimizely
+ * Copyright 2019-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OptimizelySDK/Event/EventFactory.cs
+++ b/OptimizelySDK/Event/EventFactory.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2019, Optimizely
+ * Copyright 2019-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OptimizelySDK/Event/EventFactory.cs
+++ b/OptimizelySDK/Event/EventFactory.cs
@@ -115,7 +115,8 @@ namespace OptimizelySDK.Event
 
             Decision decision = new Decision(impressionEvent.Experiment?.LayerId,
                 impressionEvent.Experiment?.Id,
-                impressionEvent.Variation?.Id);
+                impressionEvent.Variation?.Id,
+                impressionEvent.Metadata);
 
             SnapshotEvent snapshotEvent = new SnapshotEvent.Builder()
                 .WithUUID(impressionEvent.UUID)

--- a/OptimizelySDK/Event/EventFactory.cs
+++ b/OptimizelySDK/Event/EventFactory.cs
@@ -120,7 +120,7 @@ namespace OptimizelySDK.Event
 
             SnapshotEvent snapshotEvent = new SnapshotEvent.Builder()
                 .WithUUID(impressionEvent.UUID)
-                .WithEntityId(impressionEvent.Experiment.LayerId)
+                .WithEntityId(impressionEvent.Experiment?.LayerId)
                 .WithKey(ACTIVATE_EVENT_KEY)
                 .WithTimeStamp(impressionEvent.Timestamp)
                 .Build();

--- a/OptimizelySDK/Event/UserEventFactory.cs
+++ b/OptimizelySDK/Event/UserEventFactory.cs
@@ -1,4 +1,5 @@
-﻿using OptimizelySDK.Entity;
+﻿using OptimizelySDK.Bucketing;
+using OptimizelySDK.Entity;
 using OptimizelySDK.Event.Entity;
 
 namespace OptimizelySDK.Event
@@ -48,13 +49,17 @@ namespace OptimizelySDK.Event
                                                             string flagKey,
                                                             string flagType)
         {
-
+            if ((flagType == FeatureDecision.DECISION_SOURCE_ROLLOUT || variation == null) && !projectConfig.SendFlagDecisions)
+            {
+                return null;
+            }
+            
             var eventContext = new EventContext.Builder()
-                .WithProjectId(projectConfig.ProjectId)
-                .WithAccountId(projectConfig.AccountId)
-                .WithAnonymizeIP(projectConfig.AnonymizeIP)
-                .WithRevision(projectConfig.Revision)                
-                .Build();
+            .WithProjectId(projectConfig.ProjectId)
+            .WithAccountId(projectConfig.AccountId)
+            .WithAnonymizeIP(projectConfig.AnonymizeIP)
+            .WithRevision(projectConfig.Revision)                
+            .Build();
 
             var variationKey = variation?.Key;
             var metadata = new DecisionMetadata(flagKey, flagType, variationKey);

--- a/OptimizelySDK/Event/UserEventFactory.cs
+++ b/OptimizelySDK/Event/UserEventFactory.cs
@@ -40,10 +40,10 @@ namespace OptimizelySDK.Event
                                                             string userId,
                                                             UserAttributes userAttributes,
                                                             string flagKey,
-                                                            string flagType)
+                                                            string ruleType)
         {
             Variation variation = projectConfig.GetVariationFromId(activatedExperiment?.Key, variationId);
-            return CreateImpressionEvent(projectConfig, activatedExperiment, variation, userId, userAttributes, flagKey, flagType);
+            return CreateImpressionEvent(projectConfig, activatedExperiment, variation, userId, userAttributes, flagKey, ruleType);
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace OptimizelySDK.Event
         /// <param name="userId">The user Id</param>
         /// <param name="userAttributes">The user's attributes</param>
         /// <param name="flagKey">experiment key or feature key</param>
-        /// <param name="flagType">experiment or featureDecision source </param>
+        /// <param name="ruleType">experiment or featureDecision source </param>
         /// <returns>ImpressionEvent instance</returns>
         public static ImpressionEvent CreateImpressionEvent(ProjectConfig projectConfig,
                                                             Experiment activatedExperiment,
@@ -63,13 +63,13 @@ namespace OptimizelySDK.Event
                                                             string userId,
                                                             UserAttributes userAttributes,
                                                             string flagKey,
-                                                            string flagType)
+                                                            string ruleType)
         {
-            if ((flagType == FeatureDecision.DECISION_SOURCE_ROLLOUT || variation == null) && !projectConfig.SendFlagDecisions)
+            if ((ruleType == FeatureDecision.DECISION_SOURCE_ROLLOUT || variation == null) && !projectConfig.SendFlagDecisions)
             {
                 return null;
             }
-            
+
             var eventContext = new EventContext.Builder()
             .WithProjectId(projectConfig.ProjectId)
             .WithAccountId(projectConfig.AccountId)
@@ -77,8 +77,16 @@ namespace OptimizelySDK.Event
             .WithRevision(projectConfig.Revision)                
             .Build();
 
-            var variationKey = variation?.Key;
-            var metadata = new DecisionMetadata(flagKey, flagType, variationKey);
+            var variationKey = ""; 
+            var ruleKey = "";   
+            var finalRuleType = "";   
+            if (variation != null)
+            {
+                variationKey = variation.Key;
+                ruleKey = activatedExperiment.Key;
+                finalRuleType = ruleType;
+            }
+            var metadata = new DecisionMetadata(flagKey, ruleKey, finalRuleType, variationKey);
 
             return new ImpressionEvent.Builder()
                 .WithEventContext(eventContext)

--- a/OptimizelySDK/Event/UserEventFactory.cs
+++ b/OptimizelySDK/Event/UserEventFactory.cs
@@ -21,10 +21,12 @@ namespace OptimizelySDK.Event
                                                             Experiment activatedExperiment,
                                                             string variationId,
                                                             string userId,
-                                                            UserAttributes userAttributes)
+                                                            UserAttributes userAttributes,
+                                                            string flagKey,
+                                                            string flagType)
         {
             Variation variation = projectConfig.GetVariationFromId(activatedExperiment?.Key, variationId);
-            return CreateImpressionEvent(projectConfig, activatedExperiment, variation, userId, userAttributes);
+            return CreateImpressionEvent(projectConfig, activatedExperiment, variation, userId, userAttributes, flagKey, flagType);
         }
 
         /// <summary>
@@ -35,12 +37,16 @@ namespace OptimizelySDK.Event
         /// <param name="variation">The variation entity</param>
         /// <param name="userId">The user Id</param>
         /// <param name="userAttributes">The user's attributes</param>
+        /// <param name="flagKey">experiment key or feature key</param>
+        /// <param name="flagType">experiment or featureDecision source </param>
         /// <returns>ImpressionEvent instance</returns>
         public static ImpressionEvent CreateImpressionEvent(ProjectConfig projectConfig,
                                                             Experiment activatedExperiment,
                                                             Variation variation,
                                                             string userId,
-                                                            UserAttributes userAttributes)
+                                                            UserAttributes userAttributes,
+                                                            string flagKey,
+                                                            string flagType)
         {
 
             var eventContext = new EventContext.Builder()
@@ -50,10 +56,14 @@ namespace OptimizelySDK.Event
                 .WithRevision(projectConfig.Revision)                
                 .Build();
 
+            var variationKey = variation?.Key;
+            var metadata = new DecisionMetadata(flagKey, flagType, variationKey);
+
             return new ImpressionEvent.Builder()
                 .WithEventContext(eventContext)
                 .WithBotFilteringEnabled(projectConfig.BotFiltering)
                 .WithExperiment(activatedExperiment)
+                .WithMetadata(metadata)
                 .WithUserId(userId)
                 .WithVariation(variation)
                 .WithVisitorAttributes(EventFactory.BuildAttributeList(userAttributes, projectConfig))

--- a/OptimizelySDK/Event/UserEventFactory.cs
+++ b/OptimizelySDK/Event/UserEventFactory.cs
@@ -79,14 +79,12 @@ namespace OptimizelySDK.Event
 
             var variationKey = ""; 
             var ruleKey = "";   
-            var finalRuleType = "";   
             if (variation != null)
             {
                 variationKey = variation.Key;
                 ruleKey = activatedExperiment.Key;
-                finalRuleType = ruleType;
             }
-            var metadata = new DecisionMetadata(flagKey, ruleKey, finalRuleType, variationKey);
+            var metadata = new DecisionMetadata(flagKey, ruleKey, ruleType, variationKey);
 
             return new ImpressionEvent.Builder()
                 .WithEventContext(eventContext)

--- a/OptimizelySDK/Event/UserEventFactory.cs
+++ b/OptimizelySDK/Event/UserEventFactory.cs
@@ -1,4 +1,20 @@
-﻿using OptimizelySDK.Bucketing;
+﻿/**
+ *
+ *    Copyright 2019-2020, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
 using OptimizelySDK.Entity;
 using OptimizelySDK.Event.Entity;
 

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -701,8 +701,11 @@ namespace OptimizelySDK
                 return;
             }
             EventProcessor.Process(userEvent);
-            //Logger.Log(LogLevel.INFO, $"Activating user {userId} in experiment {experiment.Key}.");
 
+            if (experiment != null)
+            { 
+                Logger.Log(LogLevel.INFO, $"Activating user {userId} in experiment {experiment.Key}.");
+            }
             // Kept For backwards compatibility.
             // This notification is deprecated and the new DecisionNotifications
             // are sent via their respective method calls.

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -688,14 +688,14 @@ namespace OptimizelySDK
         /// <param name="userAttributes">The user's attributes</param>
         private void SendImpressionEvent(Experiment experiment, Variation variation, string userId,
                                          UserAttributes userAttributes, ProjectConfig config,
-                                         string flagKey, string flagType)
+                                         string flagKey, string ruleType)
         {
             if (experiment != null && !experiment.IsExperimentRunning)
             {
                 Logger.Log(LogLevel.ERROR, @"Experiment has ""Launched"" status so not dispatching event during activation.");
             }
             
-            var userEvent = UserEventFactory.CreateImpressionEvent(config, experiment, variation, userId, userAttributes, flagKey, flagType);
+            var userEvent = UserEventFactory.CreateImpressionEvent(config, experiment, variation, userId, userAttributes, flagKey, ruleType);
             if (userEvent == null)
             {
                 return;

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -690,29 +690,27 @@ namespace OptimizelySDK
                                          UserAttributes userAttributes, ProjectConfig config,
                                          string flagKey, string flagType)
         {
-            if (experiment.IsExperimentRunning)
-            {
-                var userEvent = UserEventFactory.CreateImpressionEvent(config, experiment, variation.Id, userId, userAttributes, flagKey, flagType);
-                if (userEvent == null)
-                {
-                    return;
-                }
-                EventProcessor.Process(userEvent);
-                Logger.Log(LogLevel.INFO, $"Activating user {userId} in experiment {experiment.Key}.");
-
-                // Kept For backwards compatibility.
-                // This notification is deprecated and the new DecisionNotifications
-                // are sent via their respective method calls.
-                if (NotificationCenter.GetNotificationCount(NotificationCenter.NotificationType.Activate) > 0)
-                {
-                    var impressionEvent = EventFactory.CreateLogEvent(userEvent, Logger);
-                    NotificationCenter.SendNotifications(NotificationCenter.NotificationType.Activate, experiment, userId,
-                    userAttributes, variation, impressionEvent);
-                }
-            }
-            else
+            if (experiment != null && !experiment.IsExperimentRunning)
             {
                 Logger.Log(LogLevel.ERROR, @"Experiment has ""Launched"" status so not dispatching event during activation.");
+            }
+            
+            var userEvent = UserEventFactory.CreateImpressionEvent(config, experiment, variation, userId, userAttributes, flagKey, flagType);
+            if (userEvent == null)
+            {
+                return;
+            }
+            EventProcessor.Process(userEvent);
+            //Logger.Log(LogLevel.INFO, $"Activating user {userId} in experiment {experiment.Key}.");
+
+            // Kept For backwards compatibility.
+            // This notification is deprecated and the new DecisionNotifications
+            // are sent via their respective method calls.
+            if (NotificationCenter.GetNotificationCount(NotificationCenter.NotificationType.Activate) > 0)
+            {
+                var impressionEvent = EventFactory.CreateLogEvent(userEvent, Logger);
+                NotificationCenter.SendNotifications(NotificationCenter.NotificationType.Activate, experiment, userId,
+                userAttributes, variation, impressionEvent);
             }
         }
 

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -252,7 +252,7 @@ namespace OptimizelySDK
                 return null;
             }
 
-            SendImpressionEvent(experiment, variation, userId, userAttributes, config, experimentKey, "experiment");
+            SendImpressionEvent(experiment, variation, userId, userAttributes, config, "experiment");
 
             return variation;
         }
@@ -471,8 +471,13 @@ namespace OptimizelySDK
             var sourceInfo = new Dictionary<string, string>();
             var decision = DecisionService.GetVariationForFeature(featureFlag, userId, config, userAttributes);
             var variation = decision.Variation;
+            var decisionSource = FeatureDecision.DECISION_SOURCE_ROLLOUT;
+            if (decisionSource != null)
+            {
+                decisionSource = decision.Source;
+            }
 
-            SendImpressionEvent(decision.Experiment, variation, userId, userAttributes, config, featureKey, decision.Source);
+            SendImpressionEvent(decision.Experiment, variation, userId, userAttributes, config, featureKey, decisionSource);
 
             if (variation != null)
             {
@@ -686,6 +691,23 @@ namespace OptimizelySDK
         /// <param name="variation">The variation entity</param>
         /// <param name="userId">The user ID</param>
         /// <param name="userAttributes">The user's attributes</param>
+        /// <param name="ruleType">It can either be experiment in case impression event is sent from activate or it's feature-test or rollout</param>
+        private void SendImpressionEvent(Experiment experiment, Variation variation, string userId,
+                                         UserAttributes userAttributes, ProjectConfig config,
+                                         string ruleType)
+        {
+            SendImpressionEvent(experiment, variation, userId, userAttributes, config, "", ruleType);
+        }
+
+        /// <summary>
+        /// Sends impression event.
+        /// </summary>
+        /// <param name="experiment">The experiment</param>
+        /// <param name="variation">The variation entity</param>
+        /// <param name="userId">The user ID</param>
+        /// <param name="userAttributes">The user's attributes</param>
+        /// <param name="flagKey">It can either be experiment key in case if ruleType is experiment or it's feature key in case ruleType is feature-test or rollout</param>
+        /// <param name="ruleType">It can either be experiment in case impression event is sent from activate or it's feature-test or rollout</param>
         private void SendImpressionEvent(Experiment experiment, Variation variation, string userId,
                                          UserAttributes userAttributes, ProjectConfig config,
                                          string flagKey, string ruleType)

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -478,6 +478,8 @@ namespace OptimizelySDK
             {
                 featureEnabled = variation.FeatureEnabled.GetValueOrDefault();
 
+                // This information is only necessary for feature tests.
+                // For rollouts experiments and variations are an implementation detail only.
                 if (decision.Source == FeatureDecision.DECISION_SOURCE_FEATURE_TEST)
                 {
                     sourceInfo["experimentKey"] = decision.Experiment.Key;
@@ -691,6 +693,10 @@ namespace OptimizelySDK
             if (experiment.IsExperimentRunning)
             {
                 var userEvent = UserEventFactory.CreateImpressionEvent(config, experiment, variation.Id, userId, userAttributes, flagKey, flagType);
+                if (userEvent == null)
+                {
+                    return;
+                }
                 EventProcessor.Process(userEvent);
                 Logger.Log(LogLevel.INFO, $"Activating user {userId} in experiment {experiment.Key}.");
 

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -100,6 +100,8 @@ namespace OptimizelySDK
         public const string EVENT_KEY = "Event Key";
         public const string FEATURE_KEY = "Feature Key";
         public const string VARIABLE_KEY = "Variable Key";
+        private const string SOURCE_TYPE_EXPERIMENT = "experiment";
+
         public bool Disposed { get; private set; }
 
         /// <summary>
@@ -252,7 +254,7 @@ namespace OptimizelySDK
                 return null;
             }
 
-            SendImpressionEvent(experiment, variation, userId, userAttributes, config, "experiment");
+            SendImpressionEvent(experiment, variation, userId, userAttributes, config, SOURCE_TYPE_EXPERIMENT);
 
             return variation;
         }
@@ -471,11 +473,7 @@ namespace OptimizelySDK
             var sourceInfo = new Dictionary<string, string>();
             var decision = DecisionService.GetVariationForFeature(featureFlag, userId, config, userAttributes);
             var variation = decision.Variation;
-            var decisionSource = FeatureDecision.DECISION_SOURCE_ROLLOUT;
-            if (decisionSource != null)
-            {
-                decisionSource = decision.Source;
-            }
+            var decisionSource = decision?.Source ?? FeatureDecision.DECISION_SOURCE_ROLLOUT;
 
             SendImpressionEvent(decision.Experiment, variation, userId, userAttributes, config, featureKey, decisionSource);
 

--- a/OptimizelySDK/OptimizelySDK.csproj
+++ b/OptimizelySDK/OptimizelySDK.csproj
@@ -86,6 +86,7 @@
     <Compile Include="Entity\ForcedVariation.cs" />
     <Compile Include="Entity\Group.cs" />
     <Compile Include="Entity\IdKeyEntity.cs" />
+    <Compile Include="Event\Entity\DecisionMetadata.cs" />
     <Compile Include="OptimizelyJSON.cs" />
     <Compile Include="Entity\Rollout.cs" />
     <Compile Include="Entity\TrafficAllocation.cs" />

--- a/OptimizelySDK/ProjectConfig.cs
+++ b/OptimizelySDK/ProjectConfig.cs
@@ -44,6 +44,12 @@ namespace OptimizelySDK
         /// </summary>
         string Revision { get; set; }
 
+
+        /// <summary>
+        /// SendFlagDecisions determines whether impressions events are sent for ALL decision types.
+        /// </summary>
+        bool SendFlagDecisions { get; set; }
+
         /// <summary>
         /// Allow Anonymize IP by truncating the last block of visitors' IP address.
         /// </summary>


### PR DESCRIPTION
## Summary
* Add experiment/feature flag key, variation key and type to impression events.
* Send events for **ALL** decision types.
* Add `Metadata` field to EventBatch.Decisions to capture flag type, key and variation key.

## Test plan
* All FSC and unit tests should pass