### PR TITLE
Added depreciation warning on Optimizelyconfig.ExperimentsMap field

### DIFF
--- a/OptimizelySDK/OptlyConfig/OptimizelyConfig.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyConfig.cs
@@ -15,6 +15,7 @@
  */
 
 using Newtonsoft.Json;
+using System;
 using System.Collections.Generic;
 
 namespace OptimizelySDK.OptlyConfig
@@ -27,7 +28,10 @@ namespace OptimizelySDK.OptlyConfig
         public OptimizelyEvent[] Events { get; private set; }
         public OptimizelyAudience[] Audiences { get; private set; }
         public OptimizelyAttribute[] Attributes { get; private set; }
+
+        [Obsolete("This experimentsMap is for experiments of legacy projects only. For flag projects, experiment keys are not guaranteed to be unique across multiple flags, so this map may not include all experiments when keys conflict.")]
         public IDictionary<string, OptimizelyExperiment> ExperimentsMap { get; private set; }
+
         public IDictionary<string, OptimizelyFeature> FeaturesMap { get; private set; }
 
         private string _datafile;

--- a/OptimizelySDK/OptlyConfig/OptimizelyConfig.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyConfig.cs
@@ -30,7 +30,7 @@ namespace OptimizelySDK.OptlyConfig
         public OptimizelyAttribute[] Attributes { get; private set; }
 
         /// <summary>
-        /// This experimentsMap is for experiments of legacy projects only
+        /// This experimentsMap is for experiments of legacy projects only.
         /// For flag projects, experiment keys are not guaranteed to be unique 
         /// across multiple flags, so this map may not include all experiments 
         /// when keys conflict.

--- a/OptimizelySDK/OptlyConfig/OptimizelyConfig.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyConfig.cs
@@ -29,7 +29,12 @@ namespace OptimizelySDK.OptlyConfig
         public OptimizelyAudience[] Audiences { get; private set; }
         public OptimizelyAttribute[] Attributes { get; private set; }
 
-        [Obsolete("This experimentsMap is for experiments of legacy projects only. For flag projects, experiment keys are not guaranteed to be unique across multiple flags, so this map may not include all experiments when keys conflict.")]
+        /// <summary>
+        /// This experimentsMap is for experiments of legacy projects only
+        /// For flag projects, experiment keys are not guaranteed to be unique 
+        /// across multiple flags, so this map may not include all experiments 
+        /// when keys conflict.
+        /// </summary> 
         public IDictionary<string, OptimizelyExperiment> ExperimentsMap { get; private set; }
 
         public IDictionary<string, OptimizelyFeature> FeaturesMap { get; private set; }

--- a/OptimizelySDK/OptlyConfig/OptimizelyFeature.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyFeature.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+using System;
 using System.Collections.Generic;
 
 namespace OptimizelySDK.OptlyConfig
@@ -22,6 +23,8 @@ namespace OptimizelySDK.OptlyConfig
         
         public List<OptimizelyExperiment> ExperimentRules { get; private set; }
         public List<OptimizelyExperiment> DeliveryRules { get; private set; }
+
+        [Obsolete("Use experimentRules and deliveryRules.")]
         public IDictionary<string, OptimizelyExperiment> ExperimentsMap { get; private set; }
         public IDictionary<string, OptimizelyVariable> VariablesMap { get; private set; }
 


### PR DESCRIPTION
## Summary
- Added depreciation warning on Optimizelyconfig.ExperimentsMap field as this was missed in previous PRs.

