### PR TITLE
feat(decide): clone user-context before calling optimizely decide

### DIFF
--- a/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
@@ -1,6 +1,6 @@
 ﻿/**
  *
- *    Copyright 2020, Optimizely and contributors
+ *    Copyright 2020-2021, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -181,7 +181,8 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(decision.Variables.ToDictionary(), variablesExpected.ToDictionary());
             Assert.AreEqual(decision.RuleKey, "test_experiment_multivariate");
             Assert.AreEqual(decision.FlagKey, flagKey);
-            Assert.AreEqual(decision.UserContext, user);
+            Assert.AreNotEqual(decision.UserContext, user);
+            Assert.IsTrue(TestData.CompareObjects(decision.UserContext, user));
             Assert.AreEqual(decision.Reasons.Length, 0);
         }
 
@@ -551,7 +552,8 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(decision.Variables.ToDictionary(), variablesExpected);
             Assert.AreEqual(decision.RuleKey, "test_experiment_multivariate");
             Assert.AreEqual(decision.FlagKey, flagKey);
-            Assert.AreEqual(decision.UserContext, user);
+            Assert.AreNotEqual(decision.UserContext, user);
+            Assert.IsTrue(TestData.CompareObjects(decision.UserContext, user));
             Assert.True(decision.Reasons.IsNullOrEmpty());
         }
 
@@ -580,7 +582,8 @@ namespace OptimizelySDK.Tests
             Assert.False(decision.Enabled);
             Assert.AreEqual(decision.RuleKey, "test_experiment_multivariate");
             Assert.AreEqual(decision.FlagKey, flagKey);
-            Assert.AreEqual(decision.UserContext, user);
+            Assert.AreNotEqual(decision.UserContext, user);
+            Assert.IsTrue(TestData.CompareObjects(decision.UserContext, user));
             Assert.True(decision.Reasons.IsNullOrEmpty());
 
             decision = user.Decide(flagKey, decideOptions);
@@ -611,7 +614,8 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(decision.Variables.ToDictionary(), variablesExpected.ToDictionary());
             Assert.AreEqual(decision.RuleKey, "test_experiment_multivariate");
             Assert.AreEqual(decision.FlagKey, flagKey);
-            Assert.AreEqual(decision.UserContext, user);
+            Assert.AreNotEqual(decision.UserContext, user);
+            Assert.IsTrue(TestData.CompareObjects(decision.UserContext, user));
         }
 
         [Test]
@@ -638,7 +642,8 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(decision.Variables.ToDictionary(), variablesExpected.ToDictionary());
             Assert.AreEqual(decision.RuleKey, "test_experiment_multivariate");
             Assert.AreEqual(decision.FlagKey, flagKey);
-            Assert.AreEqual(decision.UserContext, user);
+            Assert.AreNotEqual(decision.UserContext, user);
+            Assert.IsTrue(TestData.CompareObjects(decision.UserContext, user));
         }
 
         [Test]

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -46,7 +46,7 @@ namespace OptimizelySDK
             UserId = userId;
         }
 
-        private OptimizelyUserContext Clone() => new OptimizelyUserContext(Optimizely, UserId, Attributes, ErrorHandler, Logger);
+        private OptimizelyUserContext Copy() => new OptimizelyUserContext(Optimizely, UserId, GetAttributes(), ErrorHandler, Logger);
 
         /// <summary>
         /// Returns Optimizely instance associated with the UserContext.
@@ -125,7 +125,7 @@ namespace OptimizelySDK
         public OptimizelyDecision Decide(string key,
             OptimizelyDecideOption[] options)
         {
-            var optimizelyUserContext = Clone();
+            var optimizelyUserContext = Copy();
             return Optimizely.Decide(optimizelyUserContext, key, options);
         }
 
@@ -136,7 +136,7 @@ namespace OptimizelySDK
         /// <returns>A dictionary of all decision results, mapped by flag keys.</returns>
         public Dictionary<string, OptimizelyDecision> DecideForKeys(string[] keys, OptimizelyDecideOption[] options)
         {
-            var optimizelyUserContext = Clone();
+            var optimizelyUserContext = Copy();
             return Optimizely.DecideForKeys(optimizelyUserContext, keys, options);
         }
 
@@ -166,7 +166,7 @@ namespace OptimizelySDK
         /// <returns>All decision results mapped by flag keys.</returns>
         public Dictionary<string, OptimizelyDecision> DecideAll(OptimizelyDecideOption[] options)
         {
-            var optimizelyUserContext = Clone();
+            var optimizelyUserContext = Copy();
             return Optimizely.DecideAll(optimizelyUserContext, options);
         }
 

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -46,6 +46,8 @@ namespace OptimizelySDK
             UserId = userId;
         }
 
+        private OptimizelyUserContext Clone() => new OptimizelyUserContext(Optimizely, UserId, Attributes, ErrorHandler, Logger);
+
         /// <summary>
         /// Returns Optimizely instance associated with the UserContext.
         /// </summary>
@@ -123,7 +125,8 @@ namespace OptimizelySDK
         public OptimizelyDecision Decide(string key,
             OptimizelyDecideOption[] options)
         {
-            return Optimizely.Decide(this, key, options);
+            var optimizelyUserContext = Clone();
+            return Optimizely.Decide(optimizelyUserContext, key, options);
         }
 
         /// <summary>
@@ -133,7 +136,8 @@ namespace OptimizelySDK
         /// <returns>A dictionary of all decision results, mapped by flag keys.</returns>
         public Dictionary<string, OptimizelyDecision> DecideForKeys(string[] keys, OptimizelyDecideOption[] options)
         {
-            return Optimizely.DecideForKeys(this, keys, options);
+            var optimizelyUserContext = Clone();
+            return Optimizely.DecideForKeys(optimizelyUserContext, keys, options);
         }
 
         /// <summary>
@@ -162,7 +166,8 @@ namespace OptimizelySDK
         /// <returns>All decision results mapped by flag keys.</returns>
         public Dictionary<string, OptimizelyDecision> DecideAll(OptimizelyDecideOption[] options)
         {
-            return Optimizely.DecideAll(this, options);
+            var optimizelyUserContext = Clone();
+            return Optimizely.DecideAll(optimizelyUserContext, options);
         }
 
         /// <summary>

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2020, Optimizely
+ * Copyright 2020-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Clone the current user-context and pass it to optimizely.decide(), decide all and in decideForKeys
- user context can be changed while processing the decide request.
- with this fix, decide can return the copy of the original user-context as a part of the decision