### PR TITLE
Feat: Added unit tests for reasons addInfo logs 

### DIFF
--- a/OptimizelySDK.Tests/BucketerTest.cs
+++ b/OptimizelySDK.Tests/BucketerTest.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2017, 2019, Optimizely
+ * Copyright 2017, 2019-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OptimizelySDK.Tests/BucketerTest.cs
+++ b/OptimizelySDK.Tests/BucketerTest.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2017, 2019-2020, Optimizely
+ * Copyright 2017, 2019-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OptimizelySDK.Tests/BucketerTest.cs
+++ b/OptimizelySDK.Tests/BucketerTest.cs
@@ -61,7 +61,7 @@ namespace OptimizelySDK.Tests
         public void Initialize()
         {
             LoggerMock = new Mock<ILogger>();
-            DecisionReasons = DefaultDecisionReasons.NewInstance();
+            DecisionReasons = DefaultDecisionReasons.NewInstance(new OptimizelyDecideOption[] { OptimizelyDecideOption.INCLUDE_REASONS });
             Config = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object, new ErrorHandler.NoOpErrorHandler());
         }
 
@@ -105,6 +105,8 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(2));
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [3000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [testUserId] is in variation [control] of experiment [test_experiment]."));
+            Assert.AreEqual(DecisionReasons.ToReport()[0], "User [testUserId] is in variation [control] of experiment [test_experiment].");
+
             // variation
             Assert.AreEqual(new Variation { Id = "7721010009", Key = "variation" },
                 bucketer.Bucket(Config, Config.GetExperimentFromKey("test_experiment"), TestBucketingIdControl, TestUserId, DecisionReasons));
@@ -112,6 +114,7 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(4));
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [7000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [testUserId] is in variation [variation] of experiment [test_experiment]."));
+            Assert.AreEqual(DecisionReasons.ToReport()[1], "User [testUserId] is in variation [variation] of experiment [test_experiment].");
 
             // no variation
             Assert.AreEqual(new Variation { },
@@ -120,7 +123,9 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(6));
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [9000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [testUserId] is in no variation."));
-            Assert.AreEqual(DecisionReasons.ToReport().Count, 0);
+            Assert.AreEqual(DecisionReasons.ToReport()[2], "User [testUserId] is in no variation.");
+
+            Assert.AreEqual(DecisionReasons.ToReport().Count, 3);
         }
 
         [Test]
@@ -155,7 +160,12 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [testUserId] is not in experiment [group_experiment_1] of group [7722400015]."));
 
             LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(10));
-            Assert.AreEqual(DecisionReasons.ToReport().Count, 0);
+            Assert.AreEqual(DecisionReasons.ToReport().Count, 5);
+            Assert.AreEqual(DecisionReasons.ToReport()[0], "User [testUserId] is in experiment [group_experiment_1] of group [7722400015].");
+            Assert.AreEqual(DecisionReasons.ToReport()[1], "User [testUserId] is in variation [group_exp_1_var_1] of experiment [group_experiment_1].");
+            Assert.AreEqual(DecisionReasons.ToReport()[2], "User [testUserId] is in experiment [group_experiment_1] of group [7722400015].");
+            Assert.AreEqual(DecisionReasons.ToReport()[3], "User [testUserId] is in variation [group_exp_1_var_2] of experiment [group_experiment_1].");
+            Assert.AreEqual(DecisionReasons.ToReport()[4], "User [testUserId] is not in experiment [group_experiment_1] of group [7722400015].");
         }
 
         [Test]
@@ -180,7 +190,8 @@ namespace OptimizelySDK.Tests
             // make sure that the bucketing ID is used for the variation bucketing and not the user ID
             Assert.AreEqual(expectedVariation, 
                 bucketer.Bucket(Config, experiment, TestBucketingIdControl, TestUserIdBucketsToVariation, DecisionReasons));
-            Assert.AreEqual(DecisionReasons.ToReport().Count, 0);
+            Assert.AreEqual(DecisionReasons.ToReport().Count, 1);
+            Assert.AreEqual(DecisionReasons.ToReport()[0], "User [bucketsToVariation!] is in variation [control] of experiment [test_experiment].");
         }
 
         // Test for invalid experiment keys, null variation should be returned
