### PR TITLE
Add support for unit testing for user context

### DIFF
--- a/OptimizelySDK.Net35/OptimizelySDK.Net35.csproj
+++ b/OptimizelySDK.Net35/OptimizelySDK.Net35.csproj
@@ -148,6 +148,9 @@
     <Compile Include="..\OptimizelySDK\IOptimizely.cs">
       <Link>IOptimizely.cs</Link>
     </Compile>
+	<Compile Include="..\OptimizelySDK\IOptimizelyUserContext.cs">
+	  <Link>IOptimizelyUserContext.cs</Link>
+	</Compile>
     <Compile Include="..\OptimizelySDK\Logger\DefaultLogger.cs">
       <Link>Logger\DefaultLogger.cs</Link>
     </Compile>

--- a/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
+++ b/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
@@ -48,6 +48,9 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+	<Compile Include="..\OptimizelySDK\IOptimizelyUserContext.cs">
+	  <Link>IOptimizelyUserContext.cs</Link>
+	</Compile>
 	<Compile Include="..\OptimizelySDK\AudienceConditions\AndCondition.cs">
       <Link>AudienceConditions\AndCondition.cs</Link>
     </Compile>

--- a/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
+++ b/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
@@ -100,7 +100,10 @@
 		  <Link>AtomicProjectConfigManager.cs</Link>
 		</Compile>
 		<Compile Include="..\OptimizelySDK\OptimizelyFactory.cs">
-		  <Link>OptimizelyFactory.cs</Link>
+			<Link>OptimizelyFactory.cs</Link>
+		</Compile>
+		<Compile Include="..\OptimizelySDK\IOptimizelyUserContext.cs">
+		  <Link>IOptimizelyUserContext.cs</Link>
 		</Compile>
 		<Compile Include="..\OptimizelySDK\Event\Entity\ConversionEvent.cs">
 		  <Link>ConversionEvent.cs</Link>

--- a/OptimizelySDK.NetStandard20/OptimizelySDK.NetStandard20.csproj
+++ b/OptimizelySDK.NetStandard20/OptimizelySDK.NetStandard20.csproj
@@ -10,6 +10,9 @@
     <Compile Include="..\OptimizelySDK\IOptimizely.cs">
       <Link>IOptimizely.cs</Link>
     </Compile>
+	<Compile Include="..\OptimizelySDK\IOptimizelyUserContext.cs">
+		  <Link>IOptimizelyUserContext.cs</Link>
+	</Compile>
     <Compile Include="..\OptimizelySDK\Optimizely.cs">
       <Link>Optimizely.cs</Link>
     </Compile>

--- a/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
+++ b/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="TestBucketer.cs" />
     <Compile Include="BucketerTest.cs" />
     <Compile Include="ProjectConfigTest.cs" />
+    <Compile Include="TestSetup.cs" />
     <Compile Include="UtilsTests\ConditionParserTest.cs" />
     <Compile Include="UtilsTests\EventTagUtilsTest.cs" />
     <Compile Include="UtilsTests\ExceptionExtensionsTest.cs" />

--- a/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
@@ -63,7 +63,7 @@ namespace OptimizelySDK.Tests
         public void OptimizelyUserContextWithAttributes()
         {
             var attributes = new UserAttributes() { { "house", "GRYFFINDOR" } };
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, attributes, ErrorHandlerMock.Object, LoggerMock.Object);
+            IOptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, attributes, ErrorHandlerMock.Object, LoggerMock.Object);
 
             Assert.AreEqual(user.GetOptimizely(), Optimizely);
             Assert.AreEqual(user.GetUserId(), UserID);
@@ -73,7 +73,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void OptimizelyUserContextNoAttributes()
         {
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, null, ErrorHandlerMock.Object, LoggerMock.Object);
+            IOptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, null, ErrorHandlerMock.Object, LoggerMock.Object);
 
             Assert.AreEqual(user.GetOptimizely(), Optimizely);
             Assert.AreEqual(user.GetUserId(), UserID);
@@ -84,7 +84,7 @@ namespace OptimizelySDK.Tests
         public void SetAttribute()
         {
             var attributes = new UserAttributes() { { "house", "GRYFFINDOR" } };
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, attributes, ErrorHandlerMock.Object, LoggerMock.Object);
+            IOptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, attributes, ErrorHandlerMock.Object, LoggerMock.Object);
 
             user.SetAttribute("k1", "v1");
             user.SetAttribute("k2", true);
