### PR TITLE
Refact: Refactored Forced decision

### DIFF
--- a/OptimizelySDK.Net35/OptimizelySDK.Net35.csproj
+++ b/OptimizelySDK.Net35/OptimizelySDK.Net35.csproj
@@ -323,6 +323,9 @@
 	<Compile Include="..\OptimizelySDK\OptimizelyDecisionContext.cs">
       <Link>OptimizelyDecisionContext.cs</Link>
     </Compile>
+	<Compile Include="..\OptimizelySDK\ForcedDecisionsStore.cs">
+      <Link>ForcedDecisionsStore.cs</Link>
+    </Compile>
 	<Compile Include="..\OptimizelySDK\OptimizelyForcedDecision.cs">
       <Link>OptimizelyForcedDecision.cs</Link>
     </Compile>

--- a/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
+++ b/OptimizelySDK.Net40/OptimizelySDK.Net40.csproj
@@ -346,6 +346,9 @@
 	<Compile Include="..\OptimizelySDK\OptimizelyDecisionContext.cs">
       <Link>OptimizelyDecisionContext.cs</Link>
     </Compile>
+	<Compile Include="..\OptimizelySDK\ForcedDecisionsStore.cs">
+      <Link>ForcedDecisionsStore.cs</Link>
+    </Compile>
 	<Compile Include="..\OptimizelySDK\OptimizelyForcedDecision.cs">
       <Link>OptimizelyForcedDecision.cs</Link>
     </Compile>

--- a/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
+++ b/OptimizelySDK.NetStandard16/OptimizelySDK.NetStandard16.csproj
@@ -96,6 +96,7 @@
 			<Compile Include="..\OptimizelySDK\OptimizelyUserContext.cs" />
 			<Compile Include="..\OptimizelySDK\Config\FallbackProjectConfigManager.cs" />
 			<Compile Include="..\OptimizelySDK\OptimizelyDecisionContext.cs" />
+			<Compile Include="..\OptimizelySDK\ForcedDecisionsStore.cs" />
 			<Compile Include="..\OptimizelySDK\OptimizelyForcedDecision.cs">
 				<Link>OptimizelyForcedDecision.cs</Link>
 			</Compile>

--- a/OptimizelySDK.NetStandard20/OptimizelySDK.NetStandard20.csproj
+++ b/OptimizelySDK.NetStandard20/OptimizelySDK.NetStandard20.csproj
@@ -307,6 +307,9 @@
 	<Compile Include="..\OptimizelySDK\OptimizelyDecisionContext.cs">
 		<Link>OptimizelyDecisionContext.cs</Link>
 	</Compile>
+	<Compile Include="..\OptimizelySDK\ForcedDecisionsStore.cs">
+		<Link>ForcedDecisionsStore.cs</Link>
+	</Compile>
 	<Compile Include="..\OptimizelySDK\OptimizelyForcedDecision.cs">
 	  <Link>OptimizelyForcedDecision.cs</Link>
 	</Compile>

