### PR TITLE
feat: added enabled field in metadata.

### DIFF
--- a/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
@@ -87,7 +87,8 @@ namespace OptimizelySDK.Tests.EventTests
                                                             { "rule_type", "experiment" },
                                                             { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
-                                                            { "variation_key", "control" }
+                                                            { "variation_key", "control" },
+                                                            {"enabled", false }
                                                         } }
                                                     }
                                                 }
@@ -168,7 +169,9 @@ namespace OptimizelySDK.Tests.EventTests
                                                             { "rule_type", "experiment" },
                                                             { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
-                                                            { "variation_key", "control" }
+                                                            { "variation_key", "control" },
+                                                            {"enabled", false }
+
                                                         }
                                                     }
                                                 }
@@ -268,7 +271,8 @@ namespace OptimizelySDK.Tests.EventTests
                                                             { "rule_type", "experiment" },
                                                             { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
-                                                            { "variation_key", "control" }
+                                                            { "variation_key", "control" },
+                                                            {"enabled", false }
                                                         }
                                                     }
                                                 }
@@ -390,7 +394,8 @@ namespace OptimizelySDK.Tests.EventTests
                                                            { "rule_type", "experiment" },
                                                            { "rule_key", "test_experiment" },
                                                            { "flag_key", "test_experiment" },
-                                                           { "variation_key", "control" }
+                                                           { "variation_key", "control" },
+                                                           {"enabled", false }
                                                         }
                                                     }
                                                 }
@@ -512,7 +517,8 @@ namespace OptimizelySDK.Tests.EventTests
                                                             { "rule_type", "rollout" },
                                                             { "rule_key", "" },
                                                             { "flag_key", "test_feature" },
-                                                            { "variation_key", "" }
+                                                            { "variation_key", "" },
+                                                            { "enabled", false }
                                                         }
                                                     }
                                                 }
@@ -1526,7 +1532,8 @@ namespace OptimizelySDK.Tests.EventTests
                                                             { "rule_type", "experiment" },
                                                             { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
-                                                            { "variation_key", "control" }
+                                                            { "variation_key", "control" },
+                                                            {"enabled", false }
                                                         }
                                                     }
                                                 }
@@ -1633,7 +1640,8 @@ namespace OptimizelySDK.Tests.EventTests
                                                             { "rule_type", "experiment" },
                                                             { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
-                                                            { "variation_key", "control" }
+                                                            { "variation_key", "control" },
+                                                            {"enabled", false }
                                                         }
                                                     }
                                                 }
@@ -1736,7 +1744,8 @@ namespace OptimizelySDK.Tests.EventTests
                                                             { "rule_type", "experiment" },
                                                             { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
-                                                            { "variation_key", "control" }
+                                                            { "variation_key", "control" },
+                                                            {"enabled", false }
                                                         }
                                                     }
                                                 }

--- a/OptimizelySDK/Event/Entity/DecisionMetadata.cs
+++ b/OptimizelySDK/Event/Entity/DecisionMetadata.cs
@@ -32,13 +32,16 @@ namespace OptimizelySDK.Event.Entity
         public string RuleType { get; private set; }
         [JsonProperty("variation_key")]
         public string VariationKey { get; private set; }
+        [JsonProperty("enabled")]
+        public bool Enabled { get; private set; }
 
-        public DecisionMetadata(string flagKey, string ruleKey, string ruleType, string variationKey = "") 
+        public DecisionMetadata(string flagKey, string ruleKey, string ruleType, string variationKey = "", bool enabled = false) 
         {
             FlagKey = flagKey;
             RuleKey = ruleKey;
             RuleType = ruleType;
             VariationKey = variationKey;
+            Enabled = enabled;
         }
     }
 }

--- a/OptimizelySDK/Event/UserEventFactory.cs
+++ b/OptimizelySDK/Event/UserEventFactory.cs
@@ -40,10 +40,11 @@ namespace OptimizelySDK.Event
                                                             string userId,
                                                             UserAttributes userAttributes,
                                                             string flagKey,
-                                                            string ruleType)
+                                                            string ruleType,
+                                                            bool enabled = false)
         {
             Variation variation = projectConfig.GetVariationFromId(activatedExperiment?.Key, variationId);
-            return CreateImpressionEvent(projectConfig, activatedExperiment, variation, userId, userAttributes, flagKey, ruleType);
+            return CreateImpressionEvent(projectConfig, activatedExperiment, variation, userId, userAttributes, flagKey, ruleType, enabled);
         }
 
         /// <summary>