@@ -104,7 +104,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void SetAttributeNoAttribute()
         {
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, null, ErrorHandlerMock.Object, LoggerMock.Object);
+            IOptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, null, ErrorHandlerMock.Object, LoggerMock.Object);
 
             user.SetAttribute("k1", "v1");
             user.SetAttribute("k2", true);
@@ -120,7 +120,7 @@ namespace OptimizelySDK.Tests
         public void SetAttributeOverride()
         {
             var attributes = new UserAttributes() { { "house", "GRYFFINDOR" } };
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, attributes, ErrorHandlerMock.Object, LoggerMock.Object);
+            IOptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, attributes, ErrorHandlerMock.Object, LoggerMock.Object);
 
             user.SetAttribute("k1", "v1");
             user.SetAttribute("house", "v2");
@@ -134,7 +134,7 @@ namespace OptimizelySDK.Tests
         public void SetAttributeNullValue()
         {
             var attributes = new UserAttributes() { { "k1", null } };
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, attributes, ErrorHandlerMock.Object, LoggerMock.Object);
+            IOptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, attributes, ErrorHandlerMock.Object, LoggerMock.Object);
 
             var newAttributes = user.GetAttributes();
             Assert.AreEqual(newAttributes["k1"], null);
@@ -151,7 +151,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void SetAttributeToOverrideAttribute()
         {
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, null, ErrorHandlerMock.Object, LoggerMock.Object);
+            IOptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, null, ErrorHandlerMock.Object, LoggerMock.Object);
 
 
             Assert.AreEqual(user.GetOptimizely(), Optimizely);

--- a/OptimizelySDK.Tests/TestSetup.cs
+++ b/OptimizelySDK.Tests/TestSetup.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+using System.Globalization;
+using System.Threading;
+
+namespace OptimizelySDK.Tests
+{
+    [SetUpFixture]
+    public class TestSetup
+    {
+        [SetUp]
+        public void Init()
+        {
+            /* There are some issues doing assertions on tests with floating point numbers using the .ToString()
+             * method, as it's culture dependent. EG: TestGetFeatureVariableValueForTypeGivenFeatureFlagIsNotEnabledForUser,
+             * assigning the culture to English will make this kind of tests to work on others culture based systems. */
+            Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture("en-US");
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            // Empty, but required: https://nunit.org/nunitv2/docs/2.6.4/setupFixture.html
+        }
+    }
+}

