### PR TITLE
Fix: ODP Event manager not consistent in triggering events.

### DIFF
--- a/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
@@ -311,7 +311,7 @@ namespace OptimizelySDK.Tests.OdpTests
         }
 
         [Test]
-        public void ShouldAttemptToFlushAnEmptyQueueAtFlushInterval()
+        public void ShouldNotAttemptToFlushAnEmptyQueueAtFlushInterval()
         {
             var eventManager = new OdpEventManager.Builder().
                 WithOdpEventApiManager(_mockApiManager.Object).
@@ -327,7 +327,7 @@ namespace OptimizelySDK.Tests.OdpTests
             eventManager.Stop();
 
             _mockLogger.Verify(l => l.Log(LogLevel.DEBUG, "Flushing queue."),
-                Times.AtLeast(3));
+                Times.Never);
         }
 
         [Test]

--- a/OptimizelySDK/Notifications/NotificationCenterRegistry.cs
+++ b/OptimizelySDK/Notifications/NotificationCenterRegistry.cs
@@ -15,7 +15,6 @@
  */
 
 using OptimizelySDK.Logger;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 
 namespace OptimizelySDK.Notifications
@@ -24,7 +23,8 @@ namespace OptimizelySDK.Notifications
     {
         private static readonly object _mutex = new object();
 
-        private static ConcurrentDictionary<string, NotificationCenter> _notificationCenters = new ConcurrentDictionary<string, NotificationCenter>();
+        private static Dictionary<string, NotificationCenter> _notificationCenters =
+            new Dictionary<string, NotificationCenter>();
 
         /// <summary>
         /// Thread-safe access to the NotificationCenter
@@ -40,16 +40,18 @@ namespace OptimizelySDK.Notifications
                 return default;
             }
 
-            NotificationCenter notificationCenter = null;
-            
-            if (_notificationCenters.ContainsKey(sdkKey))
+            NotificationCenter notificationCenter;
+            lock (_mutex)
             {
-                notificationCenter = _notificationCenters[sdkKey];
-            }
-            else
-            {
-                notificationCenter = new NotificationCenter(logger);
-                _notificationCenters[sdkKey] = notificationCenter;
+                if (_notificationCenters.ContainsKey(sdkKey))
+                {
+                    notificationCenter = _notificationCenters[sdkKey];
+                }
+                else
+                {
+                    notificationCenter = new NotificationCenter(logger);
+                    _notificationCenters[sdkKey] = notificationCenter;
+                }
             }
 
             return notificationCenter;
@@ -72,7 +74,7 @@ namespace OptimizelySDK.Notifications
                         out NotificationCenter notificationCenter))
                 {
                     notificationCenter.ClearAllNotifications();
-                    _notificationCenters.TryRemove(sdkKey, out NotificationCenter obj);
+                    _notificationCenters.Remove(sdkKey);
                 }
             }
         }

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -146,10 +146,10 @@ namespace OptimizelySDK.Odp
             {
                 while (true)
                 {
-                    Object item;
+                    object item;
                     // If batch has events, set the timeout to remaining time for flush interval,
                     //      otherwise wait for the new event indefinitely
-                    if (_eventQueue.Count > 0)
+                    if (_currentBatch.Count > 0)
                     {
                         _eventQueue.TryTake(out item, (int)(_flushingIntervalDeadline - DateTime.Now.MillisecondsSince1970()));
                     }
@@ -160,8 +160,11 @@ namespace OptimizelySDK.Odp
                     if (item == null)
                     {
                         // null means no new events received and flush interval is over, dispatch whatever is in the batch.
-                        _logger.Log(LogLevel.DEBUG, $"Flushing queue.");
-                        FlushQueue();
+                        if (_currentBatch.Count != 0)
+                        {
+                            _logger.Log(LogLevel.DEBUG, $"Flushing queue.");
+                            FlushQueue();
+                        }
                         continue;
                     }
 

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -152,9 +152,9 @@ namespace OptimizelySDK.Odp
                         FlushQueue();
                     }
 
-                    if (!_eventQueue.TryTake(out object item, 50))
+                    if (!_eventQueue.TryTake(out object item, (int)
+                        (_flushingIntervalDeadline - DateTime.Now.MillisecondsSince1970())))
                     {
-                        Thread.Sleep(50);
                         continue;
                     }
 

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -168,7 +168,7 @@ namespace OptimizelySDK.Odp
                             FlushQueue();
                         }
                         continue;
-                    } 
+                    }
                     else if (item == _shutdownSignal)
                     {
                         _logger.Log(LogLevel.INFO, "Received shutdown signal.");

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -156,6 +156,7 @@ namespace OptimizelySDK.Odp
                     else
                     {
                         item = _eventQueue.Take();
+                        Thread.Sleep(1); // TODO: need to figure out why this is allowing item to read shutdown signal.
                     }
                     if (item == null)
                     {
@@ -166,25 +167,24 @@ namespace OptimizelySDK.Odp
                             FlushQueue();
                         }
                         continue;
-                    }
-
-                    if (item == _shutdownSignal)
+                    } 
+                    else if (item == _shutdownSignal)
                     {
                         _logger.Log(LogLevel.INFO, "Received shutdown signal.");
                         break;
                     }
 
-                    if (item == _flushSignal)
+                    else if (item == _flushSignal)
                     {
                         _logger.Log(LogLevel.DEBUG, "Received flush signal.");
                         FlushQueue();
                         continue;
                     }
-
-                    if (item is OdpEvent odpEvent)
+                    else if (item is OdpEvent odpEvent)
                     {
                         AddToBatch(odpEvent);
                     }
+
                 }
             }
             catch (InvalidOperationException ioe)

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -158,6 +158,7 @@ namespace OptimizelySDK.Odp
                         item = _eventQueue.Take();
                         Thread.Sleep(1); // TODO: need to figure out why this is allowing item to read shutdown signal.
                     }
+
                     if (item == null)
                     {
                         // null means no new events received and flush interval is over, dispatch whatever is in the batch.
@@ -173,7 +174,6 @@ namespace OptimizelySDK.Odp
                         _logger.Log(LogLevel.INFO, "Received shutdown signal.");
                         break;
                     }
-
                     else if (item == _flushSignal)
                     {
                         _logger.Log(LogLevel.DEBUG, "Received flush signal.");


### PR DESCRIPTION
## Summary
- Refactored OdpEventManager flushEvent function. 
- To wait for events using flushInterval when eventBatch is not empty.
- Or wait indefinitely if no event is in batch until any event arrive. 
- Avoid calling flush on shutdown if no events are present 
- Avoid calling unnecessary flushQueue if _currentBatch.Count is zero. 
 
## Test plan
Passing build link with FSC: [link](https://github.com/optimizely/fullstack-sdk-compatibility-suite/actions/runs/4163960853/jobs/7206348700)

## Issues
- [TODO]