### PR TITLE
Feat: Added set polling interval and set blocking timeout period method in OptimizelyFactory

### DIFF
--- a/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
@@ -63,54 +63,6 @@ namespace OptimizelySDK.Tests
         }
 
         [Test]
-        public void TestOptimizelyInstanceUsingConfigFileWithPollingInterval()
-        {
-            OptimizelyFactory.SetPollingInterval(TimeSpan.FromMilliseconds(2023));
-            var optimizely = OptimizelyFactory.NewDefaultInstance();
-            // Check values are loaded from app.config or not.
-            var projectConfigManager = optimizely.ProjectConfigManager as HttpProjectConfigManager;
-            Assert.NotNull(projectConfigManager);
-
-            var actualConfigManagerProps = new ProjectConfigManagerProps(projectConfigManager);
-            var expectedConfigManagerProps = new ProjectConfigManagerProps
-            {
-                Url = "www.testurl.com",
-                LastModified = "",
-                AutoUpdate = true,
-                DatafileAccessToken = "testingtoken123",
-                BlockingTimeout = TimeSpan.FromSeconds(10),
-                PollingInterval = TimeSpan.FromMilliseconds(2023)
-            };
-
-            Assert.AreEqual(actualConfigManagerProps, expectedConfigManagerProps);
-            optimizely.Dispose();
-        }
-
-        [Test]
-        public void TestOptimizelyInstanceUsingConfigFileWithBlockingTimeOutInterval()
-        {
-            OptimizelyFactory.SetBlockingTimeOutPeriod(TimeSpan.FromSeconds(30));
-            var optimizely = OptimizelyFactory.NewDefaultInstance();
-            // Check values are loaded from app.config or not.
-            var projectConfigManager = optimizely.ProjectConfigManager as HttpProjectConfigManager;
-            Assert.NotNull(projectConfigManager);
-
-            var actualConfigManagerProps = new ProjectConfigManagerProps(projectConfigManager);
-            var expectedConfigManagerProps = new ProjectConfigManagerProps
-            {
-                Url = "www.testurl.com",
-                LastModified = "",
-                AutoUpdate = true,
-                DatafileAccessToken = "testingtoken123",
-                BlockingTimeout = TimeSpan.FromSeconds(30),
-                PollingInterval = TimeSpan.FromSeconds(2)
-            };
-
-            Assert.AreEqual(actualConfigManagerProps, expectedConfigManagerProps);
-            optimizely.Dispose();
-        }
-
-        [Test]
         public void TestProjectConfigManagerUsingSDKKey()
         {
             var optimizely = OptimizelyFactory.NewDefaultInstance("my-sdk-key");
@@ -125,8 +77,8 @@ namespace OptimizelySDK.Tests
                 Url = "https://cdn.optimizely.com/datafiles/my-sdk-key.json",
                 LastModified = "",
                 AutoUpdate = true,
-                BlockingTimeout = TimeSpan.FromSeconds(15),
-                PollingInterval = TimeSpan.FromMinutes(5)
+                BlockingTimeout = TimeSpan.FromSeconds(30),
+                PollingInterval = TimeSpan.FromMilliseconds(2023)
             };
 
             Assert.AreEqual(actualConfigManagerProps, expectedConfigManagerProps);
@@ -149,12 +101,37 @@ namespace OptimizelySDK.Tests
                 LastModified = "",
                 DatafileAccessToken = "access-token",
                 AutoUpdate = true,
-                BlockingTimeout = TimeSpan.FromSeconds(15),
-                PollingInterval = TimeSpan.FromMinutes(5)
+                BlockingTimeout = TimeSpan.FromSeconds(30),
+                PollingInterval = TimeSpan.FromMilliseconds(2023)
             };
 
             Assert.AreEqual(actualConfigManagerProps, expectedConfigManagerProps);
 
+            optimizely.Dispose();
+        }
+
+        [Test]
+        public void TestOptimizelyInstanceUsingConfigFileWithBlockingAndPollingInterval()
+        {
+            OptimizelyFactory.SetBlockingTimeOutPeriod(TimeSpan.FromSeconds(30));
+            OptimizelyFactory.SetPollingInterval(TimeSpan.FromMilliseconds(2023));
+            var optimizely = OptimizelyFactory.NewDefaultInstance();
+            // Check values are loaded from app.config or not.
+            var projectConfigManager = optimizely.ProjectConfigManager as HttpProjectConfigManager;
+            Assert.NotNull(projectConfigManager);
+
+            var actualConfigManagerProps = new ProjectConfigManagerProps(projectConfigManager);
+            var expectedConfigManagerProps = new ProjectConfigManagerProps
+            {
+                Url = "www.testurl.com",
+                LastModified = "",
+                AutoUpdate = true,
+                DatafileAccessToken = "testingtoken123",
+                BlockingTimeout = TimeSpan.FromSeconds(30),
+                PollingInterval = TimeSpan.FromMilliseconds(2023)
+            };
+
+            Assert.AreEqual(actualConfigManagerProps, expectedConfigManagerProps);
             optimizely.Dispose();
         }
 