--- a/OptimizelySDK.Tests/ForcedDecisionsStoreTest.cs
+++ b/OptimizelySDK.Tests/ForcedDecisionsStoreTest.cs
@@ -1,0 +1,123 @@
+﻿/**
+ *
+ *    Copyright 2021, Optimizely and contributors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+using NUnit.Framework;
+
+namespace OptimizelySDK.Tests
+{
+    [TestFixture]
+    public class ForcedDecisionsStoreTest
+    {
+        [Test]
+        public void ForcedDecisionStoreGetSetForcedDecisionWithBothRuleAndFlagKey()
+        {
+            var expectedForcedDecision1 = new OptimizelyForcedDecision("sample_variation_key");
+            var expectedForcedDecision2 = new OptimizelyForcedDecision("sample_variation_key_2");
+            var context1 = new OptimizelyDecisionContext("flag_key", "rule_key");
+            var context2 = new OptimizelyDecisionContext("flag_key", "rule_key1");
+            var forcedDecisionStore = new ForcedDecisionsStore();
+            forcedDecisionStore[context1] = expectedForcedDecision1;
+            forcedDecisionStore[context2] = expectedForcedDecision2;
+
+            Assert.AreEqual(forcedDecisionStore.Count, 2);
+            Assert.AreEqual(forcedDecisionStore[context1].VariationKey, expectedForcedDecision1.VariationKey);
+            Assert.AreEqual(forcedDecisionStore[context2].VariationKey, expectedForcedDecision2.VariationKey);
+        }
+
+        [Test]
+        public void ForcedDecisionStoreNullFlagKeyForcedDecisionContext()
+        {
+            var expectedForcedDecision = new OptimizelyForcedDecision("sample_variation_key");
+            var context = new OptimizelyDecisionContext(null, "rule_key");
+            var forcedDecisionStore = new ForcedDecisionsStore();
+            forcedDecisionStore[context] = expectedForcedDecision;
+
+            Assert.AreEqual(forcedDecisionStore.Count, 0);
+        }
+
+        [Test]
+        public void ForcedDecisionStoreNullContextForcedDecisionContext()
+        {
+            var expectedForcedDecision = new OptimizelyForcedDecision("sample_variation_key");
+            OptimizelyDecisionContext context = null;
+            var forcedDecisionStore = new ForcedDecisionsStore();
+            forcedDecisionStore[context] = expectedForcedDecision;
+
+            Assert.AreEqual(forcedDecisionStore.Count, 0);
+        }
+
+        [Test]
+        public void ForcedDecisionStoreGetForcedDecisionWithBothRuleAndFlagKey()
+        {
+            var expectedForcedDecision1 = new OptimizelyForcedDecision("sample_variation_key");
+            var context1 = new OptimizelyDecisionContext("flag_key", "rule_key");
+            var NullFlagKeyContext = new OptimizelyDecisionContext(null, "rule_key");
+            var forcedDecisionStore = new ForcedDecisionsStore();
+            forcedDecisionStore[context1] = expectedForcedDecision1;
+
+            Assert.AreEqual(forcedDecisionStore.Count, 1);
+            Assert.AreEqual(forcedDecisionStore[context1].VariationKey, expectedForcedDecision1.VariationKey);
+            Assert.IsNull(forcedDecisionStore[NullFlagKeyContext]);
+        }
+
+        [Test]
+        public void ForcedDecisionStoreRemoveForcedDecisionTrue()
+        {
+            var expectedForcedDecision1 = new OptimizelyForcedDecision("sample_variation_key");
+            var expectedForcedDecision2 = new OptimizelyForcedDecision("sample_variation_key_2");
+            var context1 = new OptimizelyDecisionContext("flag_key", "rule_key");
+            var context2 = new OptimizelyDecisionContext("flag_key", "rule_key1");
+            var forcedDecisionStore = new ForcedDecisionsStore();
+            forcedDecisionStore[context1] = expectedForcedDecision1;
+            forcedDecisionStore[context2] = expectedForcedDecision2;
+
+            Assert.AreEqual(forcedDecisionStore.Count, 2);
+            Assert.IsTrue(forcedDecisionStore.Remove(context2));
+            Assert.AreEqual(forcedDecisionStore.Count, 1);
+            Assert.AreEqual(forcedDecisionStore[context1].VariationKey, expectedForcedDecision1.VariationKey);
+            Assert.IsNull(forcedDecisionStore[context2]);
+        }
+
+        [Test]
+        public void ForcedDecisionStoreRemoveForcedDecisionContextRuleKeyNotMatched()
+        {
+            var expectedForcedDecision = new OptimizelyForcedDecision("sample_variation_key");
+            var contextNotMatched = new OptimizelyDecisionContext("flag_key", "");
+            var context = new OptimizelyDecisionContext("flag_key", "rule_key");
+            var forcedDecisionStore = new ForcedDecisionsStore();
+            forcedDecisionStore[context] = expectedForcedDecision;
+
+            Assert.AreEqual(forcedDecisionStore.Count, 1);
+            Assert.IsFalse(forcedDecisionStore.Remove(contextNotMatched));
+            Assert.AreEqual(forcedDecisionStore.Count, 1);
+        }
+
+        [Test]
+        public void ForcedDecisionStoreRemoveAllForcedDecisionContext()
+        {
+            var expectedForcedDecision = new OptimizelyForcedDecision("sample_variation_key");
+            var context = new OptimizelyDecisionContext("flag_key", "rule_key");
+            var forcedDecisionStore = new ForcedDecisionsStore();
+            forcedDecisionStore[context] = expectedForcedDecision;
+
+            Assert.AreEqual(forcedDecisionStore.Count, 1);
+            forcedDecisionStore.RemoveAll();
+            Assert.AreEqual(forcedDecisionStore.Count, 0);
+        }
+
+    }
+}

--- a/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
+++ b/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
@@ -93,6 +93,7 @@
     <Compile Include="NotificationTests\NotificationCenterTests.cs" />
     <Compile Include="ClientConfigHandlerTest.cs" />
     <Compile Include="OptimizelyTest.cs" />
+    <Compile Include="ForcedDecisionsStoreTest.cs" />
     <Compile Include="OptimizelyUserContextTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestBucketer.cs" />
@@ -135,9 +136,7 @@
       <Name>OptimizelySDK</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-	<Folder Include="Utils\" />
-  </ItemGroup>
+  <ItemGroup />
   <ItemGroup>
     <None Include="packages.config" />
     <EmbeddedResource Include="unsupported_version_datafile.json" />

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -2438,7 +2438,7 @@ namespace OptimizelySDK.Tests
             Mock<OptimizelyUserContext> mockUserContext = new Mock<OptimizelyUserContext>(OptimizelyMock.Object, TestUserId, userAttributes, ErrorHandlerMock.Object, LoggerMock.Object);
             mockUserContext.Setup(ouc => ouc.GetUserId()).Returns(TestUserId);
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, It.IsAny<OptimizelyUserContext>(), It.IsAny<ProjectConfig>(), userAttributes)).Returns(variation);
+            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, It.IsAny<OptimizelyUserContext>(), It.IsAny<ProjectConfig>())).Returns(variation);
             DecisionServiceMock.Setup(ds => ds.GetVariationForFeature(featureFlag, It.IsAny<OptimizelyUserContext>(), It.IsAny<ProjectConfig>())).Returns(decision);
 
             var optly = Helper.CreatePrivateOptimizely();
@@ -2452,8 +2452,8 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
 
             // Calling Activate and IsFeatureEnabled.
-            optly.Invoke("Activate", experimentKey, TestUserId, userAttributes);
-            optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, userAttributes);
+            optStronglyTyped.Activate(experimentKey, TestUserId, userAttributes);
+            optStronglyTyped.IsFeatureEnabled(featureKey, TestUserId, userAttributes);
 
             // Verify that all the registered callbacks are called once for both Activate and IsFeatureEnabled.
             EventDispatcherMock.Verify(dispatcher => dispatcher.DispatchEvent(It.IsAny<LogEvent>()), Times.Exactly(2));
@@ -2521,7 +2521,7 @@ namespace OptimizelySDK.Tests
             Mock<OptimizelyUserContext> mockUserContext = new Mock<OptimizelyUserContext>(Optimizely, TestUserId, new UserAttributes(), ErrorHandlerMock.Object, LoggerMock.Object);
             mockUserContext.Setup(ouc => ouc.GetUserId()).Returns(TestUserId);
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, It.IsAny<OptimizelyUserContext>(), Config, userAttributes)).Returns(variation);
+            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, It.IsAny<OptimizelyUserContext>(), Config)).Returns(variation);
 
             // Adding notification listeners.
             var notificationType = NotificationCenter.NotificationType.Track;
@@ -2559,7 +2559,7 @@ namespace OptimizelySDK.Tests
             NotificationCallbackMock.Setup(nc => nc.TestDecisionCallback(It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), It.IsAny<Dictionary<string, object>>()));
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, It.IsAny<OptimizelyUserContext>(), Config, userAttributes)).Returns(variation);
+            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, It.IsAny<OptimizelyUserContext>(), Config)).Returns(variation);
 
             var optly = Helper.CreatePrivateOptimizely();
             optly.SetFieldOrProperty("ProjectConfigManager", ConfigManager);
@@ -2596,7 +2596,7 @@ namespace OptimizelySDK.Tests
             NotificationCallbackMock.Setup(nc => nc.TestDecisionCallback(It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), It.IsAny<Dictionary<string, object>>()));
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, It.IsAny<OptimizelyUserContext>(), Config, userAttributes)).Returns(variation);
+            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, It.IsAny<OptimizelyUserContext>(), Config)).Returns(variation);
 
             var optly = Helper.CreatePrivateOptimizely();
             optly.SetFieldOrProperty("ProjectConfigManager", ConfigManager);
@@ -2668,7 +2668,7 @@ namespace OptimizelySDK.Tests
             Mock<OptimizelyUserContext> mockUserContext = new Mock<OptimizelyUserContext>(optStronglyTyped, TestUserId, new UserAttributes(), ErrorHandlerMock.Object, LoggerMock.Object);
             mockUserContext.Setup(ouc => ouc.GetUserId()).Returns(TestUserId);
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, It.IsAny<OptimizelyUserContext>(), Config, userAttributes)).Returns(variation);
+            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, It.IsAny<OptimizelyUserContext>(), Config)).Returns(variation);
 
             optStronglyTyped.NotificationCenter.AddNotification(NotificationCenter.NotificationType.Decision, NotificationCallbackMock.Object.TestDecisionCallback);
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
@@ -2707,7 +2707,7 @@ namespace OptimizelySDK.Tests
             Mock<OptimizelyUserContext> mockUserContext = new Mock<OptimizelyUserContext>(optStronglyTyped, TestUserId, new UserAttributes(), ErrorHandlerMock.Object, LoggerMock.Object);
             mockUserContext.Setup(ouc => ouc.GetUserId()).Returns(TestUserId);
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, It.IsAny<OptimizelyUserContext>(), Config, userAttributes)).Returns(variation);
+            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, It.IsAny<OptimizelyUserContext>(), Config)).Returns(variation);
 
             optStronglyTyped.NotificationCenter.AddNotification(NotificationCenter.NotificationType.Decision, NotificationCallbackMock.Object.TestDecisionCallback);
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
@@ -2735,11 +2735,7 @@ namespace OptimizelySDK.Tests
             NotificationCallbackMock.Setup(nc => nc.TestDecisionCallback(It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), It.IsAny<Dictionary<string, object>>()));
 
-            Mock<OptimizelyUserContext> mockUserContext = new Mock<OptimizelyUserContext>(optStronglyTyped, TestUserId, new UserAttributes(), ErrorHandlerMock.Object, LoggerMock.Object);
-
-            mockUserContext.Setup(ouc => ouc.GetUserId()).Returns(TestUserId);
-
-            DecisionServiceMock.Setup(ds => ds.GetVariation(It.IsAny<Experiment>(), It.IsAny<OptimizelyUserContext>(), It.IsAny<ProjectConfig>(), It.IsAny<UserAttributes>())).Returns(Result<Variation>.NullResult(null));
+            DecisionServiceMock.Setup(ds => ds.GetVariation(It.IsAny<Experiment>(), It.IsAny<OptimizelyUserContext>(), It.IsAny<ProjectConfig>())).Returns(Result<Variation>.NullResult(null));
             //DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, TestUserId, Config, null)).Returns(Result<Variation>.NullResult(null));
 
             optStronglyTyped.NotificationCenter.AddNotification(NotificationCenter.NotificationType.Decision, NotificationCallbackMock.Object.TestDecisionCallback);

--- a/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
@@ -196,7 +196,7 @@ namespace OptimizelySDK.Tests
             context = new OptimizelyDecisionContext("flag", "ruleKey");
 
             Assert.AreEqual("flag", context.FlagKey);
-            Assert.AreEqual("ruleKey", context.RuleKey)
+            Assert.AreEqual("ruleKey", context.RuleKey);
         }
 
         [Test]

--- a/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
@@ -227,7 +227,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestSetForcedDecisionReturnsFalseForNullConfig()
         {
-            var optly = new Optimizely(new FallbackProjectConfigManager(null));
+            var optly = new Optimizely(new FallbackProjectConfigManager(null), logger: LoggerMock.Object);
 
             var user = optly.CreateUserContext(UserID);
 
@@ -236,7 +236,7 @@ namespace OptimizelySDK.Tests
             var result = user.SetForcedDecision(context, decision);
 
             Assert.IsFalse(result);
-            //TODO: should assert logger is called
+            LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Optimizely SDK not configured properly yet."), Times.Once);
         }
 
         [Test]

--- a/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
@@ -186,16 +186,17 @@ namespace OptimizelySDK.Tests
         }
 
         [Test]
-        public void TestForcedDecisionReturnsCorrectGetDecisionKey()
+        public void TestForcedDecisionReturnsCorrectFlagAndRuleKeys()
         {
             var user = Optimizely.CreateUserContext(UserID);
             var context = new OptimizelyDecisionContext("flag", null);
-
-            Assert.AreEqual("flag-$opt$-$opt-null-rule-key", context.DecisionKey);
+            Assert.AreEqual("flag", context.FlagKey);
+            Assert.Null(context.RuleKey);
 
             context = new OptimizelyDecisionContext("flag", "ruleKey");
 
-            Assert.AreEqual("flag-$opt$-ruleKey", context.DecisionKey);
+            Assert.AreEqual("flag", context.FlagKey);
+            Assert.AreEqual("ruleKey", context.RuleKey)
         }
 
         [Test]
@@ -310,7 +311,7 @@ namespace OptimizelySDK.Tests
 
             var context = new OptimizelyDecisionContext("flagKey", "ruleKey");
 
-            var result = user.FindValidatedForcedDecision(context);
+            var result = user.FindValidatedForcedDecision(context, null);
 
             Assertions.AreEqual(expectedResult, result);
         }

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -427,44 +427,43 @@ namespace OptimizelySDK.Tests
         {
             var allVariations = Config?.FlagVariationMap;
 
-            var expectedVariations1 = new List<Dictionary<string, List<Variation>>>();
-            var expectedVariationList = new List<Variation>
+            var expectedVariationDict = new Dictionary<string, Variation>
             {
-                new Variation
-                {
-                    FeatureEnabled = true,
-                    Id = "7722260071",
-                    Key = "group_exp_1_var_1",
-                    FeatureVariableUsageInstances = new List<FeatureVariableUsage> { new FeatureVariableUsage { Id = "155563", Value= "groupie_1_v1" } }
+                { "group_exp_1_var_1",  new Variation
+                    {
+                        FeatureEnabled = true,
+                        Id = "7722260071",
+                        Key = "group_exp_1_var_1",
+                        FeatureVariableUsageInstances = new List<FeatureVariableUsage> { new FeatureVariableUsage { Id = "155563", Value= "groupie_1_v1" } }
+                    }
                 },
-                new Variation
-                {
-                    FeatureEnabled = true,
-                    Id = "7722360022",
-                    Key = "group_exp_1_var_2",
-                    FeatureVariableUsageInstances = new List<FeatureVariableUsage> { new FeatureVariableUsage { Id = "155563", Value= "groupie_1_v2" } }
+                { "group_exp_1_var_2",  new Variation
+                    {
+                        FeatureEnabled = true,
+                        Id = "7722360022",
+                        Key = "group_exp_1_var_2",
+                        FeatureVariableUsageInstances = new List<FeatureVariableUsage> { new FeatureVariableUsage { Id = "155563", Value= "groupie_1_v2" } }
+                    }
                 },
-                new Variation
-                {
-                    FeatureEnabled = false,
-                    Id = "7713030086",
-                    Key = "group_exp_2_var_1",
-                    FeatureVariableUsageInstances = new List<FeatureVariableUsage> { new FeatureVariableUsage { Id = "155563", Value= "groupie_2_v1" } }
+                { "group_exp_2_var_1",  new Variation
+                    {
+                        FeatureEnabled = false,
+                        Id = "7713030086",
+                        Key = "group_exp_2_var_1",
+                        FeatureVariableUsageInstances = new List<FeatureVariableUsage> { new FeatureVariableUsage { Id = "155563", Value= "groupie_2_v1" } }
+                    }
                 },
-                new Variation
-                {
-                    FeatureEnabled = false,
-                    Id = "7725250007",
-                    Key = "group_exp_2_var_2",
-                    FeatureVariableUsageInstances = new List<FeatureVariableUsage> { new FeatureVariableUsage { Id = "155563", Value= "groupie_2_v2" } }
+                { "group_exp_2_var_2",  new Variation
+                    {
+                        FeatureEnabled = false,
+                        Id = "7725250007",
+                        Key = "group_exp_2_var_2",
+                        FeatureVariableUsageInstances = new List<FeatureVariableUsage> { new FeatureVariableUsage { Id = "155563", Value= "groupie_2_v2" } }
+                    }
                 }
             };
-            expectedVariations1.Add(new Dictionary<string, List<Variation>> { { "boolean_feature", expectedVariationList } });
-            var filteredActualVariation = allVariations["boolean_feature"].Select(v => v.Value).ToList().OrderBy(v => v.Id);
-            //var variations1 = allVariations.Where(v => v.Key == "boolean_feature").Select(v => new Dictionary<string, List<Variation>> { { v.Key, v.Value } }).ToList();
-            /// TODO: Need to correct it.
-            //TestData.CompareObjects(expectedVariations1, variations1);
-            //Assertions.AreEquivalent(expectedVariations1["boolean_featur, filteredActualVariation);
+            var filteredActualFlagVariations = allVariations["boolean_feature"];
+            TestData.CompareObjects(expectedVariationDict, filteredActualFlagVariations);
         }
 
         [Test]

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -460,11 +460,11 @@ namespace OptimizelySDK.Tests
                 }
             };
             expectedVariations1.Add(new Dictionary<string, List<Variation>> { { "boolean_feature", expectedVariationList } });
-
-            var variations1 = allVariations.Where(v => v.Key == "boolean_feature").Select(v => new Dictionary<string, List<Variation>> { { v.Key, v.Value } }).ToList();
-
-            TestData.CompareObjects(expectedVariations1, variations1);
-            Assertions.AreEquivalent(expectedVariations1, variations1);
+            var filteredActualVariation = allVariations["boolean_feature"].Select(v => v.Value).ToList().OrderBy(v => v.Id);
+            //var variations1 = allVariations.Where(v => v.Key == "boolean_feature").Select(v => new Dictionary<string, List<Variation>> { { v.Key, v.Value } }).ToList();
+            /// TODO: Need to correct it.
+            //TestData.CompareObjects(expectedVariations1, variations1);
+            //Assertions.AreEquivalent(expectedVariations1["boolean_featur, filteredActualVariation);
         }
 
         [Test]

--- a/OptimizelySDK/Bucketing/DecisionService.cs
+++ b/OptimizelySDK/Bucketing/DecisionService.cs
@@ -554,7 +554,7 @@ namespace OptimizelySDK.Bucketing
             //Check forced decision first
             var rule = rules[ruleIndex];
             var decisionContext = new OptimizelyDecisionContext(key, rule.Key);
-            var forcedDecisionResponse = user.FindValidatedForcedDecision(decisionContext);
+            var forcedDecisionResponse = user.FindValidatedForcedDecision(decisionContext, config);
 
             reasons += forcedDecisionResponse.DecisionReasons;
             if (forcedDecisionResponse.ResultObject != null)
@@ -612,7 +612,7 @@ namespace OptimizelySDK.Bucketing
 
             var decisionContext = new OptimizelyDecisionContext(key, ruleKey);
 
-            var forcedDecisionResponse = user.FindValidatedForcedDecision(decisionContext);
+            var forcedDecisionResponse = user.FindValidatedForcedDecision(decisionContext, config);
 
             reasons += forcedDecisionResponse.DecisionReasons;
 

--- a/OptimizelySDK/Bucketing/DecisionService.cs
+++ b/OptimizelySDK/Bucketing/DecisionService.cs
@@ -81,28 +81,27 @@ namespace OptimizelySDK.Bucketing
         /// Get a Variation of an Experiment for a user to be allocated into.
         /// </summary>
         /// <param name = "experiment" > The Experiment the user will be bucketed into.</param>
-        /// <param name = "userId" > The userId of the user.
-        /// <param name = "filteredAttributes" > The user's attributes. This should be filtered to just attributes in the Datafile.</param>
+        /// <param name = "user" > Optimizely user context.
+        /// <param name = "config" > Project config.</param>
         /// <returns>The Variation the user is allocated into.</returns>
         public virtual Result<Variation> GetVariation(Experiment experiment,
             OptimizelyUserContext user,
-            ProjectConfig config,
-            UserAttributes filteredAttributes)
+            ProjectConfig config)
         {
-            return GetVariation(experiment, user, config, filteredAttributes, new OptimizelyDecideOption[] { });
+            return GetVariation(experiment, user, config, new OptimizelyDecideOption[] { });
         }
 
         /// <summary>
         /// Get a Variation of an Experiment for a user to be allocated into.
         /// </summary>
         /// <param name = "experiment" > The Experiment the user will be bucketed into.</param>
-        /// <param name = "userId" > The userId of the user.
-        /// <param name = "filteredAttributes" > The user's attributes. This should be filtered to just attributes in the Datafile.</param>
+        /// <param name = "user" > optimizely user context.
+        /// <param name = "config" > Project Config.</param>
+        /// <param name = "options" >An array of decision options.</param>
         /// <returns>The Variation the user is allocated into.</returns>
         public virtual Result<Variation> GetVariation(Experiment experiment,
             OptimizelyUserContext user,
             ProjectConfig config,
-            UserAttributes filteredAttributes,
             OptimizelyDecideOption[] options)
         {
             var reasons = new DecisionReasons();
@@ -159,6 +158,7 @@ namespace OptimizelySDK.Bucketing
                     ErrorHandler.HandleError(new Exceptions.OptimizelyRuntimeException(exception.Message));
                 }
             }
+            var filteredAttributes = user.GetAttributes();
             var doesUserMeetAudienceConditionsResult = ExperimentUtils.DoesUserMeetAudienceConditions(config, experiment, filteredAttributes, LOGGING_KEY_TYPE_EXPERIMENT, experiment.Key, Logger);
             reasons += doesUserMeetAudienceConditionsResult.DecisionReasons;
             if (doesUserMeetAudienceConditionsResult.ResultObject)
@@ -623,7 +623,7 @@ namespace OptimizelySDK.Bucketing
                 return Result<Variation>.NewResult(variation, reasons);
             }
 
-            var decisionResponse = GetVariation(experiment, user, config, user.GetAttributes(), options);
+            var decisionResponse = GetVariation(experiment, user, config, options);
 
             reasons += decisionResponse?.DecisionReasons;
 

--- a/OptimizelySDK/Bucketing/DecisionService.cs
+++ b/OptimizelySDK/Bucketing/DecisionService.cs
@@ -568,7 +568,7 @@ namespace OptimizelySDK.Bucketing
                     decisionVariation = decisionResponse.ResultObject;
                 }
 
-                if (decisionVariation?.Id != null)
+                if (!string.IsNullOrEmpty(decisionVariation?.Id))
                 {
                     Logger.Log(LogLevel.INFO, reasons.AddInfo($"The user \"{userId}\" is bucketed into experiment \"{experiment.Key}\" of feature \"{featureFlag.Key}\"."));
 

--- a/OptimizelySDK/Bucketing/DecisionService.cs
+++ b/OptimizelySDK/Bucketing/DecisionService.cs
@@ -632,7 +632,7 @@ namespace OptimizelySDK.Bucketing
             }
 
             Logger.Log(LogLevel.INFO, reasons.AddInfo($"The user \"{userId}\" is not bucketed into a rollout for feature flag \"{featureFlag.Key}\"."));
-            return Result<FeatureDecision>.NullResult(reasons);
+            return Result<FeatureDecision>.NewResult(new FeatureDecision(null, null, FeatureDecision.DECISION_SOURCE_ROLLOUT), reasons); ;
         }
 
         /// <summary>

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -356,10 +356,12 @@ namespace OptimizelySDK.Config
             }
 
             var variationsDict = new Dictionary<string, List<Variation>>();
+            ///TODO: Need to remove.
             var flagToVariationsMap = new Dictionary<string, Dictionary<string, Variation>>();
             // Adding experiments in experiment-feature map and flag variation map to use.
             foreach (var feature in FeatureFlags)
             {
+                /// TODO: give proper name.
                 var map = new Dictionary<string, Variation>();
                 foreach (var experimentId in feature.ExperimentIds ?? new List<string>())
                 {

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -362,41 +362,30 @@ namespace OptimizelySDK.Config
             foreach (var feature in FeatureFlags)
             {
                 /// TODO: give proper name.
-                var map = new Dictionary<string, Variation>();
+                var flagVariationToVariationDict = new Dictionary<string, Variation>();
                 foreach (var experimentId in feature.ExperimentIds ?? new List<string>())
                 {
-                    var variationsKeyToVariationsMap = ExperimentIdMap[experimentId].VariationKeyToVariationMap;
-
-                    foreach (var kv in variationsKeyToVariationsMap) {
-                        map[kv.Key] = kv.Value;
+                    foreach (var variationDictKV in ExperimentIdMap[experimentId].VariationKeyToVariationMap) {
+                        flagVariationToVariationDict[variationDictKV.Key] = variationDictKV.Value;
                     }
 
                     if (ExperimentFeatureMap.ContainsKey(experimentId))
+                    {
                         ExperimentFeatureMap[experimentId].Add(feature.Id);
+                    }
                     else
+                    { 
                         ExperimentFeatureMap[experimentId] = new List<string> { feature.Id };
+                    }
                 }
                 if (RolloutIdMap.TryGetValue(feature.RolloutId, out var rolloutRules)) {
                     var rolloutRulesVariations = rolloutRules.Experiments.SelectMany(ex => ex.Variations);
                     foreach (var rolloutRuleVariation in rolloutRulesVariations) {
-                        map[rolloutRuleVariation.Key] = rolloutRuleVariation;
+                        flagVariationToVariationDict[rolloutRuleVariation.Key] = rolloutRuleVariation;
                     }
                 }
                 
-
-                flagToVariationsMap[feature.Key] = map;
-
-                //// Get the Flag variation map to use
-                //var variationIdToVariationsDict = new Dictionary<string, Variation>();
-                //foreach (var variation in from rule in GetAllRulesForFlag(feature)
-                //                          from variation in rule.Variations
-                //                          where !variationIdToVariationsDict.ContainsKey(variation.Id)
-                //                          select variation)
-                //{
-                //    variationIdToVariationsDict.Add(variation.Id, variation);
-                //}
-                //// Grab all the variations from the flag experiments and rollouts and add to flagVariationsMap
-                //variationsDict[feature.Key] = variationIdToVariationsDict.Values.ToList<Variation>();
+                flagToVariationsMap[feature.Key] = flagVariationToVariationDict;
             }
             _FlagVariationMap = flagToVariationsMap;
         }

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -374,11 +374,13 @@ namespace OptimizelySDK.Config
                     else
                         ExperimentFeatureMap[experimentId] = new List<string> { feature.Id };
                 }
-                var rolloutRules = RolloutIdMap[feature.RolloutId];
-                var rolloutRulesVariations = rolloutRules.Experiments.SelectMany(ex => ex.Variations);
-                foreach(var rolloutRuleVariation in rolloutRulesVariations) {
-                    map[rolloutRuleVariation.Key] = rolloutRuleVariation;
+                if (RolloutIdMap.TryGetValue(feature.RolloutId, out var rolloutRules)) {
+                    var rolloutRulesVariations = rolloutRules.Experiments.SelectMany(ex => ex.Variations);
+                    foreach (var rolloutRuleVariation in rolloutRulesVariations) {
+                        map[rolloutRuleVariation.Key] = rolloutRuleVariation;
+                    }
                 }
+                
 
                 flagToVariationsMap[feature.Key] = map;
 

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -205,9 +205,8 @@ namespace OptimizelySDK.Config
         private Dictionary<string, List<string>> ExperimentFeatureMap = new Dictionary<string, List<string>>();
 
         /// <summary>
-        /// Associated array of flags to variations key map.
+        /// Associated dictionary of flags to variations key value.
         /// </summary>
-
         private Dictionary<string, Dictionary<string, Variation>> _FlagVariationMap = new Dictionary<string, Dictionary<string, Variation>>();
         public Dictionary<string, Dictionary<string, Variation>> FlagVariationMap { get { return _FlagVariationMap; } }
 
@@ -355,18 +354,15 @@ namespace OptimizelySDK.Config
                 }
             }
 
-            var variationsDict = new Dictionary<string, List<Variation>>();
-            ///TODO: Need to remove.
             var flagToVariationsMap = new Dictionary<string, Dictionary<string, Variation>>();
             // Adding experiments in experiment-feature map and flag variation map to use.
             foreach (var feature in FeatureFlags)
             {
-                /// TODO: give proper name.
-                var flagVariationToVariationDict = new Dictionary<string, Variation>();
+                var variationKeyToVariationDict = new Dictionary<string, Variation>();
                 foreach (var experimentId in feature.ExperimentIds ?? new List<string>())
                 {
                     foreach (var variationDictKV in ExperimentIdMap[experimentId].VariationKeyToVariationMap) {
-                        flagVariationToVariationDict[variationDictKV.Key] = variationDictKV.Value;
+                        variationKeyToVariationDict[variationDictKV.Key] = variationDictKV.Value;
                     }
 
                     if (ExperimentFeatureMap.ContainsKey(experimentId))
@@ -381,41 +377,14 @@ namespace OptimizelySDK.Config
                 if (RolloutIdMap.TryGetValue(feature.RolloutId, out var rolloutRules)) {
                     var rolloutRulesVariations = rolloutRules.Experiments.SelectMany(ex => ex.Variations);
                     foreach (var rolloutRuleVariation in rolloutRulesVariations) {
-                        flagVariationToVariationDict[rolloutRuleVariation.Key] = rolloutRuleVariation;
+                        variationKeyToVariationDict[rolloutRuleVariation.Key] = rolloutRuleVariation;
                     }
                 }
                 
-                flagToVariationsMap[feature.Key] = flagVariationToVariationDict;
+                flagToVariationsMap[feature.Key] = variationKeyToVariationDict;
             }
             _FlagVariationMap = flagToVariationsMap;
         }
-
-        /// <summary>
-        /// Retrieves all the rules for a given feature flag
-        /// </summary>
-        /// <param name="flag">Feature flag to use</param>
-        /// <returns>A list of experiments</returns>
-        //private List<Experiment> GetAllRulesForFlag(FeatureFlag flag)
-        //{
-        //    var rules = new List<Experiment>();
-
-        //    RolloutIdMap.TryGetValue(flag.RolloutId, out var rollout);
-
-        //    foreach (var expId in flag.ExperimentIds)
-        //    {
-        //        if (ExperimentIdMap.TryGetValue(expId, out var rule))
-        //        {
-        //            rules.Add(rule);
-        //        }
-        //    }
-
-        //    if (rollout != null)
-        //    {
-        //        rules.AddRange(rollout.Experiments);
-        //    }
-
-        //    return rules;
-        //}
 
         /// <summary>
         /// Parse datafile string to create ProjectConfig instance.

--- a/OptimizelySDK/Entity/Result.cs
+++ b/OptimizelySDK/Entity/Result.cs
@@ -21,19 +21,7 @@ namespace OptimizelySDK.Entity
     {
         public T ResultObject;
         public DecisionReasons DecisionReasons;
-        public bool SkipToEveryoneElse;
 
-        /// <summary>
-        /// Result object with boolean variable as well
-        /// </summary>
-        /// <param name="resultObject"></param>
-        /// <param name="skipToEveryoneElse"></param>
-        /// <param name="decisionReasons"></param>
-        /// <returns></returns>
-        public static Result<T> NewResult(T resultObject, bool skipToEveryoneElse, DecisionReasons decisionReasons)
-        {
-            return new Result<T> { DecisionReasons = decisionReasons, ResultObject = resultObject, SkipToEveryoneElse = skipToEveryoneElse };
-        }
         public static Result<T> NewResult(T resultObject, DecisionReasons decisionReasons)
         {
             return new Result<T> { DecisionReasons = decisionReasons, ResultObject = resultObject };

--- a/OptimizelySDK/Entity/Result.cs
+++ b/OptimizelySDK/Entity/Result.cs
@@ -23,6 +23,13 @@ namespace OptimizelySDK.Entity
         public DecisionReasons DecisionReasons;
         public bool SkipToEveryoneElse;
 
+        /// <summary>
+        /// Result object with boolean variable as well
+        /// </summary>
+        /// <param name="resultObject"></param>
+        /// <param name="skipToEveryoneElse"></param>
+        /// <param name="decisionReasons"></param>
+        /// <returns></returns>
         public static Result<T> NewResult(T resultObject, bool skipToEveryoneElse, DecisionReasons decisionReasons)
         {
             return new Result<T> { DecisionReasons = decisionReasons, ResultObject = resultObject, SkipToEveryoneElse = skipToEveryoneElse };

--- a/OptimizelySDK/Event/Builder/EventBuilder.cs
+++ b/OptimizelySDK/Event/Builder/EventBuilder.cs
@@ -131,8 +131,8 @@ namespace OptimizelySDK.Event.Builder
             {
                     new Dictionary<string, object>
                     {
-                        { Params.CAMPAIGN_ID,   experiment != null ? experiment.LayerId : null },
-                        { Params.EXPERIMENT_ID, experiment != null ? experiment.Id : "" },
+                        { Params.CAMPAIGN_ID,   experiment?.LayerId },
+                        { Params.EXPERIMENT_ID, experiment?.Id ?? string.Empty },
                         { Params.VARIATION_ID,  variationId }
                     }
             };
@@ -176,11 +176,11 @@ namespace OptimizelySDK.Event.Builder
                     eventDict[EventTagUtils.REVENUE_EVENT_METRIC_NAME] = revenue;
                 }
 
-                var eventVallue = EventTagUtils.GetNumericValue(eventTags, Logger);
+                var eventValue = EventTagUtils.GetNumericValue(eventTags, Logger);
 
-                if (eventVallue != null)
+                if (eventValue != null)
                 {
-                    eventDict[EventTagUtils.VALUE_EVENT_METRIC_NAME] = eventVallue;
+                    eventDict[EventTagUtils.VALUE_EVENT_METRIC_NAME] = eventValue;
                 }
 
                 if (eventTags.Any())

--- a/OptimizelySDK/Event/EventFactory.cs
+++ b/OptimizelySDK/Event/EventFactory.cs
@@ -114,7 +114,7 @@ namespace OptimizelySDK.Event
             var eventContext = impressionEvent.Context;
 
             Decision decision = new Decision(impressionEvent.Experiment?.LayerId,
-                impressionEvent.Experiment?.Id ??"",
+                impressionEvent.Experiment?.Id ?? string.Empty,
                 impressionEvent.Variation?.Id,
                 impressionEvent.Metadata);
 

--- a/OptimizelySDK/Event/UserEventFactory.cs
+++ b/OptimizelySDK/Event/UserEventFactory.cs
@@ -84,7 +84,7 @@ namespace OptimizelySDK.Event
             if (variation != null)
             {
                 variationKey = variation.Key;
-                ruleKey = activatedExperiment != null ? activatedExperiment.Key : "";
+                ruleKey = activatedExperiment?.Key ?? string.Empty;
             }
             var metadata = new DecisionMetadata(flagKey, ruleKey, ruleType, variationKey, enabled);
 

--- a/OptimizelySDK/ForcedDecisionsStore.cs
+++ b/OptimizelySDK/ForcedDecisionsStore.cs
@@ -1,0 +1,80 @@
+﻿/*
+ * Copyright 2021, Optimizely
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+using System.Collections.Generic;
+
+namespace OptimizelySDK
+{
+    /// <summary>
+    /// ForcedDecisionsStore defines helper methods that are used for optimizelyDecisionContext object manipulation.
+    /// </summary>
+    public class ForcedDecisionsStore
+    {
+        public const string OPTI_NULL_RULE_KEY = "$opt-null-rule-key";
+        public const string OPTI_KEY_DIVIDER = "-$opt$-";
+
+        private Dictionary<string, OptimizelyForcedDecision> ForcedDecisionsMap { get; set; }
+
+        public ForcedDecisionsStore()
+        {
+            ForcedDecisionsMap = new Dictionary<string, OptimizelyForcedDecision>();
+        }
+
+        public int Count
+        {
+            get
+            {
+                return ForcedDecisionsMap.Count;
+            }
+        }
+        public bool Remove(OptimizelyDecisionContext context)
+        {
+            var decisionKey = getKey(context);
+            return ForcedDecisionsMap.Remove(decisionKey);
+        }
+
+        public void RemoveAll()
+        {
+            ForcedDecisionsMap.Clear();
+        }
+
+        private string getKey(OptimizelyDecisionContext context)
+        {
+            return string.Format("{0}{1}{2}", context.FlagKey, OPTI_KEY_DIVIDER, context.RuleKey ?? OPTI_NULL_RULE_KEY);
+        }
+
+        public OptimizelyForcedDecision this[OptimizelyDecisionContext context]
+        {
+            get
+            {
+                if (context != null && context.FlagKey != null
+                    && ForcedDecisionsMap.TryGetValue(getKey(context), out OptimizelyForcedDecision flagForcedDecision))
+                {
+                    return flagForcedDecision;
+                }
+                return null;
+            }
+            set
+            {
+                if (context != null && context.FlagKey != null)
+                {
+                    ForcedDecisionsMap[getKey(context)] = value;
+                }
+            }
+
+        }
+    }
+}

--- a/OptimizelySDK/ForcedDecisionsStore.cs
+++ b/OptimizelySDK/ForcedDecisionsStore.cs
@@ -24,10 +24,28 @@ namespace OptimizelySDK
     public class ForcedDecisionsStore
     {
         private Dictionary<string, OptimizelyForcedDecision> ForcedDecisionsMap { get; set; }
+        private static ForcedDecisionsStore NullForcedDecisionStore;
 
+        /// <summary>
+        /// Instantiates a NULL object when ForcedDecisionStore first time is used.
+        /// </summary>
+        static ForcedDecisionsStore()
+        {
+            NullForcedDecisionStore = new ForcedDecisionsStore();
+        }
         public ForcedDecisionsStore()
         {
             ForcedDecisionsMap = new Dictionary<string, OptimizelyForcedDecision>();
+        }
+
+        /// <summary>
+        /// This method will return instance of ForcedDecisionStore that won't be accessible from outside.
+        /// Instead of copying everytime or putting NULL for every forced decision condition, this approach looks fine to me.
+        /// </summary>
+        /// <returns></returns>
+        internal static ForcedDecisionsStore NullForcedDecision()
+        {
+            return NullForcedDecisionStore;
         }
 
         public ForcedDecisionsStore(ForcedDecisionsStore forcedDecisionsStore)

--- a/OptimizelySDK/ForcedDecisionsStore.cs
+++ b/OptimizelySDK/ForcedDecisionsStore.cs
@@ -23,14 +23,16 @@ namespace OptimizelySDK
     /// </summary>
     public class ForcedDecisionsStore
     {
-        public const string OPTI_NULL_RULE_KEY = "$opt-null-rule-key";
-        public const string OPTI_KEY_DIVIDER = "-$opt$-";
-
         private Dictionary<string, OptimizelyForcedDecision> ForcedDecisionsMap { get; set; }
 
         public ForcedDecisionsStore()
         {
             ForcedDecisionsMap = new Dictionary<string, OptimizelyForcedDecision>();
+        }
+
+        public ForcedDecisionsStore(ForcedDecisionsStore forcedDecisionsStore)
+        {
+            ForcedDecisionsMap = new Dictionary<string, OptimizelyForcedDecision>(forcedDecisionsStore.ForcedDecisionsMap);
         }
 
         public int Count
@@ -42,8 +44,7 @@ namespace OptimizelySDK
         }
         public bool Remove(OptimizelyDecisionContext context)
         {
-            var decisionKey = getKey(context);
-            return ForcedDecisionsMap.Remove(decisionKey);
+            return ForcedDecisionsMap.Remove(context.GetKey());
         }
 
         public void RemoveAll()
@@ -51,17 +52,12 @@ namespace OptimizelySDK
             ForcedDecisionsMap.Clear();
         }
 
-        private string getKey(OptimizelyDecisionContext context)
-        {
-            return string.Format("{0}{1}{2}", context.FlagKey, OPTI_KEY_DIVIDER, context.RuleKey ?? OPTI_NULL_RULE_KEY);
-        }
-
         public OptimizelyForcedDecision this[OptimizelyDecisionContext context]
         {
             get
             {
                 if (context != null && context.FlagKey != null
-                    && ForcedDecisionsMap.TryGetValue(getKey(context), out OptimizelyForcedDecision flagForcedDecision))
+                    && ForcedDecisionsMap.TryGetValue(context.GetKey(), out OptimizelyForcedDecision flagForcedDecision))
                 {
                     return flagForcedDecision;
                 }
@@ -71,7 +67,7 @@ namespace OptimizelySDK
             {
                 if (context != null && context.FlagKey != null)
                 {
-                    ForcedDecisionsMap[getKey(context)] = value;
+                    ForcedDecisionsMap[context.GetKey()] = value;
                 }
             }
 

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -451,28 +451,24 @@ namespace OptimizelySDK
         /// <param name="flagKey">The flag key for the variation</param>
         /// <param name="variationKey">The variation key for the variation</param>
         /// <returns>Returns a variation based on flagKey and variationKey, otherwise null</returns>
-        public Variation GetFlagVariationByKey(string flagKey, string variationKey)
-        {
-            var config = ProjectConfigManager?.GetConfig();
+        //public Variation GetFlagVariationByKey(string flagKey, string variationKey)
+        //{
+        //    var config = ProjectConfigManager?.GetConfig();
 
-            if (config == null)
-            {
-                return null;
-            }
+        //    if (config == null)
+        //    {
+        //        return null;
+        //    }
 
-            var flagVariationMap = config.FlagVariationMap;
-            if (flagVariationMap.TryGetValue(flagKey, out var variations))
-            {
-                foreach (var variation in from variation in variations
-                                          where variation.Key == variationKey
-                                          select variation)
-                {
-                    return variation;
-                }
-            }
+        //    if (config.FlagVariationMap.TryGetValue(flagKey, out var variationsKeyMap))
+        //    {
 
-            return null;
-        }
+        //        variationsKeyMap.TryGetValue(variationKey, out var variation);
+        //        return variation;
+        //    }
+
+        //    return null;
+        //}
 
         #region FeatureFlag APIs
 
@@ -790,7 +786,7 @@ namespace OptimizelySDK
             FeatureDecision decision = null;
 
             var decisionContext = new OptimizelyDecisionContext(flag.Key);
-            var forcedDecisionVariation = user.FindValidatedForcedDecision(decisionContext);
+            var forcedDecisionVariation = user.FindValidatedForcedDecision(decisionContext, config);
             decisionReasons += forcedDecisionVariation.DecisionReasons;
 
             if (forcedDecisionVariation.ResultObject != null)

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -445,31 +445,6 @@ namespace OptimizelySDK
             return DecisionService.GetForcedVariation(experimentKey, userId, config).ResultObject;
         }
 
-        /// <summary>
-        /// Gets a variation based on flagKey and variationKey
-        /// </summary>
-        /// <param name="flagKey">The flag key for the variation</param>
-        /// <param name="variationKey">The variation key for the variation</param>
-        /// <returns>Returns a variation based on flagKey and variationKey, otherwise null</returns>
-        //public Variation GetFlagVariationByKey(string flagKey, string variationKey)
-        //{
-        //    var config = ProjectConfigManager?.GetConfig();
-
-        //    if (config == null)
-        //    {
-        //        return null;
-        //    }
-
-        //    if (config.FlagVariationMap.TryGetValue(flagKey, out var variationsKeyMap))
-        //    {
-
-        //        variationsKeyMap.TryGetValue(variationKey, out var variation);
-        //        return variation;
-        //    }
-
-        //    return null;
-        //}
-
         #region FeatureFlag APIs
 
         /// <summary>

--- a/OptimizelySDK/OptimizelyDecisionContext.cs
+++ b/OptimizelySDK/OptimizelyDecisionContext.cs
@@ -22,8 +22,12 @@ namespace OptimizelySDK
     /// </summary>
     public class OptimizelyDecisionContext
     {
+        public const string OPTI_NULL_RULE_KEY = "$opt-null-rule-key";
+        public const string OPTI_KEY_DIVIDER = "-$opt$-";
+
         private string flagKey;
         private string ruleKey;
+        private string decisionKey;
 
         public string FlagKey { get { return flagKey; } }
         public string RuleKey { get { return ruleKey; } }
@@ -33,6 +37,12 @@ namespace OptimizelySDK
             this.flagKey = flagKey;
             this.ruleKey = ruleKey;
         }
+
+        public string GetKey()
+        {
+            return string.Format("{0}{1}{2}", FlagKey, OPTI_KEY_DIVIDER, RuleKey ?? OPTI_NULL_RULE_KEY);
+        }
+
 
     }
 }

--- a/OptimizelySDK/OptimizelyDecisionContext.cs
+++ b/OptimizelySDK/OptimizelyDecisionContext.cs
@@ -16,25 +16,22 @@
 
 namespace OptimizelySDK
 {
+    /// <summary>
+    /// ///TODO: Add documentation.
+    /// </summary>
     public class OptimizelyDecisionContext
     {
-        public const string OPTI_NULL_RULE_KEY = "$opt-null-rule-key";
-        public const string OPTI_KEY_DIVIDER = "-$opt$-";
         private string flagKey;
         private string ruleKey;
-        private string decisionKey;
 
-        public OptimizelyDecisionContext(string flagKey, string ruleKey = null)
+        public string FlagKey { get { return flagKey; } }
+        public string RuleKey { get { return ruleKey; } }
+
+        public OptimizelyDecisionContext(string flagKey, string ruleKey= null)
         {
             this.flagKey = flagKey;
             this.ruleKey = ruleKey;
-            this.decisionKey = string.Format("{0}{1}{2}", flagKey, OPTI_KEY_DIVIDER, ruleKey ?? OPTI_NULL_RULE_KEY);
         }
 
-        public string FlagKey { get { return flagKey; } }
-
-        public string RuleKey { get { return ruleKey; } }
-
-        public string DecisionKey { get { return decisionKey; } }
     }
 }

--- a/OptimizelySDK/OptimizelyDecisionContext.cs
+++ b/OptimizelySDK/OptimizelyDecisionContext.cs
@@ -17,7 +17,8 @@
 namespace OptimizelySDK
 {
     /// <summary>
-    /// ///TODO: Add documentation.
+    /// OptimizelyDecisionContext contains flag key and rule key to be used for setting 
+    /// and getting forced decision.
     /// </summary>
     public class OptimizelyDecisionContext
     {

--- a/OptimizelySDK/OptimizelyDecisionContext.cs
+++ b/OptimizelySDK/OptimizelyDecisionContext.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2020-2021, Optimizely
+ * Copyright 2021, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OptimizelySDK/OptimizelySDK.csproj
+++ b/OptimizelySDK/OptimizelySDK.csproj
@@ -92,6 +92,7 @@
     <Compile Include="OptimizelyDecisions\OptimizelyDecideOption.cs" />
     <Compile Include="OptimizelyDecisions\OptimizelyDecision.cs" />
     <Compile Include="OptimizelyForcedDecision.cs" />
+    <Compile Include="ForcedDecisionsStore.cs" />
     <Compile Include="OptimizelyUserContext.cs" />
     <Compile Include="OptimizelyJSON.cs" />
     <Compile Include="Entity\Rollout.cs" />

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -102,6 +102,11 @@ namespace OptimizelySDK
             ForcedDecisionsStore copiedForcedDecisionsStore = null;
             lock (mutex)
             {
+                if (ForcedDecisionsStore.Count == 0)
+                {
+                    copiedForcedDecisionsStore = ForcedDecisionsStore.NullForcedDecision();
+                }
+
                 copiedForcedDecisionsStore = new ForcedDecisionsStore(ForcedDecisionsStore);
             }
 

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -371,7 +371,7 @@ namespace OptimizelySDK
             DecisionReasons reasons = new DecisionReasons();
             var forcedDecision = GetForcedDecision(context);
 
-            if (forcedDecision != null)
+            if (config != null && forcedDecision != null)
             {
                 var loggingKey = context.RuleKey != null ? "flag (" + context.FlagKey + "), rule (" + context.RuleKey + ")" : "flag (" + context.FlagKey + ")";
                 var variationKey = forcedDecision.VariationKey;

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -105,9 +105,10 @@ namespace OptimizelySDK
                 if (ForcedDecisionsStore.Count == 0)
                 {
                     copiedForcedDecisionsStore = ForcedDecisionsStore.NullForcedDecision();
+                } else
+                {
+                    copiedForcedDecisionsStore = new ForcedDecisionsStore(ForcedDecisionsStore);
                 }
-
-                copiedForcedDecisionsStore = new ForcedDecisionsStore(ForcedDecisionsStore);
             }
 
             return copiedForcedDecisionsStore;

--- a/OptimizelySDK/ProjectConfig.cs
+++ b/OptimizelySDK/ProjectConfig.cs
@@ -118,10 +118,10 @@ namespace OptimizelySDK
         /// </summary>
         Dictionary<string, Rollout> RolloutIdMap { get; }
 
-        /// <summary>
-        /// Associative array of Flag to Variation in the datafile
+        /// <summary> ///TODO: Need to check either it's dictionary or array.
+        /// Associative dictionary of Flag to Variation key and Variation in the datafile
         /// </summary>
-        Dictionary<string, List<Variation>> FlagVariationMap { get; }
+        Dictionary<string, Dictionary<string, Variation>> FlagVariationMap { get; }
 
         //========================= Datafile Entities ===========================
 

--- a/OptimizelySDK/ProjectConfig.cs
+++ b/OptimizelySDK/ProjectConfig.cs
@@ -118,7 +118,7 @@ namespace OptimizelySDK
         /// </summary>
         Dictionary<string, Rollout> RolloutIdMap { get; }
 
-        /// <summary> ///TODO: Need to check either it's dictionary or array.
+        /// <summary>
         /// Associative dictionary of Flag to Variation key and Variation in the datafile
         /// </summary>
         Dictionary<string, Dictionary<string, Variation>> FlagVariationMap { get; }


### PR DESCRIPTION
## Summary
- Refactored code and fixed some minor issues. 
- Introduced ForcedDecisionStore class that will be used for storing forced decisions.
- Removed DecisionKey, instead introduced map of map in forceddecisionstore class. 
- GetFlagVariationKey removed from optimizely method, single source of truth for all mappings is DatafileProjectConfig class
- Added config in the FindValidatedForcedDecision since no access of ProjectConfig directly from OptimizelyUserContext.
- Refactored DecisionService, not needed for GetVariationFromExperimentRules or GetVariationFromDeliveryRules etc ... 
- No need of Separate mapping method in DatafileProjectConfig, tried to use existing maps to prepare FlagVariationsMap.
- Documentation corrected.

## Test plan
All FSC and unit tests should pass


## Issues
- I still see a little room of refactoring in DecisionService but for now this is fine. 