### PR TITLE
[OASIS-8370] Handle null, empty, or whitespaces for RolloutId

### DIFF
--- a/OptimizelySDK.Tests/EmptyRolloutRule.json
+++ b/OptimizelySDK.Tests/EmptyRolloutRule.json
@@ -25,6 +25,20 @@
       ],
       "id": "18244658520",
       "key": "empty_rollout"
+    },
+    {
+      "experimentIds": [],
+      "rolloutId": "",
+      "variables": [
+        {
+          "defaultValue": "",
+          "type": "string",
+          "id": "2832355113",
+          "key": "var_2"
+        }
+      ],
+      "id": "24246538512",
+      "key": "empty_rollout_id"
     }
   ],
   "experiments": [],

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -822,5 +822,18 @@ namespace OptimizelySDK.Tests
 
             Assert.True(typedConfig.IsFeatureExperiment(experiment.Id));
         }
+        
+        [Test]
+        public void TestRolloutWithEmptyStringRolloutId()
+        {
+            var rolloutId = string.Empty;
+            
+            var rollout = Config.GetRolloutFromId(rolloutId);
+
+            // OptlyConfig.OptimizelyConfigService.GetDeliveryRules L362
+            Assert.IsNull(rollout.Experiments);
+            // Bucketing.DecisionService.GetVariationForFeatureRollout L439
+            Assert.IsNull(rollout.Id);
+        }
     }
 }

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -850,5 +850,18 @@ namespace OptimizelySDK.Tests
             // Bucketing.DecisionService.GetVariationForFeatureRollout L439
             Assert.IsNull(rollout.Id);
         }
+        
+        [Test]
+        public void TestRolloutWithConsistingOfASingleSpaceRolloutId()
+        {
+            var rolloutId = " "; // single space
+            
+            var rollout = Config.GetRolloutFromId(rolloutId);
+
+            // OptlyConfig.OptimizelyConfigService.GetDeliveryRules L362
+            Assert.IsNull(rollout.Experiments);
+            // Bucketing.DecisionService.GetVariationForFeatureRollout L439
+            Assert.IsNull(rollout.Id);
+        }
     }
 }

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2017-2021, Optimizely
+ * Copyright 2017-2022, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -824,6 +824,21 @@ namespace OptimizelySDK.Tests
         }
         
         [Test]
+        public void TestRolloutWithEmptyStringRolloutIdFromConfigFile()
+        {
+            var projectConfig = DatafileProjectConfig.Create(TestData.EmptyRolloutDatafile, new NoOpLogger(), new NoOpErrorHandler());
+            Assert.IsNotNull(projectConfig);
+            var featureFlag = projectConfig.FeatureKeyMap["empty_rollout_id"];
+            
+            var rollout = projectConfig.GetRolloutFromId(featureFlag.RolloutId);
+
+            // OptlyConfig.OptimizelyConfigService.GetDeliveryRules L362
+            Assert.IsNull(rollout.Experiments);
+            // Bucketing.DecisionService.GetVariationForFeatureRollout L439
+            Assert.IsNull(rollout.Id);
+        }
+        
+        [Test]
         public void TestRolloutWithEmptyStringRolloutId()
         {
             var rolloutId = string.Empty;

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -826,15 +826,13 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestRolloutWithEmptyStringRolloutIdFromConfigFile()
         {
-            var projectConfig = DatafileProjectConfig.Create(TestData.EmptyRolloutDatafile, new NoOpLogger(), new NoOpErrorHandler());
+            var projectConfig = DatafileProjectConfig.Create(TestData.EmptyRolloutDatafile, null, null);
             Assert.IsNotNull(projectConfig);
             var featureFlag = projectConfig.FeatureKeyMap["empty_rollout_id"];
             
             var rollout = projectConfig.GetRolloutFromId(featureFlag.RolloutId);
 
-            // OptlyConfig.OptimizelyConfigService.GetDeliveryRules L362
             Assert.IsNull(rollout.Experiments);
-            // Bucketing.DecisionService.GetVariationForFeatureRollout L439
             Assert.IsNull(rollout.Id);
         }
         
@@ -845,9 +843,7 @@ namespace OptimizelySDK.Tests
             
             var rollout = Config.GetRolloutFromId(rolloutId);
 
-            // OptlyConfig.OptimizelyConfigService.GetDeliveryRules L362
             Assert.IsNull(rollout.Experiments);
-            // Bucketing.DecisionService.GetVariationForFeatureRollout L439
             Assert.IsNull(rollout.Id);
         }
         