--- a/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
@@ -111,7 +111,7 @@ namespace OptimizelySDK.Tests
         }
 
         [Test]
-        public void TestOptimizelyInstanceUsingConfigFileWithBlockingAndPollingInterval()
+        public void TestOptimizelyInstanceUsingConfigNotUseFactoryClassBlockingTimeoutAndPollingInterval()
         {
             OptimizelyFactory.SetBlockingTimeOutPeriod(TimeSpan.FromSeconds(30));
             OptimizelyFactory.SetPollingInterval(TimeSpan.FromMilliseconds(2023));
@@ -127,8 +127,8 @@ namespace OptimizelySDK.Tests
                 LastModified = "",
                 AutoUpdate = true,
                 DatafileAccessToken = "testingtoken123",
-                BlockingTimeout = TimeSpan.FromSeconds(30),
-                PollingInterval = TimeSpan.FromMilliseconds(2023)
+                BlockingTimeout = TimeSpan.FromMilliseconds(10000),
+                PollingInterval = TimeSpan.FromMilliseconds(2000)
             };
 
             Assert.AreEqual(actualConfigManagerProps, expectedConfigManagerProps);

--- a/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
@@ -62,6 +62,53 @@ namespace OptimizelySDK.Tests
             optimizely.Dispose();
         }
 
+        [Test]
+        public void TestOptimizelyInstanceUsingConfigFileWithPollingInterval()
+        {
+            OptimizelyFactory.SetPollingInterval(TimeSpan.FromMilliseconds(2023));
+            var optimizely = OptimizelyFactory.NewDefaultInstance();
+            // Check values are loaded from app.config or not.
+            var projectConfigManager = optimizely.ProjectConfigManager as HttpProjectConfigManager;
+            Assert.NotNull(projectConfigManager);
+
+            var actualConfigManagerProps = new ProjectConfigManagerProps(projectConfigManager);
+            var expectedConfigManagerProps = new ProjectConfigManagerProps
+            {
+                Url = "www.testurl.com",
+                LastModified = "",
+                AutoUpdate = true,
+                DatafileAccessToken = "testingtoken123",
+                BlockingTimeout = TimeSpan.FromSeconds(10),
+                PollingInterval = TimeSpan.FromMilliseconds(2023)
+            };
+
+            Assert.AreEqual(actualConfigManagerProps, expectedConfigManagerProps);
+            optimizely.Dispose();
+        }
+
+        [Test]
+        public void TestOptimizelyInstanceUsingConfigFileWithBlockingTimeOutInterval()
+        {
+            OptimizelyFactory.SetBlockingTimeOutPeriod(TimeSpan.FromSeconds(30));
+            var optimizely = OptimizelyFactory.NewDefaultInstance();
+            // Check values are loaded from app.config or not.
+            var projectConfigManager = optimizely.ProjectConfigManager as HttpProjectConfigManager;
+            Assert.NotNull(projectConfigManager);
+
+            var actualConfigManagerProps = new ProjectConfigManagerProps(projectConfigManager);
+            var expectedConfigManagerProps = new ProjectConfigManagerProps
+            {
+                Url = "www.testurl.com",
+                LastModified = "",
+                AutoUpdate = true,
+                DatafileAccessToken = "testingtoken123",
+                BlockingTimeout = TimeSpan.FromSeconds(30),
+                PollingInterval = TimeSpan.FromSeconds(2)
+            };
+
+            Assert.AreEqual(actualConfigManagerProps, expectedConfigManagerProps);
+            optimizely.Dispose();
+        }
 
         [Test]
         public void TestProjectConfigManagerUsingSDKKey()

