### PR TITLE
Create virtual methods on user context

### DIFF
--- a/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
+++ b/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
@@ -97,6 +97,7 @@
     <Compile Include="TestBucketer.cs" />
     <Compile Include="BucketerTest.cs" />
     <Compile Include="ProjectConfigTest.cs" />
+    <Compile Include="TestSetup.cs" />
     <Compile Include="UtilsTests\ConditionParserTest.cs" />
     <Compile Include="UtilsTests\EventTagUtilsTest.cs" />
     <Compile Include="UtilsTests\ExceptionExtensionsTest.cs" />

--- a/OptimizelySDK.Tests/TestSetup.cs
+++ b/OptimizelySDK.Tests/TestSetup.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+using System.Globalization;
+using System.Threading;
+
+namespace OptimizelySDK.Tests
+{
+    [SetUpFixture]
+    public class TestSetup
+    {
+        [SetUp]
+        public void Init()
+        {
+            /* There are some issues doing assertions on tests with floating point numbers using the .ToString()
+             * method, as it's culture dependent. EG: TestGetFeatureVariableValueForTypeGivenFeatureFlagIsNotEnabledForUser,
+             * assigning the culture to English will make this kind of tests to work on others culture based systems. */
+            Thread.CurrentThread.CurrentCulture = CultureInfo.CreateSpecificCulture("en-US");
+        }
+
+        [TearDown]
+        public void Cleanup()
+        {
+            // Empty, but required: https://nunit.org/nunitv2/docs/2.6.4/setupFixture.html
+        }
+    }
+}

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -52,7 +52,7 @@ namespace OptimizelySDK
         /// Returns Optimizely instance associated with the UserContext.
         /// </summary>
         /// <returns> Optimizely instance.</returns>
-        public Optimizely GetOptimizely()
+        public virtual Optimizely GetOptimizely()
         {
             return Optimizely;
         }
@@ -61,7 +61,7 @@ namespace OptimizelySDK
         /// Returns UserId associated with the UserContext
         /// </summary>
         /// <returns>UserId of this instance.</returns>
-        public string GetUserId()
+        public virtual string GetUserId()
         {
             return UserId;
         }
@@ -108,7 +108,7 @@ namespace OptimizelySDK
         /// </summary>
         /// <param name="key">A flag key for which a decision will be made.</param>
         /// <returns>A decision result.</returns>
-        public OptimizelyDecision Decide(string key)
+        public virtual OptimizelyDecision Decide(string key)
         {
             return Decide(key, new OptimizelyDecideOption[] { });
         }
@@ -122,7 +122,7 @@ namespace OptimizelySDK
         /// <param name="key">A flag key for which a decision will be made.</param>
         /// <param name="options">A list of options for decision-making.</param>
         /// <returns>A decision result.</returns>
-        public OptimizelyDecision Decide(string key,
+        public virtual OptimizelyDecision Decide(string key,
             OptimizelyDecideOption[] options)
         {
             var optimizelyUserContext = Copy();
@@ -134,7 +134,7 @@ namespace OptimizelySDK
         /// </summary>
         /// <param name="keys">list of flag keys for which a decision will be made.</param>
         /// <returns>A dictionary of all decision results, mapped by flag keys.</returns>
-        public Dictionary<string, OptimizelyDecision> DecideForKeys(string[] keys, OptimizelyDecideOption[] options)
+        public virtual Dictionary<string, OptimizelyDecision> DecideForKeys(string[] keys, OptimizelyDecideOption[] options)
         {
             var optimizelyUserContext = Copy();
             return Optimizely.DecideForKeys(optimizelyUserContext, keys, options);
@@ -145,7 +145,7 @@ namespace OptimizelySDK
         /// </summary>
         /// <param name="keys">list of flag keys for which a decision will be made.</param>
         /// <returns>A dictionary of all decision results, mapped by flag keys.</returns>
-        public Dictionary<string, OptimizelyDecision> DecideForKeys(string[] keys)
+        public virtual Dictionary<string, OptimizelyDecision> DecideForKeys(string[] keys)
         {
             return DecideForKeys(keys, new OptimizelyDecideOption[] { });
         }
@@ -154,7 +154,7 @@ namespace OptimizelySDK
         /// Returns a key-map of decision results ({@link OptimizelyDecision}) for all active flag keys.
         /// </summary>
         /// <returns>A dictionary of all decision results, mapped by flag keys.</returns>
-        public Dictionary<string, OptimizelyDecision> DecideAll()
+        public virtual Dictionary<string, OptimizelyDecision> DecideAll()
         {
             return DecideAll(new OptimizelyDecideOption[] { });
         }
@@ -164,7 +164,7 @@ namespace OptimizelySDK
         /// </summary>
         /// <param name="options">A list of options for decision-making.</param>
         /// <returns>All decision results mapped by flag keys.</returns>
-        public Dictionary<string, OptimizelyDecision> DecideAll(OptimizelyDecideOption[] options)
+        public virtual Dictionary<string, OptimizelyDecision> DecideAll(OptimizelyDecideOption[] options)
         {
             var optimizelyUserContext = Copy();
             return Optimizely.DecideAll(optimizelyUserContext, options);
@@ -174,7 +174,7 @@ namespace OptimizelySDK
         /// Track an event.
         /// </summary>
         /// <param name="eventName">The event name.</param>
-        public void TrackEvent(string eventName)
+        public virtual void TrackEvent(string eventName)
         {
             TrackEvent(eventName, new EventTags());
         }
@@ -184,7 +184,7 @@ namespace OptimizelySDK
         /// </summary>
         /// <param name="eventName">The event name.</param>
         /// <param name="eventTags">A map of event tag names to event tag values.</param>
-        public void TrackEvent(string eventName, 
+        public virtual void TrackEvent(string eventName, 
             EventTags eventTags)
         {
             Optimizely.Track(eventName, UserId, Attributes, eventTags);


### PR DESCRIPTION
The following versions of Optimizely C# SDK would use the methods defined on the class _OptimizelyUserContext_ to perform some processes, E.G: Decide, TrackEvent, DecideAll, etc...

Then, it is required on the vast majority of unit testing frameworks, for mocking this object to be able to override such members.

This can be accomplished, at least on C#, usually in two ways:
1. Declaring an _interface_ (with the methods to be overriden) and having the class implementing it.
2. Declaring the members as _virtual_, would allow also allow the testing framework to override them.

This PR uses the second approach, it makes the methods on _OptimizelyUserContext_ virtual.

Also fixes a problem with development environments with a culture different from English.