### PR TITLE
Fix: SendImpressionEvent will return false when event is not sent

### DIFF
--- a/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
@@ -654,7 +654,7 @@ namespace OptimizelySDK.Tests
             var enabled = true;
             var variables = Optimizely.GetAllFeatureVariables(flagKey, UserID);
             var ruleKey = "test_experiment_with_feature_rollout";
-            var reasons = new Dictionary<string, object>();
+            var reasons = new string[] { };
             var user = Optimizely.CreateUserContext(UserID);
             user.SetAttribute("browser_type", "chrome");
 

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -811,8 +811,7 @@ namespace OptimizelySDK
             var decisionSource = flagDecisionResult.ResultObject?.Source ?? FeatureDecision.DECISION_SOURCE_ROLLOUT;
             if (!allOptions.Contains(OptimizelyDecideOption.DISABLE_DECISION_EVENT))
             {
-                SendImpressionEvent(flagDecisionResult.ResultObject?.Experiment, variation, userId, userAttributes, config, key, decisionSource, featureEnabled);
-                decisionEventDispatched = true;
+                decisionEventDispatched = SendImpressionEvent(flagDecisionResult.ResultObject?.Experiment, variation, userId, userAttributes, config, key, decisionSource, featureEnabled);
             }
             var decisionReasons = flagDecisionResult.DecisionReasons;
             var reasonsToReport = decisionReasons.ToReport(allOptions.Contains(OptimizelyDecideOption.INCLUDE_REASONS));
@@ -929,7 +928,7 @@ namespace OptimizelySDK
         /// <param name="userAttributes">The user's attributes</param>
         /// <param name="flagKey">It can either be experiment key in case if ruleType is experiment or it's feature key in case ruleType is feature-test or rollout</param>
         /// <param name="ruleType">It can either be experiment in case impression event is sent from activate or it's feature-test or rollout</param>
-        private void SendImpressionEvent(Experiment experiment, Variation variation, string userId,
+        private bool SendImpressionEvent(Experiment experiment, Variation variation, string userId,
                                          UserAttributes userAttributes, ProjectConfig config,
                                          string flagKey, string ruleType, bool enabled)
         {
@@ -941,7 +940,7 @@ namespace OptimizelySDK
             var userEvent = UserEventFactory.CreateImpressionEvent(config, experiment, variation, userId, userAttributes, flagKey, ruleType, enabled);
             if (userEvent == null)
             {
-                return;
+                return false;
             }
             EventProcessor.Process(userEvent);
 
@@ -958,6 +957,7 @@ namespace OptimizelySDK
                 NotificationCenter.SendNotifications(NotificationCenter.NotificationType.Activate, experiment, userId,
                 userAttributes, variation, impressionEvent);
             }
+            return true;
         }
 
         /// <summary>

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -814,7 +814,7 @@ namespace OptimizelySDK
                 decisionEventDispatched = SendImpressionEvent(flagDecisionResult.ResultObject?.Experiment, variation, userId, userAttributes, config, key, decisionSource, featureEnabled);
             }
             var decisionReasons = flagDecisionResult.DecisionReasons;
-            var reasonsToReport = decisionReasons.ToReport(allOptions.Contains(OptimizelyDecideOption.INCLUDE_REASONS));
+            var reasonsToReport = decisionReasons.ToReport(allOptions.Contains(OptimizelyDecideOption.INCLUDE_REASONS)).ToArray();
             var variationKey = flagDecisionResult.ResultObject?.Variation?.Key;
 
             // TODO: add ruleKey values when available later. use a copy of experimentKey until then.
@@ -827,7 +827,7 @@ namespace OptimizelySDK
                 { "variables", variableMap },
                 { "variationKey", variationKey },
                 { "ruleKey", ruleKey },
-                { "reasons", decisionReasons },
+                { "reasons", reasonsToReport },
                 { "decisionEventDispatched", decisionEventDispatched }
             };
 
@@ -841,7 +841,7 @@ namespace OptimizelySDK
                 ruleKey,
                 key,
                 user,
-                reasonsToReport.ToArray());
+                reasonsToReport);
         }
 
         internal Dictionary<string, OptimizelyDecision> DecideAll(OptimizelyUserContext user,


### PR DESCRIPTION
## Summary
- SendImpressionEvent will return false when event is not sent and return true when sent successfully
- In case of userEvent is null it will return false