--- a/OptimizelySDK.Tests/TestSetup.cs
+++ b/OptimizelySDK.Tests/TestSetup.cs
@@ -1,4 +1,20 @@
-﻿using NUnit.Framework;
+﻿/* 
+ * Copyright 2021, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using NUnit.Framework;
 using System.Globalization;
 using System.Threading;
 

--- a/OptimizelySDK/IOptimizely.cs
+++ b/OptimizelySDK/IOptimizely.cs
@@ -41,7 +41,7 @@ namespace OptimizelySDK
 		/// <param name="userId">The user ID to be used for bucketing.</param>
 		/// <param name="userAttributes">The user's attributes</param>
 		/// <returns>OptimizelyUserContext | An OptimizelyUserContext associated with this OptimizelyClient.</returns>
-		OptimizelyUserContext CreateUserContext(string userId, UserAttributes userAttributes = null);
+		IOptimizelyUserContext CreateUserContext(string userId, UserAttributes userAttributes = null);
 
 		/// <summary>
 		/// Sends conversion event to Optimizely.

--- a/OptimizelySDK/IOptimizelyUserContext.cs
+++ b/OptimizelySDK/IOptimizelyUserContext.cs
@@ -1,0 +1,112 @@
+﻿/* 
+ * Copyright 2020-2021, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using OptimizelySDK.Entity;
+using OptimizelySDK.OptimizelyDecisions;
+using System.Collections.Generic;
+
+namespace OptimizelySDK
+{
+    public interface IOptimizelyUserContext
+    {
+        /// <summary>
+        /// Returns a decision result ({@link OptimizelyDecision}) for a given flag key and a user context, which contains all data required to deliver the flag.
+        /// <ul>
+        /// <li>If the SDK finds an error, it’ll return a decision with <b>null</b> for <b>variationKey</b>. The decision will include an error message in <b>reasons</b>.
+        /// </ul>
+        /// </summary>
+        /// <param name="key">A flag key for which a decision will be made.</param>
+        /// <returns>A decision result.</returns>
+        OptimizelyDecision Decide(string key);
+
+        /// <summary>
+        /// Returns a decision result ({@link OptimizelyDecision}) for a given flag key and a user context, which contains all data required to deliver the flag.
+        /// <ul>
+        /// <li>If the SDK finds an error, it’ll return a decision with <b>null</b> for <b>variationKey</b>. The decision will include an error message in <b>reasons</b>.
+        /// </ul>
+        /// </summary>
+        /// <param name="key">A flag key for which a decision will be made.</param>
+        /// <param name="options">A list of options for decision-making.</param>
+        /// <returns>A decision result.</returns>
+        OptimizelyDecision Decide(string key, OptimizelyDecideOption[] options);
+
+        /// <summary>
+        /// Returns a key-map of decision results ({@link OptimizelyDecision}) for all active flag keys.
+        /// </summary>
+        /// <returns>A dictionary of all decision results, mapped by flag keys.</returns>
+        Dictionary<string, OptimizelyDecision> DecideAll();
+
+        /// <summary>
+        /// Returns a key-map of decision results ({@link OptimizelyDecision}) for all active flag keys.
+        /// </summary>
+        /// <param name="options">A list of options for decision-making.</param>
+        /// <returns>All decision results mapped by flag keys.</returns>
+        Dictionary<string, OptimizelyDecision> DecideAll(OptimizelyDecideOption[] options);
+
+        /// <summary>
+        /// Returns a key-map of decision results for multiple flag keys and a user context.
+        /// </summary>
+        /// <param name="keys">list of flag keys for which a decision will be made.</param>
+        /// <returns>A dictionary of all decision results, mapped by flag keys.</returns>
+        Dictionary<string, OptimizelyDecision> DecideForKeys(string[] keys);
+
+        /// <summary>
+        /// Returns a key-map of decision results for multiple flag keys and a user context.
+        /// </summary>
+        /// <param name="keys">list of flag keys for which a decision will be made.</param>
+        /// <param name="options">An array of decision options.</param>
+        /// <returns></returns>
+        Dictionary<string, OptimizelyDecision> DecideForKeys(string[] keys, OptimizelyDecideOption[] options);
+
+        /// <summary>
+        /// Returns copy of UserAttributes associated with UserContext.
+        /// </summary>
+        /// <returns>copy of UserAttributes.</returns>
+        UserAttributes GetAttributes();
+
+        /// <summary>
+        /// Returns Optimizely instance associated with the UserContext.
+        /// </summary>
+        /// <returns> Optimizely instance.</returns>
+        Optimizely GetOptimizely();
+
+        /// <summary>
+        /// Returns UserId associated with the UserContext
+        /// </summary>
+        /// <returns>UserId of this instance.</returns>
+        string GetUserId();
+
+        /// <summary>
+        /// Set an attribute for a given key.
+        /// </summary>
+        /// <param name="key">An attribute key</param>
+        /// <param name="value">value An attribute value</param>
+        void SetAttribute(string key, object value);
+
+        /// <summary>
+        /// Track an event.
+        /// </summary>
+        /// <param name="eventName">The event name.</param>
+        void TrackEvent(string eventName);
+
+        /// <summary>
+        /// Track an event.
+        /// </summary>
+        /// <param name="eventName">The event name.</param>
+        /// <param name="eventTags">A map of event tag names to event tag values.</param>
+        void TrackEvent(string eventName, EventTags eventTags);
+    }
+}

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -700,7 +700,7 @@ namespace OptimizelySDK
         /// <param name="userId">The user ID to be used for bucketing.</param>
         /// <param name="userAttributes">The user's attributes</param>
         /// <returns>OptimizelyUserContext | An OptimizelyUserContext associated with this OptimizelyClient.</returns>
-        public OptimizelyUserContext CreateUserContext(string userId,
+        public IOptimizelyUserContext CreateUserContext(string userId,
                                                        UserAttributes userAttributes = null)
         {
             var inputValues = new Dictionary<string, string>
@@ -724,7 +724,7 @@ namespace OptimizelySDK
         /// <param name="key">A flag key for which a decision will be made.</param>
         /// <param name="options">A list of options for decision-making.</param>
         /// <returns>A decision result.</returns>
-        internal OptimizelyDecision Decide(OptimizelyUserContext user,
+        internal OptimizelyDecision Decide(IOptimizelyUserContext user,
                               string key,
                               OptimizelyDecideOption[] options)
         {
@@ -844,7 +844,7 @@ namespace OptimizelySDK
                 reasonsToReport);
         }
 
-        internal Dictionary<string, OptimizelyDecision> DecideAll(OptimizelyUserContext user,
+        internal Dictionary<string, OptimizelyDecision> DecideAll(IOptimizelyUserContext user,
                                               OptimizelyDecideOption[] options)
         {
             var decisionMap = new Dictionary<string, OptimizelyDecision>();
@@ -862,7 +862,7 @@ namespace OptimizelySDK
             return DecideForKeys(user, allFlagKeys, options);
         }
 
-        internal Dictionary<string, OptimizelyDecision> DecideForKeys(OptimizelyUserContext user,
+        internal Dictionary<string, OptimizelyDecision> DecideForKeys(IOptimizelyUserContext user,
                                                       string[] keys,
                                                       OptimizelyDecideOption[] options)
         {

--- a/OptimizelySDK/OptimizelyDecisions/OptimizelyDecision.cs
+++ b/OptimizelySDK/OptimizelyDecisions/OptimizelyDecision.cs
@@ -53,7 +53,7 @@ namespace OptimizelySDK.OptimizelyDecisions
         /// <summary>
         /// user context for which the  decision was made.
         /// </summary>
-        public OptimizelyUserContext UserContext { get; private set; }
+        public IOptimizelyUserContext UserContext { get; private set; }
         
         /// <summary>
         /// an array of error/info/debug messages describing why the decision has been made.
@@ -65,7 +65,7 @@ namespace OptimizelySDK.OptimizelyDecisions
                               OptimizelyJSON variables,
                               string ruleKey,
                               string flagKey,
-                              OptimizelyUserContext userContext,
+                              IOptimizelyUserContext userContext,
                               string[] reasons)
         {
             VariationKey = variationKey;
@@ -84,7 +84,7 @@ namespace OptimizelySDK.OptimizelyDecisions
         /// and error reason array
         /// </summary>
         public static OptimizelyDecision NewErrorDecision(string key,
-            OptimizelyUserContext optimizelyUserContext,
+            IOptimizelyUserContext optimizelyUserContext,
             string error,
             IErrorHandler errorHandler,
             ILogger logger)

--- a/OptimizelySDK/OptimizelySDK.csproj
+++ b/OptimizelySDK/OptimizelySDK.csproj
@@ -87,6 +87,7 @@
     <Compile Include="Entity\Group.cs" />
     <Compile Include="Entity\IdKeyEntity.cs" />
     <Compile Include="Event\Entity\DecisionMetadata.cs" />
+    <Compile Include="IOptimizelyUserContext.cs" />
     <Compile Include="OptimizelyDecisions\DecisionMessage.cs" />
     <Compile Include="OptimizelyDecisions\DecisionReasons.cs" />
     <Compile Include="OptimizelyDecisions\OptimizelyDecideOption.cs" />

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -25,7 +25,7 @@ namespace OptimizelySDK
     /// <summary>
     /// OptimizelyUserContext defines user contexts that the SDK will use to make decisions for
     /// </summary>
-    public class OptimizelyUserContext
+    public class OptimizelyUserContext : IOptimizelyUserContext
     {
         private ILogger Logger;
         private IErrorHandler ErrorHandler;
@@ -46,7 +46,7 @@ namespace OptimizelySDK
             UserId = userId;
         }
 
-        private OptimizelyUserContext Copy() => new OptimizelyUserContext(Optimizely, UserId, GetAttributes(), ErrorHandler, Logger);
+        private IOptimizelyUserContext Copy() => new OptimizelyUserContext(Optimizely, UserId, GetAttributes(), ErrorHandler, Logger);
 
         /// <summary>
         /// Returns Optimizely instance associated with the UserContext.
@@ -133,6 +133,7 @@ namespace OptimizelySDK
         /// Returns a key-map of decision results for multiple flag keys and a user context.
         /// </summary>
         /// <param name="keys">list of flag keys for which a decision will be made.</param>
+        /// <param name="options">An array of decision options.</param>
         /// <returns>A dictionary of all decision results, mapped by flag keys.</returns>
         public Dictionary<string, OptimizelyDecision> DecideForKeys(string[] keys, OptimizelyDecideOption[] options)
         {


### PR DESCRIPTION
## Summary
The following versions of _Optimizely C# SDK_ would use the methods defined on the class OptimizelyUserContext to perform some processes, E.G: Decide, TrackEvent, DecideAll, etc...

Them, it is required on the vast majority of unit testing frameworks for mocking this object to have an interface for it.

This PR creates the interface _IOptimizelyUserContext_ for doing so.

Also fixes a problem with development environments with a culture different from english.


