### PR TITLE
fix: experimentRules should have same order as experimentIds

### DIFF
--- a/OptimizelySDK/OptlyConfig/OptimizelyConfigService.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyConfigService.cs
@@ -227,12 +227,9 @@ namespace OptimizelySDK.OptlyConfig
             foreach (var featureFlag in projectConfig.FeatureFlags)   
             {
 
-                var featureExperimentMap = new Dictionary<string, OptimizelyExperiment>();
-                foreach (var experimentId in featureFlag.ExperimentIds)
-                {
-                    var experimentDictionary = experimentsMapById[experimentId];
-                    featureExperimentMap.Add(experimentDictionary.Key, experimentDictionary);
-                }
+                var featureExperimentMap = featureFlag.ExperimentIds.Select(experimentId => experimentsMapById[experimentId])
+                    .ToDictionary(experiment => experiment.Key, experiment => experiment);
+
                 var featureVariableMap = featureFlag.Variables.Select(v => (OptimizelyVariable)v).ToDictionary(k => k.Key, v => v) ?? new Dictionary<string, OptimizelyVariable>();
 
                 var experimentRules = featureExperimentMap.Select(exMap => exMap.Value).ToList();

--- a/OptimizelySDK/OptlyConfig/OptimizelyConfigService.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyConfigService.cs
@@ -227,9 +227,12 @@ namespace OptimizelySDK.OptlyConfig
             foreach (var featureFlag in projectConfig.FeatureFlags)   
             {
 
-                var featureExperimentMap = experimentsMapById.Where(expMap => featureFlag.ExperimentIds.Contains(expMap.Key))
-                    .ToDictionary(k => k.Value.Key, v => v.Value);
-
+                var featureExperimentMap = new Dictionary<string, OptimizelyExperiment>();
+                foreach (var experimentId in featureFlag.ExperimentIds)
+                {
+                    var experimentDictionary = experimentsMapById[experimentId];
+                    featureExperimentMap.Add(experimentDictionary.Key, experimentDictionary);
+                }
                 var featureVariableMap = featureFlag.Variables.Select(v => (OptimizelyVariable)v).ToDictionary(k => k.Key, v => v) ?? new Dictionary<string, OptimizelyVariable>();
 
                 var experimentRules = featureExperimentMap.Select(exMap => exMap.Value).ToList();


### PR DESCRIPTION
## Summary
- ExperimentRules sequence critically important when evaluating for decision. it should follow experimentIds under featureFlag object sequence.

## Test plan
- We have test cases in FSC, must pass for unsorted scenarios.