@@ -858,9 +854,18 @@ namespace OptimizelySDK.Tests
             
             var rollout = Config.GetRolloutFromId(rolloutId);
 
-            // OptlyConfig.OptimizelyConfigService.GetDeliveryRules L362
             Assert.IsNull(rollout.Experiments);
-            // Bucketing.DecisionService.GetVariationForFeatureRollout L439
+            Assert.IsNull(rollout.Id);
+        }
+        
+        [Test]
+        public void TestRolloutWithConsistingOfANullRolloutId()
+        {
+            string nullRolloutId = null;
+            
+            var rollout = Config.GetRolloutFromId(nullRolloutId);
+
+            Assert.IsNull(rollout.Experiments);
             Assert.IsNull(rollout.Id);
         }
     }

--- a/OptimizelySDK.sln.DotSettings
+++ b/OptimizelySDK.sln.DotSettings
@@ -13,6 +13,7 @@
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/CASE_BLOCK_BRACES/@EntryValue">END_OF_LINE</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/EMPTY_BLOCK_STYLE/@EntryValue">TOGETHER_SAME_LINE</s:String>
 	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_EXPR_MEMBER_ARRANGEMENT/@EntryValue">False</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/KEEP_EXISTING_INITIALIZER_ARRANGEMENT/@EntryValue">False</s:Boolean>
 	<s:Int64 x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/MAX_INITIALIZER_ELEMENTS_ON_LINE/@EntryValue">0</s:Int64>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/OTHER_BRACES/@EntryValue">END_OF_LINE</s:String>
 	<s:String x:Key="/Default/CodeStyle/CodeFormatting/CSharpFormat/PLACE_ACCESSOR_ATTRIBUTE_ON_SAME_LINE_EX/@EntryValue">NEVER</s:String>
@@ -40,4 +41,8 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=EnumMember/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=Interfaces/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="I" Suffix="" Style="AaBb" /&gt;</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=LocalConstants/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="AA_BB" /&gt;</s:String>
-	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String></wpf:ResourceDictionary>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateStaticReadonly/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="" Suffix="" Style="aaBb" /&gt;</s:String>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -636,7 +636,11 @@ namespace OptimizelySDK.Config
         /// <returns>Rollout Entity corresponding to the rollout ID or a dummy entity if ID is invalid</returns>
         public Rollout GetRolloutFromId(string rolloutId)
         {
-            if (string.IsNullOrEmpty(rolloutId.Trim()))
+#if NET35 || NET40
+    if (string.IsNullOrEmpty(rolloutId) || string.IsNullOrEmpty(rolloutId.Trim()))
+#else
+    if (string.IsNullOrWhiteSpace(rolloutId))
+#endif
             {
                 return new Rollout();
             }

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -636,7 +636,7 @@ namespace OptimizelySDK.Config
         /// <returns>Rollout Entity corresponding to the rollout ID or a dummy entity if ID is invalid</returns>
         public Rollout GetRolloutFromId(string rolloutId)
         {
-            if (string.IsNullOrWhiteSpace(rolloutId))
+            if (string.IsNullOrEmpty(rolloutId.Trim()))
             {
                 return new Rollout();
             }

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -636,6 +636,11 @@ namespace OptimizelySDK.Config
         /// <returns>Rollout Entity corresponding to the rollout ID or a dummy entity if ID is invalid</returns>
         public Rollout GetRolloutFromId(string rolloutId)
         {
+            if (string.IsNullOrWhiteSpace(rolloutId))
+            {
+                return new Rollout();
+            }
+            
             if (_RolloutIdMap.ContainsKey(rolloutId))
                 return _RolloutIdMap[rolloutId];
 

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2019-2021, Optimizely
+ * Copyright 2019-2022, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary
- Handle possible empty string `rolloutId` in datafile

An empty string rolloutId should be ignored and not raise and exception

## Test plan

Unit test added to OptimizelySDK.Tests/ProjectConfigTest.cs

## Issues
- OASIS-8370