@@ -63,7 +64,8 @@ namespace OptimizelySDK.Event
                                                             string userId,
                                                             UserAttributes userAttributes,
                                                             string flagKey,
-                                                            string ruleType)
+                                                            string ruleType,
+                                                            bool enabled = false)
         {
             if ((ruleType == FeatureDecision.DECISION_SOURCE_ROLLOUT || variation == null) && !projectConfig.SendFlagDecisions)
             {
@@ -84,7 +86,7 @@ namespace OptimizelySDK.Event
                 variationKey = variation.Key;
                 ruleKey = activatedExperiment.Key;
             }
-            var metadata = new DecisionMetadata(flagKey, ruleKey, ruleType, variationKey);
+            var metadata = new DecisionMetadata(flagKey, ruleKey, ruleType, variationKey, enabled);
 
             return new ImpressionEvent.Builder()
                 .WithEventContext(eventContext)

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -254,7 +254,7 @@ namespace OptimizelySDK
                 return null;
             }
 
-            SendImpressionEvent(experiment, variation, userId, userAttributes, config, SOURCE_TYPE_EXPERIMENT);
+            SendImpressionEvent(experiment, variation, userId, userAttributes, config, SOURCE_TYPE_EXPERIMENT, true);
 
             return variation;
         }
@@ -475,7 +475,6 @@ namespace OptimizelySDK
             var variation = decision.Variation;
             var decisionSource = decision?.Source ?? FeatureDecision.DECISION_SOURCE_ROLLOUT;
 
-            SendImpressionEvent(decision.Experiment, variation, userId, userAttributes, config, featureKey, decisionSource);
 
             if (variation != null)
             {
@@ -506,6 +505,8 @@ namespace OptimizelySDK
                 { "source", decision.Source },
                 { "sourceInfo", sourceInfo },
             };
+
+            SendImpressionEvent(decision.Experiment, variation, userId, userAttributes, config, featureKey, decisionSource, featureEnabled);
 
             NotificationCenter.SendNotifications(NotificationCenter.NotificationType.Decision, DecisionNotificationTypes.FEATURE, userId,
                userAttributes ?? new UserAttributes(), decisionInfo);
@@ -692,9 +693,9 @@ namespace OptimizelySDK
         /// <param name="ruleType">It can either be experiment in case impression event is sent from activate or it's feature-test or rollout</param>
         private void SendImpressionEvent(Experiment experiment, Variation variation, string userId,
                                          UserAttributes userAttributes, ProjectConfig config,
-                                         string ruleType)
+                                         string ruleType, bool enabled)
         {
-            SendImpressionEvent(experiment, variation, userId, userAttributes, config, "", ruleType);
+            SendImpressionEvent(experiment, variation, userId, userAttributes, config, "", ruleType, enabled);
         }
 
         /// <summary>
@@ -708,14 +709,14 @@ namespace OptimizelySDK
         /// <param name="ruleType">It can either be experiment in case impression event is sent from activate or it's feature-test or rollout</param>
         private void SendImpressionEvent(Experiment experiment, Variation variation, string userId,
                                          UserAttributes userAttributes, ProjectConfig config,
-                                         string flagKey, string ruleType)
+                                         string flagKey, string ruleType, bool enabled)
         {
             if (experiment != null && !experiment.IsExperimentRunning)
             {
                 Logger.Log(LogLevel.ERROR, @"Experiment has ""Launched"" status so not dispatching event during activation.");
             }
             
-            var userEvent = UserEventFactory.CreateImpressionEvent(config, experiment, variation, userId, userAttributes, flagKey, ruleType);
+            var userEvent = UserEventFactory.CreateImpressionEvent(config, experiment, variation, userId, userAttributes, flagKey, ruleType, enabled);
             if (userEvent == null)
             {
                 return;


### PR DESCRIPTION
## Summary
- While sending impression events, metadata should have enabled field as well.

## Test plan
- updated unit tests
- FSC should pass
- Custom Trigger  - https://travis-ci.com/github/optimizely/fullstack-sdk-compatibility-suite/builds/199495582