@@ -206,7 +217,9 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(expectedGroupVariation,
                 bucketer.Bucket(Config, Config.GetExperimentFromKey("group_experiment_2"), 
                 TestBucketingIdGroupExp2Var2, TestUserIdBucketsToNoGroup, DecisionReasons));
-            Assert.AreEqual(DecisionReasons.ToReport().Count, 0);
+            Assert.AreEqual(DecisionReasons.ToReport().Count, 2);
+            Assert.AreEqual(DecisionReasons.ToReport()[0], "User [testUserId] is in experiment [group_experiment_2] of group [7722400015].");
+            Assert.AreEqual(DecisionReasons.ToReport()[1], "User [testUserId] is in variation [group_exp_2_var_2] of experiment [group_experiment_2].");
         }
 
         // Make sure that user gets bucketed into the rollout rule.
@@ -220,7 +233,8 @@ namespace OptimizelySDK.Tests
 
             Assert.True(TestData.CompareObjects(expectedVariation, 
                 bucketer.Bucket(Config, rolloutRule, "testBucketingId", TestUserId, DecisionReasons)));
-            Assert.AreEqual(DecisionReasons.ToReport().Count, 0);
+            Assert.AreEqual(DecisionReasons.ToReport().Count, 1);
+            Assert.AreEqual(DecisionReasons.ToReport()[0], "User [testUserId] is in variation [177773] of experiment [177772].");
         }
     }
 }

--- a/OptimizelySDK.Tests/DecisionServiceTest.cs
+++ b/OptimizelySDK.Tests/DecisionServiceTest.cs
@@ -1,6 +1,6 @@
 ﻿/**
  *
- *    Copyright 2017-2020, Optimizely and contributors
+ *    Copyright 2017-2021, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/OptimizelySDK.Tests/UtilsTests/ExperimentUtilsTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/ExperimentUtilsTest.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2019-2020, Optimizely
+ * Copyright 2019-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OptimizelySDK.Tests/UtilsTests/ExperimentUtilsTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/ExperimentUtilsTest.cs
@@ -19,6 +19,7 @@ using NUnit.Framework;
 using OptimizelySDK.Config;
 using OptimizelySDK.Entity;
 using OptimizelySDK.Logger;
+using OptimizelySDK.OptimizelyDecisions;
 using OptimizelySDK.Utils;
 
 namespace OptimizelySDK.Tests.UtilsTests
@@ -58,10 +59,11 @@ namespace OptimizelySDK.Tests.UtilsTests
         {
             var experiment = Config.GetExperimentFromKey("feat_with_var_test");
             experiment.AudienceIds = new string[] { "3468206648" };
-            
+            var decisionReasons = DefaultDecisionReasons.NewInstance(new OptimizelyDecideOption[] { OptimizelyDecideOption.INCLUDE_REASONS });
             Assert.True(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment, null , "experiment", experiment.Key, Logger));;
-            Assert.True(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment, new UserAttributes { }, "experiment", experiment.Key, Logger));
+            Assert.True(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment, new UserAttributes { }, "experiment", experiment.Key, decisionReasons, Logger));
 
+            Assert.AreEqual(decisionReasons.ToReport()[0], "Audiences for experiment \"feat_with_var_test\" collectively evaluated to TRUE");
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Evaluating audiences for experiment ""feat_with_var_test"": [""3468206648""]."), Times.Exactly(2));
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3468206648"" with conditions: [""not"",{""name"":""input_value"",""type"":""custom_attribute"",""match"":""exists""}]"), Times.Exactly(2));
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $@"Audience ""3468206648"" evaluated to TRUE"), Times.Exactly(2));


### PR DESCRIPTION
## Summary
- Added few unit tests to test that DecisionReasons contains the info logs upon setting decideOption as INCLUDE_REASONS

## Test plan
It should pass with FSC and all unit tests should pass 