--- a/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
@@ -1,6 +1,6 @@
 ﻿/**
  *
- *    Copyright 2020, Optimizely and contributors
+ *    Copyright 2020-2021, Optimizely and contributors
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.

--- a/OptimizelySDK/OptimizelyFactory.cs
+++ b/OptimizelySDK/OptimizelyFactory.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2019-2020, Optimizely
+ * Copyright 2019-2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use file except in compliance with the License.

--- a/OptimizelySDK/OptimizelyFactory.cs
+++ b/OptimizelySDK/OptimizelyFactory.cs
@@ -92,8 +92,8 @@ namespace OptimizelySDK
                 .WithSdkKey(httpProjectConfigElement.SDKKey)
                 .WithUrl(httpProjectConfigElement.Url)
                 .WithFormat(httpProjectConfigElement.Format)
-                .WithPollingInterval(PollingInterval == TimeSpan.Zero ? TimeSpan.FromMilliseconds(httpProjectConfigElement.PollingInterval) : PollingInterval)
-                .WithBlockingTimeoutPeriod(BlockingTimeOutPeriod == TimeSpan.Zero ? TimeSpan.FromMilliseconds(httpProjectConfigElement.BlockingTimeOutPeriod) : BlockingTimeOutPeriod)
+                .WithPollingInterval(TimeSpan.FromMilliseconds(httpProjectConfigElement.PollingInterval))
+                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(httpProjectConfigElement.BlockingTimeOutPeriod))
 #if !NET40 && !NET35
                 .WithAccessToken(httpProjectConfigElement.DatafileAccessToken)
 #endif

--- a/OptimizelySDK/OptimizelyFactory.cs
+++ b/OptimizelySDK/OptimizelyFactory.cs
@@ -35,6 +35,8 @@ namespace OptimizelySDK
     {
         private static int MaxEventBatchSize;
         private static TimeSpan MaxEventFlushInterval;
+        private static TimeSpan PollingInterval;
+        private static TimeSpan BlockingTimeOutPeriod;
         private static ILogger OptimizelyLogger;
         private const string ConfigSectionName = "optlySDKConfigSection";
 
@@ -47,6 +49,16 @@ namespace OptimizelySDK
         public static void SetFlushInterval(TimeSpan flushInterval)
         {
             MaxEventFlushInterval = flushInterval;
+        }
+
+        public static void SetPollingInterval(TimeSpan pollingInterval)
+        {
+            PollingInterval = pollingInterval;
+        }
+
+        public static void SetBlockingTimeOutPeriod(TimeSpan blockingTimeOutPeriod)
+        {
+            BlockingTimeOutPeriod = blockingTimeOutPeriod;
         }
 
         public static void SetLogger(ILogger logger)
@@ -76,13 +88,12 @@ namespace OptimizelySDK
             var eventDispatcher = new DefaultEventDispatcher(logger);
             var builder = new HttpProjectConfigManager.Builder();
             var notificationCenter = new NotificationCenter();
-            
             var configManager = builder
                 .WithSdkKey(httpProjectConfigElement.SDKKey)
                 .WithUrl(httpProjectConfigElement.Url)
                 .WithFormat(httpProjectConfigElement.Format)
-                .WithPollingInterval(TimeSpan.FromMilliseconds(httpProjectConfigElement.PollingInterval))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(httpProjectConfigElement.BlockingTimeOutPeriod))
+                .WithPollingInterval(PollingInterval == TimeSpan.Zero ? TimeSpan.FromMilliseconds(httpProjectConfigElement.PollingInterval) : PollingInterval)
+                .WithBlockingTimeoutPeriod(BlockingTimeOutPeriod == TimeSpan.Zero ? TimeSpan.FromMilliseconds(httpProjectConfigElement.BlockingTimeOutPeriod) : BlockingTimeOutPeriod)
 #if !NET40 && !NET35
                 .WithAccessToken(httpProjectConfigElement.DatafileAccessToken)
 #endif
@@ -111,7 +122,7 @@ namespace OptimizelySDK
         }
 #endif
 
-            public static Optimizely NewDefaultInstance(string sdkKey)
+        public static Optimizely NewDefaultInstance(string sdkKey)
         {
             return NewDefaultInstance(sdkKey, null);
         }
@@ -128,6 +139,8 @@ namespace OptimizelySDK
                 .WithSdkKey(sdkKey)
                 .WithDatafile(fallback)
                 .WithLogger(logger)
+                .WithPollingInterval(PollingInterval)
+                .WithBlockingTimeoutPeriod(BlockingTimeOutPeriod)
                 .WithErrorHandler(errorHandler)
                 .WithAccessToken(datafileAuthToken)
                 .WithNotificationCenter(notificationCenter)
@@ -160,6 +173,8 @@ namespace OptimizelySDK
                 .WithSdkKey(sdkKey)
                 .WithDatafile(fallback)
                 .WithLogger(logger)
+                .WithPollingInterval(PollingInterval)
+                .WithBlockingTimeoutPeriod(BlockingTimeOutPeriod)
                 .WithErrorHandler(errorHandler)
                 .WithNotificationCenter(notificationCenter)
                 .Build(true);


### PR DESCRIPTION
## Summary
- Polling interval and blocking timeout period of configManager can be now set using optimizelyFactory and the provided intervals will be given priority over config file values. 

## Test plan
All Unit tests and FSC tests should pass.

## Issues
- [OASIS-7690](https://optimizely.atlassian.net/browse/OASIS-7690)
