### PR TITLE
fix: CVE-2018-1285 update Log4Net

### DIFF
--- a/OptimizelySDK.DemoApp/OptimizelySDK.DemoApp.csproj
+++ b/OptimizelySDK.DemoApp/OptimizelySDK.DemoApp.csproj
@@ -52,9 +52,8 @@
       <HintPath>..\packages\Antlr.3.4.1.9004\lib\Antlr3.Runtime.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="log4net, Version=2.0.8.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
-      <HintPath>..\packages\log4net.2.0.8\lib\net45-full\log4net.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="log4net, Version=2.0.13.0, Culture=neutral, PublicKeyToken=669e0ddf0bb1aa2a, processorArchitecture=MSIL">
+      <HintPath>..\packages\log4net.2.0.13\lib\net45\log4net.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeDom.Providers.DotNetCompilerPlatform, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.1.0.0\lib\net45\Microsoft.CodeDom.Providers.DotNetCompilerPlatform.dll</HintPath>

--- a/OptimizelySDK.DemoApp/packages.config
+++ b/OptimizelySDK.DemoApp/packages.config
@@ -4,7 +4,7 @@
   <package id="bootstrap" version="4.0.0" targetFramework="net45" />
   <package id="jQuery" version="3.0.0" targetFramework="net45" />
   <package id="jQuery.Validation" version="1.11.1" targetFramework="net45" />
-  <package id="log4net" version="2.0.8" targetFramework="net45" />
+  <package id="log4net" version="2.0.13" targetFramework="net45" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="3.2.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net45" />


### PR DESCRIPTION
## Summary
- Update Log4Net to latest possible version to resolve [CVE-2018-1285](https://github.com/advisories/GHSA-2cwj-8chv-9pp9)

## Test plan
- all tests and fsc still pass
- Demo App loads after update.


