### PR TITLE
maint: apply code formatting rules to pass CI linter

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,239 +1,129 @@
-# Remove the line below if you want to inherit .editorconfig settings from higher directories
 root = true
 
-# C# files
-[*.cs]
+###############################
+# Core EditorConfig Options   #
+###############################
+# https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/code-style-rule-options
 
-#### Core EditorConfig Options ####
-
-# Indentation and spacing
+# All files
+[*]
 indent_style = space
 
-# New line preferences
-insert_final_newline = true
+# XML project files
+[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
+indent_size = 2
 
-#### .NET Coding Conventions ####
+# XML config files
+[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
+indent_size = 2
 
-# Organize usings
-dotnet_separate_import_directive_groups = false
-dotnet_sort_system_directives_first = false
-file_header_template = unset
-
-# this. and Me. preferences
-dotnet_style_qualification_for_event = false
-dotnet_style_qualification_for_field = false
-dotnet_style_qualification_for_method = false
-dotnet_style_qualification_for_property = false
-
-# Language keywords vs BCL types preferences
-dotnet_style_predefined_type_for_locals_parameters_members = true
-dotnet_style_predefined_type_for_member_access = true
-
-# Parentheses preferences
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity
-
-# Modifier preferences
-dotnet_style_require_accessibility_modifiers = for_non_interface_members
-
-# Expression-level preferences
-dotnet_style_coalesce_expression = true
-dotnet_style_collection_initializer = true
-dotnet_style_explicit_tuple_names = true
-dotnet_style_namespace_match_folder = true
-dotnet_style_null_propagation = true
-dotnet_style_object_initializer = true
-dotnet_style_operator_placement_when_wrapping = beginning_of_line
-dotnet_style_prefer_auto_properties = true
-dotnet_style_prefer_compound_assignment = true
-dotnet_style_prefer_conditional_expression_over_assignment = true
-dotnet_style_prefer_conditional_expression_over_return = true
-dotnet_style_prefer_inferred_anonymous_type_member_names = true
-dotnet_style_prefer_inferred_tuple_names = true
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true
-dotnet_style_prefer_simplified_boolean_expressions = true
-dotnet_style_prefer_simplified_interpolation = true
-
-# Field preferences
-dotnet_style_readonly_field = true
-
-# Parameter preferences
-dotnet_code_quality_unused_parameters = all
-
-# Suppression preferences
-dotnet_remove_unnecessary_suppression_exclusions = none
-
-# New line preferences
-dotnet_style_allow_multiple_blank_lines_experimental = true
-dotnet_style_allow_statement_immediately_after_block_experimental = true
-
-#### C# Coding Conventions ####
-
-# var preferences
-csharp_style_var_elsewhere = false
-csharp_style_var_for_built_in_types = false
-csharp_style_var_when_type_is_apparent = false
-
-# Expression-bodied members
-csharp_style_expression_bodied_accessors = true:silent
-csharp_style_expression_bodied_constructors = false:silent
-csharp_style_expression_bodied_indexers = true:silent
-csharp_style_expression_bodied_lambdas = true:silent
-csharp_style_expression_bodied_local_functions = false:silent
-csharp_style_expression_bodied_methods = false:silent
-csharp_style_expression_bodied_operators = false:silent
-csharp_style_expression_bodied_properties = true:silent
-
-# Pattern matching preferences
-csharp_style_pattern_matching_over_as_with_null_check = true
-csharp_style_pattern_matching_over_is_with_cast_check = true
-csharp_style_prefer_extended_property_pattern = true
-csharp_style_prefer_not_pattern = true
-csharp_style_prefer_pattern_matching = true
-csharp_style_prefer_switch_expression = true
-
-# Null-checking preferences
-csharp_style_conditional_delegate_call = true
-
-# Modifier preferences
-csharp_prefer_static_local_function = true
-csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async
-
-# Code-block preferences
-csharp_prefer_braces = true:silent
-csharp_prefer_simple_using_statement = true:suggestion
-csharp_style_namespace_declarations = block_scoped:silent
-
-# Expression-level preferences
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_style_deconstructed_variable_declaration = true
-csharp_style_implicit_object_creation_when_type_is_apparent = true
-csharp_style_inlined_variable_declaration = true
-csharp_style_prefer_index_operator = true
-csharp_style_prefer_local_over_anonymous_function = true:suggestion
-csharp_style_prefer_null_check_over_type_check = true:suggestion
-csharp_style_prefer_range_operator = true
-csharp_style_prefer_tuple_swap = true
-csharp_style_throw_expression = true:suggestion
-csharp_style_unused_value_assignment_preference = discard_variable
-csharp_style_unused_value_expression_statement_preference = discard_variable
-
-# 'using' directive preferences
-csharp_using_directive_placement = outside_namespace:silent
-
-# New line preferences
-csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true
-csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true
-csharp_style_allow_embedded_statements_on_same_line_experimental = true
-
-#### C# Formatting Rules ####
-
-# New line preferences
-csharp_new_line_before_catch = true
-csharp_new_line_before_else = true
-csharp_new_line_before_finally = true
-csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_before_members_in_object_initializers = true
-csharp_new_line_before_open_brace = all
-csharp_new_line_between_query_expression_clauses = true
-
-# Indentation preferences
-csharp_indent_block_contents = true
-csharp_indent_braces = false
-csharp_indent_case_contents = true
-csharp_indent_case_contents_when_block = true
-csharp_indent_labels = one_less_than_current
-csharp_indent_switch_labels = true
-
-# Space preferences
-csharp_space_after_cast = false
-csharp_space_after_colon_in_inheritance_clause = true
-csharp_space_after_comma = true
-csharp_space_after_dot = false
-csharp_space_after_keywords_in_control_flow_statements = true
-csharp_space_after_semicolon_in_for_statement = true
-csharp_space_around_binary_operators = before_and_after
-csharp_space_around_declaration_statements = false
-csharp_space_before_colon_in_inheritance_clause = true
-csharp_space_before_comma = false
-csharp_space_before_dot = false
-csharp_space_before_open_square_brackets = false
-csharp_space_before_semicolon_in_for_statement = false
-csharp_space_between_empty_square_brackets = false
-csharp_space_between_method_call_empty_parameter_list_parentheses = false
-csharp_space_between_method_call_name_and_opening_parenthesis = false
-csharp_space_between_method_call_parameter_list_parentheses = false
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
-csharp_space_between_method_declaration_name_and_open_parenthesis = false
-csharp_space_between_method_declaration_parameter_list_parentheses = false
-csharp_space_between_parentheses = false
-csharp_space_between_square_brackets = false
-
-# Wrapping preferences
-csharp_preserve_single_line_blocks = true
-csharp_preserve_single_line_statements = true
-
-#### Naming styles ####
-
-# Naming rules
-
-dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
-dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
-dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
-
-dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.types_should_be_pascal_case.symbols = types
-dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
-
-dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
-dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
-
-# Symbol specifications
-
-dotnet_naming_symbols.interface.applicable_kinds = interface
-dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers =
-
-dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
-dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers =
-
-dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
-dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers =
-
-# Naming styles
-
-dotnet_naming_style.pascal_case.required_prefix =
-dotnet_naming_style.pascal_case.required_suffix =
-dotnet_naming_style.pascal_case.word_separator =
-dotnet_naming_style.pascal_case.capitalization = pascal_case
-
-dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix =
-dotnet_naming_style.begins_with_i.word_separator =
-dotnet_naming_style.begins_with_i.capitalization = pascal_case
-
-[*.{cs,vb}]
-dotnet_style_operator_placement_when_wrapping = beginning_of_line
-tab_width = 4
+# Code files
+[*.{cs,csx,vb,vbx}]
 indent_size = 4
-end_of_line = lf
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
-dotnet_style_prefer_auto_properties = true:silent
+insert_final_newline = true
+charset = utf-8-bom
+###############################
+# .NET Coding Conventions     #
+###############################
+[*.{cs,vb}]
+# Organize usings
+dotnet_sort_system_directives_first = true
+# this. preferences
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_event = false:silent
+# Language keywords vs BCL types preferences
+dotnet_style_predefined_type_for_locals_parameters_members = true:silent
+dotnet_style_predefined_type_for_member_access = true:silent
+# Parentheses preferences
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+# Modifier preferences
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
+dotnet_style_readonly_field = true:suggestion
+# Expression-level preferences
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
-dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_style_prefer_conditional_expression_over_return = true:silent
 dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
 dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_compound_assignment = true:suggestion
-dotnet_style_prefer_simplified_interpolation = true:suggestion
-dotnet_style_namespace_match_folder = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+###############################
+# Naming Conventions          #
+###############################
+# Style Definitions
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+# Use PascalCase for constant fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.applicable_accessibilities = *
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+###############################
+# C# Coding Conventions       #
+###############################
+[*.cs]
+# var preferences
+csharp_style_var_for_built_in_types = true:silent
+csharp_style_var_when_type_is_apparent = true:silent
+csharp_style_var_elsewhere = true:silent
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+# Pattern matching preferences
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+# Null-checking preferences
+csharp_style_throw_expression = true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion
+# Modifier preferences
+csharp_preferred_modifier_order = public, private, protected, internal, static, extern, new, virtual, abstract, sealed, override, readonly, unsafe, volatile, async:suggestion
+# Expression-level preferences
+csharp_prefer_braces = true:silent
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_prefer_local_over_anonymous_function = true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion
+###############################
+# C# Formatting Rules         #
+###############################
+# New line preferences
+csharp_new_line_before_open_brace = all
+csharp_new_line_before_else = true
+csharp_new_line_before_catch = true
+csharp_new_line_before_finally = true
+csharp_new_line_before_members_in_object_initializers = false
+csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+# Indentation preferences
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+# Space preferences
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+csharp_space_before_colon_in_inheritance_clause = true
+csharp_space_after_colon_in_inheritance_clause = true
+csharp_space_around_binary_operators = before_and_after
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
+csharp_space_between_method_call_name_and_opening_parenthesis = false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false
+# Wrapping preferences
+csharp_preserve_single_line_statements = true
+csharp_preserve_single_line_blocks = true

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -25,7 +25,7 @@ jobs:
         uses: github/super-linter@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: false
+          VALIDATE_ALL_CODEBASE: true
           DEFAULT_BRANCH: master
           VALIDATE_CSHARP: true
           VALIDATE_MARKDOWN: true

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -25,7 +25,7 @@ jobs:
         uses: github/super-linter@v4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: true
+          VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: master
           VALIDATE_CSHARP: true
           VALIDATE_MARKDOWN: true

--- a/OptimizelySDK.Tests/App.config
+++ b/OptimizelySDK.Tests/App.config
@@ -5,44 +5,47 @@
 -->
 <configuration>
 
-  <configSections>
-    <section name="optlySDKConfigSection"
-             type="OptimizelySDK.OptimizelySDKConfigSection, OptimizelySDK" />
-  </configSections>
-  
-  <optlySDKConfigSection>
-  
-    <HttpProjectConfig sdkKey="43214321" 
-                       url="www.testurl.com" 
-                       format="https://cdn.optimizely.com/data/{0}.json" 
-                       pollingInterval="2000" 
-                       blockingTimeOutPeriod="10000" 
-                       datafileAccessToken="testingtoken123"
-                       autoUpdate="true" 
-                       defaultStart="true">
-    </HttpProjectConfig>
+    <configSections>
+        <section name="optlySDKConfigSection"
+                 type="OptimizelySDK.OptimizelySDKConfigSection, OptimizelySDK"/>
+    </configSections>
 
-    <BatchEventProcessor batchSize="10"
-                         flushInterval="2000"
-                         timeoutInterval="10000"
-                         defaultStart="true">
-    </BatchEventProcessor>
-  
-  </optlySDKConfigSection>
-  
+    <optlySDKConfigSection>
+
+        <HttpProjectConfig sdkKey="43214321"
+                           url="www.testurl.com"
+                           format="https://cdn.optimizely.com/data/{0}.json"
+                           pollingInterval="2000"
+                           blockingTimeOutPeriod="10000"
+                           datafileAccessToken="testingtoken123"
+                           autoUpdate="true"
+                           defaultStart="true">
+        </HttpProjectConfig>
+
+        <BatchEventProcessor batchSize="10"
+                             flushInterval="2000"
+                             timeoutInterval="10000"
+                             defaultStart="true">
+        </BatchEventProcessor>
+
+    </optlySDKConfigSection>
+
     <connectionStrings>
 
     </connectionStrings>
-  <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234" />
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0" />
-      </dependentAssembly>
-    </assemblyBinding>
-  </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>
+    <runtime>
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-1.5.2.14234" newVersion="1.5.2.14234"/>
+            </dependentAssembly>
+            <dependentAssembly>
+                <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+                <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
+            </dependentAssembly>
+        </assemblyBinding>
+    </runtime>
+    <startup>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/>
+    </startup>
+</configuration>

--- a/OptimizelySDK.Tests/Assertions.cs
+++ b/OptimizelySDK.Tests/Assertions.cs
@@ -36,10 +36,14 @@ namespace OptimizelySDK.Tests
     {
         #region Basic asserts
 
-        public static bool HasItems(IEnumerable<object> expected, IEnumerable<object> actual, bool allowNull = true)
+        public static bool HasItems(IEnumerable<object> expected, IEnumerable<object> actual,
+            bool allowNull = true
+        )
         {
             if (allowNull && expected == null && actual == null)
+            {
                 return false;
+            }
 
             Assert.AreEqual(expected.Count(), actual.Count());
 
@@ -51,40 +55,50 @@ namespace OptimizelySDK.Tests
             if (HasItems(expected, actual, false))
             {
                 var zipped = expected.Zip(actual, (e, a) =>
-                {
-                    return new
                     {
-                        Expected = e,
-                        Actual = a
-                    };
-                }).ToList();
+                        return new
+                        {
+                            Expected = e,
+                            Actual = a,
+                        };
+                    }).
+                    ToList();
 
                 foreach (var z in zipped)
                 {
                     Assert.AreEqual(z.Expected, z.Actual);
-                };
+                }
+
+                ;
             }
         }
 
-        public static void AreEquivalent(Dictionary<string, string> expected, Dictionary<string, string> actual)
+        public static void AreEquivalent(Dictionary<string, string> expected,
+            Dictionary<string, string> actual
+        )
         {
             Assert.AreEqual(expected.Count, actual.Count);
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 AreEqual(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
-        public static void AreEqual(KeyValuePair<string, string> expected, KeyValuePair<string, string> actual)
+        public static void AreEqual(KeyValuePair<string, string> expected,
+            KeyValuePair<string, string> actual
+        )
         {
             Assert.AreEqual(expected.Key, actual.Key);
             Assert.AreEqual(expected.Value, actual.Value);
@@ -95,7 +109,9 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(expected.ToString(), actual.ToString());
         }
 
-        private static void AreEquivalent(KeyValuePair<string, object> expected, KeyValuePair<string, object> actual)
+        private static void AreEquivalent(KeyValuePair<string, object> expected,
+            KeyValuePair<string, object> actual
+        )
         {
             Assert.AreEqual(expected.Key, actual.Key);
             Assert.AreEqual(expected.Value, actual.Value);
@@ -105,7 +121,9 @@ namespace OptimizelySDK.Tests
 
         #region
 
-        public static void AreEqual(OptimizelyForcedDecision expected, OptimizelyForcedDecision actual)
+        public static void AreEqual(OptimizelyForcedDecision expected,
+            OptimizelyForcedDecision actual
+        )
         {
             Assert.AreEqual(expected.VariationKey, actual.VariationKey);
         }
@@ -114,22 +132,27 @@ namespace OptimizelySDK.Tests
 
         #region OptimizelyAttribute
 
-        public static void AreEquivalent(OptimizelyAttribute[] expected, OptimizelyAttribute[] actual)
+        public static void AreEquivalent(OptimizelyAttribute[] expected,
+            OptimizelyAttribute[] actual
+        )
         {
             Assert.AreEqual(expected.Count(), actual.Count());
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 AreEqual(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
         public static void AreEqual(OptimizelyAttribute expected, OptimizelyAttribute actual)
@@ -142,22 +165,26 @@ namespace OptimizelySDK.Tests
 
         #region OptimizelyAudience
 
-        private static void AreEquivalent(OptimizelyAudience[] expected, OptimizelyAudience[] actual)
+        private static void AreEquivalent(OptimizelyAudience[] expected, OptimizelyAudience[] actual
+        )
         {
             Assert.AreEqual(expected.Count(), actual.Count());
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 AreEqual(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
         private static void AreEqual(OptimizelyAudience expected, OptimizelyAudience actual)
@@ -197,18 +224,21 @@ namespace OptimizelySDK.Tests
         {
             Assert.AreEqual(expected.Count, actual.Count);
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 AreEquivalent(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
         #endregion
@@ -219,18 +249,21 @@ namespace OptimizelySDK.Tests
         {
             Assert.AreEqual(expected.Count(), actual.Count());
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 AreEqual(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
         private static void AreEqual(OptimizelyEvent expected, OptimizelyEvent actual)
@@ -254,25 +287,32 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(expected.VariationKey, actual.VariationKey);
         }
 
-        public static void AreEquivalent(IDictionary<string, OptimizelyDecision> expected, IDictionary<string, OptimizelyDecision> actual)
+        public static void AreEquivalent(IDictionary<string, OptimizelyDecision> expected,
+            IDictionary<string, OptimizelyDecision> actual
+        )
         {
             Assert.AreEqual(expected.Count, actual.Count);
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 AreEquivalent(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
-        public static void AreEquivalent(KeyValuePair<string, OptimizelyDecision> expected, KeyValuePair<string, OptimizelyDecision> actual)
+        public static void AreEquivalent(KeyValuePair<string, OptimizelyDecision> expected,
+            KeyValuePair<string, OptimizelyDecision> actual
+        )
         {
             Assert.AreEqual(expected.Key, actual.Key);
             AreEqual(expected.Value, actual.Value);
@@ -282,22 +322,27 @@ namespace OptimizelySDK.Tests
 
         #region OptimizelyExperiement
 
-        public static void AreEquivalent(List<OptimizelyExperiment> expected, List<OptimizelyExperiment> actual)
+        public static void AreEquivalent(List<OptimizelyExperiment> expected,
+            List<OptimizelyExperiment> actual
+        )
         {
             Assert.AreEqual(expected.Count, actual.Count);
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 AreEqual(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
         public static void AreEqual(OptimizelyExperiment expected, OptimizelyExperiment actual)
@@ -307,25 +352,32 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(expected.Audiences, actual.Audiences);
         }
 
-        public static void AreEquivalent(IDictionary<string, OptimizelyExperiment> expected, IDictionary<string, OptimizelyExperiment> actual)
+        public static void AreEquivalent(IDictionary<string, OptimizelyExperiment> expected,
+            IDictionary<string, OptimizelyExperiment> actual
+        )
         {
             Assert.AreEqual(expected.Count, actual.Count);
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 AreEquivalent(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
-        public static void AreEquivalent(KeyValuePair<string, OptimizelyExperiment> expected, KeyValuePair<string, OptimizelyExperiment> actual)
+        public static void AreEquivalent(KeyValuePair<string, OptimizelyExperiment> expected,
+            KeyValuePair<string, OptimizelyExperiment> actual
+        )
         {
             Assert.AreEqual(expected.Key, actual.Key);
             AreEqual(expected.Value, actual.Value);
@@ -335,25 +387,32 @@ namespace OptimizelySDK.Tests
 
         #region OptimizelyFeature
 
-        public static void AreEquivalent(IDictionary<string, OptimizelyFeature> expected, IDictionary<string, OptimizelyFeature> actual)
+        public static void AreEquivalent(IDictionary<string, OptimizelyFeature> expected,
+            IDictionary<string, OptimizelyFeature> actual
+        )
         {
             Assert.AreEqual(expected.Count, actual.Count);
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 AreEquivalent(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
-        public static void AreEquivalent(KeyValuePair<string, OptimizelyFeature> expected, KeyValuePair<string, OptimizelyFeature> actual)
+        public static void AreEquivalent(KeyValuePair<string, OptimizelyFeature> expected,
+            KeyValuePair<string, OptimizelyFeature> actual
+        )
         {
             Assert.AreEqual(expected.Key, actual.Key);
             AreEqual(expected.Value, actual.Value);
@@ -373,25 +432,32 @@ namespace OptimizelySDK.Tests
 
         #region OptimizelyVariable
 
-        public static void AreEquivalent(IDictionary<string, OptimizelyVariable> expected, IDictionary<string, OptimizelyVariable> actual)
+        public static void AreEquivalent(IDictionary<string, OptimizelyVariable> expected,
+            IDictionary<string, OptimizelyVariable> actual
+        )
         {
             Assert.AreEqual(expected.Count, actual.Count);
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 AreEquivalent(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
-        public static void AreEquivalent(KeyValuePair<string, OptimizelyVariable> expected, KeyValuePair<string, OptimizelyVariable> actual)
+        public static void AreEquivalent(KeyValuePair<string, OptimizelyVariable> expected,
+            KeyValuePair<string, OptimizelyVariable> actual
+        )
         {
             Assert.AreEqual(expected.Key, actual.Key);
             AreEqual(expected.Value, actual.Value);
@@ -446,17 +512,20 @@ namespace OptimizelySDK.Tests
 
         #region FeatureFlags
 
-        public static void AreEquivalent(Dictionary<string, FeatureFlag> expected, Dictionary<string, FeatureFlag> actual)
+        public static void AreEquivalent(Dictionary<string, FeatureFlag> expected,
+            Dictionary<string, FeatureFlag> actual
+        )
         {
             Assert.AreEqual(expected.Count, actual.Count);
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
@@ -464,7 +533,9 @@ namespace OptimizelySDK.Tests
             }
         }
 
-        public static void AreEqual(KeyValuePair<string, FeatureFlag> expected, KeyValuePair<string, FeatureFlag> actual)
+        public static void AreEqual(KeyValuePair<string, FeatureFlag> expected,
+            KeyValuePair<string, FeatureFlag> actual
+        )
         {
             Assert.AreEqual(expected.Key, actual.Key);
             AreEqual(expected.Value, actual.Value);
@@ -475,7 +546,8 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(expected.Id, actual.Id);
             Assert.AreEqual(expected.Key, actual.Key);
             Assert.AreEqual(expected.RolloutId, actual.RolloutId);
-            AreEquivalent(expected.VariableKeyToFeatureVariableMap, actual.VariableKeyToFeatureVariableMap);
+            AreEquivalent(expected.VariableKeyToFeatureVariableMap,
+                actual.VariableKeyToFeatureVariableMap);
         }
 
         #endregion FeatureFlags
@@ -492,17 +564,20 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(expected.Type, actual.Type);
         }
 
-        public static void AreEquivalent(Dictionary<string, FeatureVariable> expected, Dictionary<string, FeatureVariable> actual)
+        public static void AreEquivalent(Dictionary<string, FeatureVariable> expected,
+            Dictionary<string, FeatureVariable> actual
+        )
         {
             Assert.AreEqual(expected.Count, actual.Count);
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
@@ -510,7 +585,9 @@ namespace OptimizelySDK.Tests
             }
         }
 
-        public static void AreEquivalent(KeyValuePair<string, FeatureVariable> expected, KeyValuePair<string, FeatureVariable> actual)
+        public static void AreEquivalent(KeyValuePair<string, FeatureVariable> expected,
+            KeyValuePair<string, FeatureVariable> actual
+        )
         {
             Assert.AreEqual(expected.Key, actual.Key);
             AreEqual(expected.Value, actual.Value);
@@ -526,121 +603,154 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(expected.Key, actual.Key);
             Assert.AreEqual(expected.FeatureEnabled, actual.FeatureEnabled);
 
-            AreEquivalent(expected.FeatureVariableUsageInstances, actual.FeatureVariableUsageInstances);
-            AreEquivalent(expected.VariableIdToVariableUsageInstanceMap, actual.VariableIdToVariableUsageInstanceMap);
+            AreEquivalent(expected.FeatureVariableUsageInstances,
+                actual.FeatureVariableUsageInstances);
+            AreEquivalent(expected.VariableIdToVariableUsageInstanceMap,
+                actual.VariableIdToVariableUsageInstanceMap);
         }
 
-        public static void AreEquivalent(Dictionary<string, Variation> expected, Dictionary<string, Variation> actual)
+        public static void AreEquivalent(Dictionary<string, Variation> expected,
+            Dictionary<string, Variation> actual
+        )
         {
             Assert.AreEqual(expected.Count, actual.Count);
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 AreEqual(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
-        public static void AreEquivalent(List<Dictionary<string, List<Variation>>> expected, List<Dictionary<string, List<Variation>>> actual)
+        public static void AreEquivalent(List<Dictionary<string, List<Variation>>> expected,
+            List<Dictionary<string, List<Variation>>> actual
+        )
         {
             Assert.AreEqual(expected.Count, actual.Count);
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 AreEquivalent(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
-        public static void AreEquivalent(IDictionary<string, List<Variation>> expected, IDictionary<string, List<Variation>> actual)
+        public static void AreEquivalent(IDictionary<string, List<Variation>> expected,
+            IDictionary<string, List<Variation>> actual
+        )
         {
             Assert.AreEqual(expected.Count, actual.Count);
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 AreEqual(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
-        public static void AreEqual(KeyValuePair<string, Variation> expected, KeyValuePair<string, Variation> actual)
+        public static void AreEqual(KeyValuePair<string, Variation> expected,
+            KeyValuePair<string, Variation> actual
+        )
         {
             Assert.AreEqual(expected.Key, actual.Key);
             AreEqual(expected.Value, actual.Value);
         }
 
-        public static void AreEqual(KeyValuePair<string, List<Variation>> expected, KeyValuePair<string, List<Variation>> actual)
+        public static void AreEqual(KeyValuePair<string, List<Variation>> expected,
+            KeyValuePair<string, List<Variation>> actual
+        )
         {
             Assert.AreEqual(expected.Key, actual.Key);
             AreEquivalent(expected.Value, actual.Value);
         }
 
-        public static void AreEquivalent(KeyValuePair<string, List<Variation>> expected, KeyValuePair<string, List<Variation>> actual)
+        public static void AreEquivalent(KeyValuePair<string, List<Variation>> expected,
+            KeyValuePair<string, List<Variation>> actual
+        )
         {
             Assert.AreEqual(expected.Key, actual.Key);
             AreEquivalent(expected.Value, actual.Value);
         }
 
-        public static void AreEquivalent(IEnumerable<Variation> expected, IEnumerable<Variation> actual)
+        public static void AreEquivalent(IEnumerable<Variation> expected,
+            IEnumerable<Variation> actual
+        )
         {
             Assert.AreEqual(expected.Count(), actual.Count());
             expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList().ForEach((item) =>
-            {
-                AreEqual(item.Expected, item.Actual);
-            });
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList().
+                ForEach((item) =>
+                {
+                    AreEqual(item.Expected, item.Actual);
+                });
         }
 
         #endregion Variations
 
         #region FeatureVariableUsage
 
-        public static void AreEquivalent(IEnumerable<FeatureVariableUsage> expected, IEnumerable<FeatureVariableUsage> actual)
+        public static void AreEquivalent(IEnumerable<FeatureVariableUsage> expected,
+            IEnumerable<FeatureVariableUsage> actual
+        )
         {
             if (HasItems(expected, actual))
             {
                 expected.Zip(actual, (e, a) =>
-                {
-                    return new
                     {
-                        Expected = e,
-                        Actual = a
-                    };
-                }).ToList().ForEach((item) =>
-                {
-                    AreEqual(item.Expected, item.Actual);
-                });
+                        return new
+                        {
+                            Expected = e,
+                            Actual = a,
+                        };
+                    }).
+                    ToList().
+                    ForEach((item) =>
+                    {
+                        AreEqual(item.Expected, item.Actual);
+                    });
             }
         }
 
-        public static void AreEquivalent(Dictionary<string, FeatureVariableUsage> expected, Dictionary<string, FeatureVariableUsage> actual)
+        public static void AreEquivalent(Dictionary<string, FeatureVariableUsage> expected,
+            Dictionary<string, FeatureVariableUsage> actual
+        )
         {
             if (expected == null && actual == null)
             {
@@ -649,19 +759,23 @@ namespace OptimizelySDK.Tests
 
             Assert.AreEqual(expected.Count(), actual.Count());
             expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList().ForEach((item) =>
-            {
-                AreEquivalent(item.Expected, item.Actual);
-            });
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList().
+                ForEach((item) =>
+                {
+                    AreEquivalent(item.Expected, item.Actual);
+                });
         }
 
-        public static void AreEquivalent(KeyValuePair<string, FeatureVariableUsage> expected, KeyValuePair<string, FeatureVariableUsage> actual)
+        public static void AreEquivalent(KeyValuePair<string, FeatureVariableUsage> expected,
+            KeyValuePair<string, FeatureVariableUsage> actual
+        )
         {
             Assert.AreEqual(expected.Key, actual.Key);
             AreEqual(expected.Value, actual.Value);
@@ -677,22 +791,27 @@ namespace OptimizelySDK.Tests
 
         #region TrafficAllocation
 
-        public static void AreEquivalent(IEnumerable<TrafficAllocation> expected, IEnumerable<TrafficAllocation> actual)
+        public static void AreEquivalent(IEnumerable<TrafficAllocation> expected,
+            IEnumerable<TrafficAllocation> actual
+        )
         {
             Assert.AreEqual(expected.Count(), actual.Count());
             var zipped = expected.Zip(actual, (e, a) =>
-            {
-                return new
                 {
-                    Expected = e,
-                    Actual = a
-                };
-            }).ToList();
+                    return new
+                    {
+                        Expected = e,
+                        Actual = a,
+                    };
+                }).
+                ToList();
 
             foreach (var z in zipped)
             {
                 Assert.AreEqual(z.Expected, z.Actual);
-            };
+            }
+
+            ;
         }
 
         public static void AreEqual(TrafficAllocation expected, TrafficAllocation actual)

--- a/OptimizelySDK.Tests/Assertions.cs
+++ b/OptimizelySDK.Tests/Assertions.cs
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-using NUnit.Framework;
-using OptimizelySDK.Entity;
-using OptimizelySDK.OptimizelyDecisions;
-using OptimizelySDK.OptlyConfig;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NUnit.Framework;
+using OptimizelySDK.Entity;
+using OptimizelySDK.OptimizelyDecisions;
+using OptimizelySDK.OptlyConfig;
 
 namespace OptimizelySDK.Tests
 {
@@ -418,6 +418,7 @@ namespace OptimizelySDK.Tests
             AreEqual(expected.Value, actual.Value);
         }
 
+        [Obsolete]
         public static void AreEqual(OptimizelyFeature expected, OptimizelyFeature actual)
         {
             AreEquivalent(expected.DeliveryRules, actual.DeliveryRules);

--- a/OptimizelySDK.Tests/AudienceConditionsTests/ConditionEvaluationTest.cs
+++ b/OptimizelySDK.Tests/AudienceConditionsTests/ConditionEvaluationTest.cs
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.AudienceConditions;
 using OptimizelySDK.Entity;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Tests.Utils;
-using System;
-using System.Collections.Generic;
 
 namespace OptimizelySDK.Tests.AudienceConditionsTests
 {
@@ -29,25 +29,25 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
     public class ConditionEvaluationTest
     {
         private BaseCondition LegacyCondition = new BaseCondition
-            { Name = "device_type", Value = "iPhone", Type = "custom_attribute" };
+        { Name = "device_type", Value = "iPhone", Type = "custom_attribute" };
 
         private BaseCondition ExistsCondition = new BaseCondition
-            { Name = "input_value", Match = "exists", Type = "custom_attribute" };
+        { Name = "input_value", Match = "exists", Type = "custom_attribute" };
 
         private BaseCondition SubstrCondition = new BaseCondition
-            { Name = "location", Value = "USA", Match = "substring", Type = "custom_attribute" };
+        { Name = "location", Value = "USA", Match = "substring", Type = "custom_attribute" };
 
         private BaseCondition GTCondition = new BaseCondition
-            { Name = "distance_gt", Value = 10, Match = "gt", Type = "custom_attribute" };
+        { Name = "distance_gt", Value = 10, Match = "gt", Type = "custom_attribute" };
 
         private BaseCondition GECondition = new BaseCondition
-            { Name = "distance_ge", Value = 10, Match = "ge", Type = "custom_attribute" };
+        { Name = "distance_ge", Value = 10, Match = "ge", Type = "custom_attribute" };
 
         private BaseCondition LTCondition = new BaseCondition
-            { Name = "distance_lt", Value = 10, Match = "lt", Type = "custom_attribute" };
+        { Name = "distance_lt", Value = 10, Match = "lt", Type = "custom_attribute" };
 
         private BaseCondition LECondition = new BaseCondition
-            { Name = "distance_le", Value = 10, Match = "le", Type = "custom_attribute" };
+        { Name = "distance_le", Value = 10, Match = "le", Type = "custom_attribute" };
 
         private BaseCondition ExactStrCondition = new BaseCondition
         {
@@ -60,10 +60,10 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         };
 
         private BaseCondition ExactDecimalCondition = new BaseCondition
-            { Name = "pi_value", Value = 3.14, Match = "exact", Type = "custom_attribute" };
+        { Name = "pi_value", Value = 3.14, Match = "exact", Type = "custom_attribute" };
 
         private BaseCondition ExactIntCondition = new BaseCondition
-            { Name = "lasers_count", Value = 9000, Match = "exact", Type = "custom_attribute" };
+        { Name = "lasers_count", Value = 9000, Match = "exact", Type = "custom_attribute" };
 
         private BaseCondition InfinityIntCondition = new BaseCondition
         {
@@ -169,7 +169,7 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         public void TestEvaluateWithMissingTypeProperty()
         {
             var condition = new BaseCondition
-                { Name = "input_value", Value = "Android", Match = "exists" };
+            { Name = "input_value", Value = "Android", Match = "exists" };
             Assert.That(
                 condition.Evaluate(null,
                     new UserAttributes { { "device_type", "iPhone" } }.ToUserContext(), Logger),
@@ -338,7 +338,7 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
                 Times.Once);
 
             invalidCondition = new BaseCondition
-                { Name = "location", Value = 25, Match = "substring", Type = "custom_attribute" };
+            { Name = "location", Value = 25, Match = "substring", Type = "custom_attribute" };
             Assert.That(
                 invalidCondition.Evaluate(null,
                     new UserAttributes { { "location", "USA" } }.ToUserContext(), Logger), Is.Null);

--- a/OptimizelySDK.Tests/AudienceConditionsTests/ConditionEvaluationTest.cs
+++ b/OptimizelySDK.Tests/AudienceConditionsTests/ConditionEvaluationTest.cs
@@ -28,23 +28,73 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
     [TestFixture]
     public class ConditionEvaluationTest
     {
-        private BaseCondition LegacyCondition = new BaseCondition { Name = "device_type", Value = "iPhone", Type = "custom_attribute" };
-        private BaseCondition ExistsCondition = new BaseCondition { Name = "input_value", Match = "exists", Type = "custom_attribute" };
-        private BaseCondition SubstrCondition = new BaseCondition { Name = "location", Value = "USA", Match = "substring", Type = "custom_attribute" };
-        private BaseCondition GTCondition = new BaseCondition { Name = "distance_gt", Value = 10, Match = "gt", Type = "custom_attribute" };
-        private BaseCondition GECondition = new BaseCondition { Name = "distance_ge", Value = 10, Match = "ge", Type = "custom_attribute" };
-        private BaseCondition LTCondition = new BaseCondition { Name = "distance_lt", Value = 10, Match = "lt", Type = "custom_attribute" };
-        private BaseCondition LECondition = new BaseCondition { Name = "distance_le", Value = 10, Match = "le", Type = "custom_attribute" };
-        private BaseCondition ExactStrCondition = new BaseCondition { Name = "browser_type", Value = "firefox", Match = "exact", Type = "custom_attribute" };
-        private BaseCondition ExactBoolCondition = new BaseCondition { Name = "is_registered_user", Value = false, Match = "exact", Type = "custom_attribute" };
-        private BaseCondition ExactDecimalCondition = new BaseCondition { Name = "pi_value", Value = 3.14, Match = "exact", Type = "custom_attribute" };
-        private BaseCondition ExactIntCondition = new BaseCondition { Name = "lasers_count", Value = 9000, Match = "exact", Type = "custom_attribute" };
-        private BaseCondition InfinityIntCondition = new BaseCondition { Name = "max_num_value", Value = 9223372036854775807, Match = "exact", Type = "custom_attribute" };
-        private BaseCondition SemVerLTCondition = new BaseCondition { Name = "semversion_lt", Value = "3.7.1", Match = "semver_lt", Type = "custom_attribute" };
-        private BaseCondition SemVerGTCondition = new BaseCondition { Name = "semversion_gt", Value = "3.7.1", Match = "semver_gt", Type = "custom_attribute" };
-        private BaseCondition SemVerEQCondition = new BaseCondition { Name = "semversion_eq", Value = "3.7.1", Match = "semver_eq", Type = "custom_attribute" };
-        private BaseCondition SemVerGECondition = new BaseCondition { Name = "semversion_ge", Value = "3.7.1", Match = "semver_ge", Type = "custom_attribute" };
-        private BaseCondition SemVerLECondition = new BaseCondition { Name = "semversion_le", Value = "3.7.1", Match = "semver_le", Type = "custom_attribute" };
+        private BaseCondition LegacyCondition = new BaseCondition
+            { Name = "device_type", Value = "iPhone", Type = "custom_attribute" };
+
+        private BaseCondition ExistsCondition = new BaseCondition
+            { Name = "input_value", Match = "exists", Type = "custom_attribute" };
+
+        private BaseCondition SubstrCondition = new BaseCondition
+            { Name = "location", Value = "USA", Match = "substring", Type = "custom_attribute" };
+
+        private BaseCondition GTCondition = new BaseCondition
+            { Name = "distance_gt", Value = 10, Match = "gt", Type = "custom_attribute" };
+
+        private BaseCondition GECondition = new BaseCondition
+            { Name = "distance_ge", Value = 10, Match = "ge", Type = "custom_attribute" };
+
+        private BaseCondition LTCondition = new BaseCondition
+            { Name = "distance_lt", Value = 10, Match = "lt", Type = "custom_attribute" };
+
+        private BaseCondition LECondition = new BaseCondition
+            { Name = "distance_le", Value = 10, Match = "le", Type = "custom_attribute" };
+
+        private BaseCondition ExactStrCondition = new BaseCondition
+        {
+            Name = "browser_type", Value = "firefox", Match = "exact", Type = "custom_attribute",
+        };
+
+        private BaseCondition ExactBoolCondition = new BaseCondition
+        {
+            Name = "is_registered_user", Value = false, Match = "exact", Type = "custom_attribute",
+        };
+
+        private BaseCondition ExactDecimalCondition = new BaseCondition
+            { Name = "pi_value", Value = 3.14, Match = "exact", Type = "custom_attribute" };
+
+        private BaseCondition ExactIntCondition = new BaseCondition
+            { Name = "lasers_count", Value = 9000, Match = "exact", Type = "custom_attribute" };
+
+        private BaseCondition InfinityIntCondition = new BaseCondition
+        {
+            Name = "max_num_value", Value = 9223372036854775807, Match = "exact",
+            Type = "custom_attribute",
+        };
+
+        private BaseCondition SemVerLTCondition = new BaseCondition
+        {
+            Name = "semversion_lt", Value = "3.7.1", Match = "semver_lt", Type = "custom_attribute",
+        };
+
+        private BaseCondition SemVerGTCondition = new BaseCondition
+        {
+            Name = "semversion_gt", Value = "3.7.1", Match = "semver_gt", Type = "custom_attribute",
+        };
+
+        private BaseCondition SemVerEQCondition = new BaseCondition
+        {
+            Name = "semversion_eq", Value = "3.7.1", Match = "semver_eq", Type = "custom_attribute",
+        };
+
+        private BaseCondition SemVerGECondition = new BaseCondition
+        {
+            Name = "semversion_ge", Value = "3.7.1", Match = "semver_ge", Type = "custom_attribute",
+        };
+
+        private BaseCondition SemVerLECondition = new BaseCondition
+        {
+            Name = "semversion_le", Value = "3.7.1", Match = "semver_le", Type = "custom_attribute",
+        };
 
         private ILogger Logger;
         private Mock<ILogger> LoggerMock;
@@ -64,121 +114,263 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         {
             var userAttributes = new UserAttributes
             {
-                {"browser_type", "firefox" },
-                {"is_registered_user", false },
-                {"distance_gt", 15 },
-                {"pi_value", 3.14 },
+                { "browser_type", "firefox" },
+                { "is_registered_user", false },
+                { "distance_gt", 15 },
+                { "pi_value", 3.14 },
             };
 
-            Assert.That(ExactStrCondition.Evaluate(null, userAttributes.ToUserContext(), Logger), Is.True);
-            Assert.That(ExactBoolCondition.Evaluate(null, userAttributes.ToUserContext(), Logger), Is.True);
-            Assert.That(GTCondition.Evaluate(null, userAttributes.ToUserContext(), Logger), Is.True);
-            Assert.That(ExactDecimalCondition.Evaluate(null, userAttributes.ToUserContext(), Logger), Is.True);
+            Assert.That(ExactStrCondition.Evaluate(null, userAttributes.ToUserContext(), Logger),
+                Is.True);
+            Assert.That(ExactBoolCondition.Evaluate(null, userAttributes.ToUserContext(), Logger),
+                Is.True);
+            Assert.That(GTCondition.Evaluate(null, userAttributes.ToUserContext(), Logger),
+                Is.True);
+            Assert.That(
+                ExactDecimalCondition.Evaluate(null, userAttributes.ToUserContext(), Logger),
+                Is.True);
         }
 
         [Test]
         public void TestEvaluateWithNoMatchType()
         {
-            Assert.That(LegacyCondition.Evaluate(null, new UserAttributes { { "device_type", "iPhone" } }.ToUserContext(), Logger), Is.True);
+            Assert.That(
+                LegacyCondition.Evaluate(null,
+                    new UserAttributes { { "device_type", "iPhone" } }.ToUserContext(), Logger),
+                Is.True);
 
             // Assumes exact evaluator if no match type is provided.
-            Assert.That(LegacyCondition.Evaluate(null, new UserAttributes { { "device_type", "IPhone" } }.ToUserContext(), Logger), Is.False);
+            Assert.That(
+                LegacyCondition.Evaluate(null,
+                    new UserAttributes { { "device_type", "IPhone" } }.ToUserContext(), Logger),
+                Is.False);
         }
 
         [Test]
         public void TestEvaluateWithInvalidTypeProperty()
         {
-            BaseCondition condition = new BaseCondition { Name = "input_value", Value = "Android", Match = "exists", Type = "invalid_type" };
-            Assert.That(condition.Evaluate(null, new UserAttributes { { "device_type", "iPhone" } }.ToUserContext(), Logger), Is.Null);
+            var condition = new BaseCondition
+            {
+                Name = "input_value", Value = "Android", Match = "exists", Type = "invalid_type",
+            };
+            Assert.That(
+                condition.Evaluate(null,
+                    new UserAttributes { { "device_type", "iPhone" } }.ToUserContext(), Logger),
+                Is.Null);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, $@"Audience condition ""{condition}"" uses an unknown condition type. You may need to upgrade to a newer release of the Optimizely SDK."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    $@"Audience condition ""{condition
+                    }"" uses an unknown condition type. You may need to upgrade to a newer release of the Optimizely SDK."),
+                Times.Once);
         }
 
         [Test]
         public void TestEvaluateWithMissingTypeProperty()
         {
-            var condition = new BaseCondition { Name = "input_value", Value = "Android", Match = "exists" };
-            Assert.That(condition.Evaluate(null, new UserAttributes { { "device_type", "iPhone" } }.ToUserContext(), Logger), Is.Null);
+            var condition = new BaseCondition
+                { Name = "input_value", Value = "Android", Match = "exists" };
+            Assert.That(
+                condition.Evaluate(null,
+                    new UserAttributes { { "device_type", "iPhone" } }.ToUserContext(), Logger),
+                Is.Null);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, $@"Audience condition ""{condition}"" uses an unknown condition type. You may need to upgrade to a newer release of the Optimizely SDK."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    $@"Audience condition ""{condition
+                    }"" uses an unknown condition type. You may need to upgrade to a newer release of the Optimizely SDK."),
+                Times.Once);
         }
 
         [Test]
         public void TestEvaluateWithInvalidMatchProperty()
         {
-            BaseCondition condition = new BaseCondition { Name = "device_type", Value = "Android", Match = "invalid_match", Type = "custom_attribute" };
-            Assert.That(condition.Evaluate(null, new UserAttributes { { "device_type", "Android" } }.ToUserContext(), Logger), Is.Null);
+            var condition = new BaseCondition
+            {
+                Name = "device_type", Value = "Android", Match = "invalid_match",
+                Type = "custom_attribute",
+            };
+            Assert.That(
+                condition.Evaluate(null,
+                    new UserAttributes { { "device_type", "Android" } }.ToUserContext(), Logger),
+                Is.Null);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, $@"Audience condition ""{condition}"" uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    $@"Audience condition ""{condition
+                    }"" uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK."),
+                Times.Once);
         }
 
         [Test]
-        public void TestEvaluateLogsWarningAndReturnNullWhenAttributeIsNotProvidedAndConditionTypeIsNotExists()
+        public void
+            TestEvaluateLogsWarningAndReturnNullWhenAttributeIsNotProvidedAndConditionTypeIsNotExists()
         {
-            Assert.That(ExactBoolCondition.Evaluate(null, new UserAttributes { }.ToUserContext(), Logger), Is.Null);
-            Assert.That(SubstrCondition.Evaluate(null, new UserAttributes { }.ToUserContext(), Logger), Is.Null);
-            Assert.That(LTCondition.Evaluate(null, new UserAttributes { }.ToUserContext(), Logger), Is.Null);
-            Assert.That(GTCondition.Evaluate(null, new UserAttributes { }.ToUserContext(), Logger), Is.Null);
+            Assert.That(
+                ExactBoolCondition.Evaluate(null, new UserAttributes { }.ToUserContext(), Logger),
+                Is.Null);
+            Assert.That(
+                SubstrCondition.Evaluate(null, new UserAttributes { }.ToUserContext(), Logger),
+                Is.Null);
+            Assert.That(LTCondition.Evaluate(null, new UserAttributes { }.ToUserContext(), Logger),
+                Is.Null);
+            Assert.That(GTCondition.Evaluate(null, new UserAttributes { }.ToUserContext(), Logger),
+                Is.Null);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""is_registered_user"",""value"":false} evaluated to UNKNOWN because no value was passed for user attribute ""is_registered_user""."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience condition {""type"":""custom_attribute"",""match"":""substring"",""name"":""location"",""value"":""USA""} evaluated to UNKNOWN because no value was passed for user attribute ""location""."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience condition {""type"":""custom_attribute"",""match"":""lt"",""name"":""distance_lt"",""value"":10} evaluated to UNKNOWN because no value was passed for user attribute ""distance_lt""."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience condition {""type"":""custom_attribute"",""match"":""gt"",""name"":""distance_gt"",""value"":10} evaluated to UNKNOWN because no value was passed for user attribute ""distance_gt""."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""is_registered_user"",""value"":false} evaluated to UNKNOWN because no value was passed for user attribute ""is_registered_user""."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""substring"",""name"":""location"",""value"":""USA""} evaluated to UNKNOWN because no value was passed for user attribute ""location""."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""lt"",""name"":""distance_lt"",""value"":10} evaluated to UNKNOWN because no value was passed for user attribute ""distance_lt""."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""gt"",""name"":""distance_gt"",""value"":10} evaluated to UNKNOWN because no value was passed for user attribute ""distance_gt""."),
+                Times.Once);
         }
 
         [Test]
-        public void TestEvaluateLogsAndReturnNullWhenAttributeValueIsNullAndConditionTypeIsNotExists()
+        public void
+            TestEvaluateLogsAndReturnNullWhenAttributeValueIsNullAndConditionTypeIsNotExists()
         {
-            Assert.That(ExactBoolCondition.Evaluate(null, new UserAttributes { { "is_registered_user", null } }.ToUserContext(), Logger), Is.Null);
-            Assert.That(SubstrCondition.Evaluate(null, new UserAttributes { { "location", null } }.ToUserContext(), Logger), Is.Null);
-            Assert.That(LTCondition.Evaluate(null, new UserAttributes { { "distance_lt", null } }.ToUserContext(), Logger), Is.Null);
-            Assert.That(GTCondition.Evaluate(null, new UserAttributes { { "distance_gt", null } }.ToUserContext(), Logger), Is.Null);
+            Assert.That(
+                ExactBoolCondition.Evaluate(null,
+                    new UserAttributes { { "is_registered_user", null } }.ToUserContext(), Logger),
+                Is.Null);
+            Assert.That(
+                SubstrCondition.Evaluate(null,
+                    new UserAttributes { { "location", null } }.ToUserContext(), Logger), Is.Null);
+            Assert.That(
+                LTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_lt", null } }.ToUserContext(), Logger),
+                Is.Null);
+            Assert.That(
+                GTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_gt", null } }.ToUserContext(), Logger),
+                Is.Null);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""is_registered_user"",""value"":false} evaluated to UNKNOWN because a null value was passed for user attribute ""is_registered_user""."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience condition {""type"":""custom_attribute"",""match"":""substring"",""name"":""location"",""value"":""USA""} evaluated to UNKNOWN because a null value was passed for user attribute ""location""."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience condition {""type"":""custom_attribute"",""match"":""lt"",""name"":""distance_lt"",""value"":10} evaluated to UNKNOWN because a null value was passed for user attribute ""distance_lt""."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience condition {""type"":""custom_attribute"",""match"":""gt"",""name"":""distance_gt"",""value"":10} evaluated to UNKNOWN because a null value was passed for user attribute ""distance_gt""."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""is_registered_user"",""value"":false} evaluated to UNKNOWN because a null value was passed for user attribute ""is_registered_user""."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""substring"",""name"":""location"",""value"":""USA""} evaluated to UNKNOWN because a null value was passed for user attribute ""location""."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""lt"",""name"":""distance_lt"",""value"":10} evaluated to UNKNOWN because a null value was passed for user attribute ""distance_lt""."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""gt"",""name"":""distance_gt"",""value"":10} evaluated to UNKNOWN because a null value was passed for user attribute ""distance_gt""."),
+                Times.Once);
         }
 
         [Test]
-        public void TestEvaluateReturnsFalseAndDoesNotLogForExistsConditionWhenAttributeIsNotProvided()
+        public void
+            TestEvaluateReturnsFalseAndDoesNotLogForExistsConditionWhenAttributeIsNotProvided()
         {
-            Assert.That(ExistsCondition.Evaluate(null, new UserAttributes().ToUserContext(), Logger), Is.False);
+            Assert.That(
+                ExistsCondition.Evaluate(null, new UserAttributes().ToUserContext(), Logger),
+                Is.False);
             LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Never);
         }
 
         [Test]
         public void TestEvaluateLogsWarningAndReturnNullWhenAttributeTypeIsInvalid()
         {
-            Assert.That(ExactBoolCondition.Evaluate(null, new UserAttributes { { "is_registered_user", 5 } }.ToUserContext(), Logger), Is.Null);
-            Assert.That(SubstrCondition.Evaluate(null, new UserAttributes { { "location", false } }.ToUserContext(), Logger), Is.Null);
-            Assert.That(LTCondition.Evaluate(null, new UserAttributes { { "distance_lt", "invalid" } }.ToUserContext(), Logger), Is.Null);
-            Assert.That(GTCondition.Evaluate(null, new UserAttributes { { "distance_gt", true } }.ToUserContext(), Logger), Is.Null);
+            Assert.That(
+                ExactBoolCondition.Evaluate(null,
+                    new UserAttributes { { "is_registered_user", 5 } }.ToUserContext(), Logger),
+                Is.Null);
+            Assert.That(
+                SubstrCondition.Evaluate(null,
+                    new UserAttributes { { "location", false } }.ToUserContext(), Logger), Is.Null);
+            Assert.That(
+                LTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_lt", "invalid" } }.ToUserContext(), Logger),
+                Is.Null);
+            Assert.That(
+                GTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_gt", true } }.ToUserContext(), Logger),
+                Is.Null);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""is_registered_user"",""value"":false} evaluated to UNKNOWN because a value of type ""Int32"" was passed for user attribute ""is_registered_user""."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""substring"",""name"":""location"",""value"":""USA""} evaluated to UNKNOWN because a value of type ""Boolean"" was passed for user attribute ""location""."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""lt"",""name"":""distance_lt"",""value"":10} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""distance_lt""."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""gt"",""name"":""distance_gt"",""value"":10} evaluated to UNKNOWN because a value of type ""Boolean"" was passed for user attribute ""distance_gt""."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""is_registered_user"",""value"":false} evaluated to UNKNOWN because a value of type ""Int32"" was passed for user attribute ""is_registered_user""."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""substring"",""name"":""location"",""value"":""USA""} evaluated to UNKNOWN because a value of type ""Boolean"" was passed for user attribute ""location""."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""lt"",""name"":""distance_lt"",""value"":10} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""distance_lt""."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""gt"",""name"":""distance_gt"",""value"":10} evaluated to UNKNOWN because a value of type ""Boolean"" was passed for user attribute ""distance_gt""."),
+                Times.Once);
         }
 
         [Test]
         public void TestEvaluateLogsWarningAndReturnNullWhenConditionTypeIsInvalid()
         {
-            var invalidCondition = new BaseCondition { Name = "is_registered_user", Value = new string[] { }, Match = "exact", Type = "custom_attribute" };
-            Assert.That(invalidCondition.Evaluate(null, new UserAttributes { { "is_registered_user", true } }.ToUserContext(), Logger), Is.Null);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""is_registered_user"",""value"":[]} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."), Times.Once);
+            var invalidCondition = new BaseCondition
+            {
+                Name = "is_registered_user", Value = new string[] { }, Match = "exact",
+                Type = "custom_attribute",
+            };
+            Assert.That(
+                invalidCondition.Evaluate(null,
+                    new UserAttributes { { "is_registered_user", true } }.ToUserContext(), Logger),
+                Is.Null);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""is_registered_user"",""value"":[]} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."),
+                Times.Once);
 
-            invalidCondition = new BaseCondition { Name = "location", Value = 25, Match = "substring", Type = "custom_attribute" };
-            Assert.That(invalidCondition.Evaluate(null, new UserAttributes { { "location", "USA" } }.ToUserContext(), Logger), Is.Null);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""substring"",""name"":""location"",""value"":25} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."), Times.Once);
+            invalidCondition = new BaseCondition
+                { Name = "location", Value = 25, Match = "substring", Type = "custom_attribute" };
+            Assert.That(
+                invalidCondition.Evaluate(null,
+                    new UserAttributes { { "location", "USA" } }.ToUserContext(), Logger), Is.Null);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""substring"",""name"":""location"",""value"":25} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."),
+                Times.Once);
 
-            invalidCondition = new BaseCondition { Name = "distance_lt", Value = "invalid", Match = "lt", Type = "custom_attribute" };
-            Assert.That(invalidCondition.Evaluate(null, new UserAttributes { { "distance_lt", 5 } }.ToUserContext(), Logger), Is.Null);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""lt"",""name"":""distance_lt"",""value"":""invalid""} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."), Times.Once);
+            invalidCondition = new BaseCondition
+            {
+                Name = "distance_lt", Value = "invalid", Match = "lt", Type = "custom_attribute",
+            };
+            Assert.That(
+                invalidCondition.Evaluate(null,
+                    new UserAttributes { { "distance_lt", 5 } }.ToUserContext(), Logger), Is.Null);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""lt"",""name"":""distance_lt"",""value"":""invalid""} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."),
+                Times.Once);
 
-            invalidCondition = new BaseCondition { Name = "distance_gt", Value = "invalid", Match = "gt", Type = "custom_attribute" };
-            Assert.That(invalidCondition.Evaluate(null, new UserAttributes { { "distance_gt", "invalid" } }.ToUserContext(), Logger), Is.Null);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""gt"",""name"":""distance_gt"",""value"":""invalid""} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."), Times.Once);
+            invalidCondition = new BaseCondition
+            {
+                Name = "distance_gt", Value = "invalid", Match = "gt", Type = "custom_attribute",
+            };
+            Assert.That(
+                invalidCondition.Evaluate(null,
+                    new UserAttributes { { "distance_gt", "invalid" } }.ToUserContext(), Logger),
+                Is.Null);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""gt"",""name"":""distance_gt"",""value"":""invalid""} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."),
+                Times.Once);
         }
 
         #endregion // Evaluate Tests
@@ -188,45 +380,109 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestExactMatcherReturnsFalseWhenAttributeValueDoesNotMatch()
         {
-            Assert.That(ExactStrCondition.Evaluate(null, new UserAttributes { { "browser_type", "chrome" } }.ToUserContext(), Logger), Is.False);
-            Assert.That(ExactBoolCondition.Evaluate(null, new UserAttributes { { "is_registered_user", true } }.ToUserContext(), Logger), Is.False);
-            Assert.That(ExactDecimalCondition.Evaluate(null, new UserAttributes { { "pi_value", 2.5 } }.ToUserContext(), Logger), Is.False);
-            Assert.That(ExactIntCondition.Evaluate(null, new UserAttributes { { "lasers_count", 55 } }.ToUserContext(), Logger), Is.False);
+            Assert.That(
+                ExactStrCondition.Evaluate(null,
+                    new UserAttributes { { "browser_type", "chrome" } }.ToUserContext(), Logger),
+                Is.False);
+            Assert.That(
+                ExactBoolCondition.Evaluate(null,
+                    new UserAttributes { { "is_registered_user", true } }.ToUserContext(), Logger),
+                Is.False);
+            Assert.That(
+                ExactDecimalCondition.Evaluate(null,
+                    new UserAttributes { { "pi_value", 2.5 } }.ToUserContext(), Logger), Is.False);
+            Assert.That(
+                ExactIntCondition.Evaluate(null,
+                    new UserAttributes { { "lasers_count", 55 } }.ToUserContext(), Logger),
+                Is.False);
         }
 
         [Test]
         public void TestExactMatcherReturnsNullWhenTypeMismatch()
         {
-            Assert.That(ExactStrCondition.Evaluate(null, new UserAttributes { { "browser_type", true } }.ToUserContext(), Logger), Is.Null);
-            Assert.That(ExactBoolCondition.Evaluate(null, new UserAttributes { { "is_registered_user", "abcd" } }.ToUserContext(), Logger), Is.Null);
-            Assert.That(ExactDecimalCondition.Evaluate(null, new UserAttributes { { "pi_value", false } }.ToUserContext(), Logger), Is.Null);
-            Assert.That(ExactIntCondition.Evaluate(null, new UserAttributes { { "lasers_count", "infinity" } }.ToUserContext(), Logger), Is.Null);
+            Assert.That(
+                ExactStrCondition.Evaluate(null,
+                    new UserAttributes { { "browser_type", true } }.ToUserContext(), Logger),
+                Is.Null);
+            Assert.That(
+                ExactBoolCondition.Evaluate(null,
+                    new UserAttributes { { "is_registered_user", "abcd" } }.ToUserContext(),
+                    Logger), Is.Null);
+            Assert.That(
+                ExactDecimalCondition.Evaluate(null,
+                    new UserAttributes { { "pi_value", false } }.ToUserContext(), Logger), Is.Null);
+            Assert.That(
+                ExactIntCondition.Evaluate(null,
+                    new UserAttributes { { "lasers_count", "infinity" } }.ToUserContext(), Logger),
+                Is.Null);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""browser_type"",""value"":""firefox""} evaluated to UNKNOWN because a value of type ""Boolean"" was passed for user attribute ""browser_type""."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""is_registered_user"",""value"":false} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""is_registered_user""."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""pi_value"",""value"":3.14} evaluated to UNKNOWN because a value of type ""Boolean"" was passed for user attribute ""pi_value""."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""lasers_count"",""value"":9000} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""lasers_count""."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""browser_type"",""value"":""firefox""} evaluated to UNKNOWN because a value of type ""Boolean"" was passed for user attribute ""browser_type""."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""is_registered_user"",""value"":false} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""is_registered_user""."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""pi_value"",""value"":3.14} evaluated to UNKNOWN because a value of type ""Boolean"" was passed for user attribute ""pi_value""."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""lasers_count"",""value"":9000} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""lasers_count""."),
+                Times.Once);
         }
 
         [Test]
         public void TestExactMatcherReturnsNullForOutOfBoundNumericValues()
         {
-            Assert.That(ExactIntCondition.Evaluate(null, new UserAttributes { { "lasers_count", double.NegativeInfinity } }.ToUserContext(), Logger), Is.Null);
-            Assert.That(ExactDecimalCondition.Evaluate(null, new UserAttributes { { "pi_value", Math.Pow(2, 53) + 2 } }.ToUserContext(), Logger), Is.Null);
-            Assert.That(InfinityIntCondition.Evaluate(null, new UserAttributes { { "max_num_value", 15 } }.ToUserContext(), Logger), Is.Null);
+            Assert.That(
+                ExactIntCondition.Evaluate(null,
+                    new UserAttributes
+                        { { "lasers_count", double.NegativeInfinity } }.ToUserContext(), Logger),
+                Is.Null);
+            Assert.That(
+                ExactDecimalCondition.Evaluate(null,
+                    new UserAttributes { { "pi_value", Math.Pow(2, 53) + 2 } }.ToUserContext(),
+                    Logger), Is.Null);
+            Assert.That(
+                InfinityIntCondition.Evaluate(null,
+                    new UserAttributes { { "max_num_value", 15 } }.ToUserContext(), Logger),
+                Is.Null);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""lasers_count"",""value"":9000} evaluated to UNKNOWN because the number value for user attribute ""lasers_count"" is not in the range [-2^53, +2^53]."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""pi_value"",""value"":3.14} evaluated to UNKNOWN because the number value for user attribute ""pi_value"" is not in the range [-2^53, +2^53]."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""max_num_value"",""value"":9223372036854775807} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""lasers_count"",""value"":9000} evaluated to UNKNOWN because the number value for user attribute ""lasers_count"" is not in the range [-2^53, +2^53]."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""pi_value"",""value"":3.14} evaluated to UNKNOWN because the number value for user attribute ""pi_value"" is not in the range [-2^53, +2^53]."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""max_num_value"",""value"":9223372036854775807} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK."),
+                Times.Once);
         }
 
         [Test]
         public void TestExactMatcherReturnsTrueWhenAttributeValueMatches()
         {
-            Assert.That(ExactStrCondition.Evaluate(null, new UserAttributes { { "browser_type", "firefox" } }.ToUserContext(), Logger), Is.True);
-            Assert.That(ExactBoolCondition.Evaluate(null, new UserAttributes { { "is_registered_user", false } }.ToUserContext(), Logger), Is.True);
-            Assert.That(ExactDecimalCondition.Evaluate(null, new UserAttributes { { "pi_value", 3.14 } }.ToUserContext(), Logger), Is.True);
-            Assert.That(ExactIntCondition.Evaluate(null, new UserAttributes { { "lasers_count", 9000 } }.ToUserContext(), Logger), Is.True);
+            Assert.That(
+                ExactStrCondition.Evaluate(null,
+                    new UserAttributes { { "browser_type", "firefox" } }.ToUserContext(), Logger),
+                Is.True);
+            Assert.That(
+                ExactBoolCondition.Evaluate(null,
+                    new UserAttributes { { "is_registered_user", false } }.ToUserContext(), Logger),
+                Is.True);
+            Assert.That(
+                ExactDecimalCondition.Evaluate(null,
+                    new UserAttributes { { "pi_value", 3.14 } }.ToUserContext(), Logger), Is.True);
+            Assert.That(
+                ExactIntCondition.Evaluate(null,
+                    new UserAttributes { { "lasers_count", 9000 } }.ToUserContext(), Logger),
+                Is.True);
         }
 
         #endregion // ExactMatcher Tests
@@ -236,22 +492,37 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestExistsMatcherReturnsFalseWhenAttributeIsNotProvided()
         {
-            Assert.That(ExistsCondition.Evaluate(null, new UserAttributes { }.ToUserContext(), Logger), Is.False);
+            Assert.That(
+                ExistsCondition.Evaluate(null, new UserAttributes { }.ToUserContext(), Logger),
+                Is.False);
         }
 
         [Test]
         public void TestExistsMatcherReturnsFalseWhenAttributeIsNull()
         {
-            Assert.That(ExistsCondition.Evaluate(null, new UserAttributes { { "input_value", null } }.ToUserContext(), Logger), Is.False);
+            Assert.That(
+                ExistsCondition.Evaluate(null,
+                    new UserAttributes { { "input_value", null } }.ToUserContext(), Logger),
+                Is.False);
         }
 
         [Test]
         public void TestExistsMatcherReturnsTrueWhenAttributeValueIsProvided()
         {
-            Assert.That(ExistsCondition.Evaluate(null, new UserAttributes { { "input_value", "" } }.ToUserContext(), Logger), Is.True);
-            Assert.That(ExistsCondition.Evaluate(null, new UserAttributes { { "input_value", "iPhone" } }.ToUserContext(), Logger), Is.True);
-            Assert.That(ExistsCondition.Evaluate(null, new UserAttributes { { "input_value", 10 } }.ToUserContext(), Logger), Is.True);
-            Assert.That(ExistsCondition.Evaluate(null, new UserAttributes { { "input_value", false } }.ToUserContext(), Logger), Is.True);
+            Assert.That(
+                ExistsCondition.Evaluate(null,
+                    new UserAttributes { { "input_value", "" } }.ToUserContext(), Logger), Is.True);
+            Assert.That(
+                ExistsCondition.Evaluate(null,
+                    new UserAttributes { { "input_value", "iPhone" } }.ToUserContext(), Logger),
+                Is.True);
+            Assert.That(
+                ExistsCondition.Evaluate(null,
+                    new UserAttributes { { "input_value", 10 } }.ToUserContext(), Logger), Is.True);
+            Assert.That(
+                ExistsCondition.Evaluate(null,
+                    new UserAttributes { { "input_value", false } }.ToUserContext(), Logger),
+                Is.True);
         }
 
         #endregion // ExistsMatcher Tests
@@ -261,21 +532,34 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestSubstringMatcherReturnsFalseWhenAttributeValueIsNotASubstring()
         {
-            Assert.That(SubstrCondition.Evaluate(null, new UserAttributes { { "location", "Los Angeles" } }.ToUserContext(), Logger), Is.False);
+            Assert.That(
+                SubstrCondition.Evaluate(null,
+                    new UserAttributes { { "location", "Los Angeles" } }.ToUserContext(), Logger),
+                Is.False);
         }
 
         [Test]
         public void TestSubstringMatcherReturnsNullWhenAttributeValueIsNotAString()
         {
-            Assert.That(SubstrCondition.Evaluate(null, new UserAttributes { { "location", 10.5 } }.ToUserContext(), Logger), Is.Null);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""substring"",""name"":""location"",""value"":""USA""} evaluated to UNKNOWN because a value of type ""Double"" was passed for user attribute ""location""."), Times.Once);
+            Assert.That(
+                SubstrCondition.Evaluate(null,
+                    new UserAttributes { { "location", 10.5 } }.ToUserContext(), Logger), Is.Null);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""substring"",""name"":""location"",""value"":""USA""} evaluated to UNKNOWN because a value of type ""Double"" was passed for user attribute ""location""."),
+                Times.Once);
         }
 
         [Test]
         public void TestSubstringMatcherReturnsTrueWhenAttributeValueIsASubstring()
         {
-            Assert.That(SubstrCondition.Evaluate(null, new UserAttributes { { "location", "USA" } }.ToUserContext(), Logger), Is.True);
-            Assert.That(SubstrCondition.Evaluate(null, new UserAttributes { { "location", "San Francisco, USA" } }.ToUserContext(), Logger), Is.True);
+            Assert.That(
+                SubstrCondition.Evaluate(null,
+                    new UserAttributes { { "location", "USA" } }.ToUserContext(), Logger), Is.True);
+            Assert.That(
+                SubstrCondition.Evaluate(null,
+                    new UserAttributes { { "location", "San Francisco, USA" } }.ToUserContext(),
+                    Logger), Is.True);
         }
 
         #endregion // SubstringMatcher Tests
@@ -285,81 +569,138 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestGTMatcherReturnsFalseWhenAttributeValueIsLessThanOrEqualToConditionValue()
         {
-            Assert.That(GTCondition.Evaluate(null, new UserAttributes { { "distance_gt", 5 } }.ToUserContext(), Logger), Is.False);
-            Assert.That(GTCondition.Evaluate(null, new UserAttributes { { "distance_gt", 10 } }.ToUserContext(), Logger), Is.False);
+            Assert.That(
+                GTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_gt", 5 } }.ToUserContext(), Logger), Is.False);
+            Assert.That(
+                GTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_gt", 10 } }.ToUserContext(), Logger),
+                Is.False);
         }
 
         [Test]
         public void TestGTMatcherReturnsNullWhenAttributeValueIsNotANumericValue()
         {
-            Assert.That(GTCondition.Evaluate(null, new UserAttributes { { "distance_gt", "invalid_type" } }.ToUserContext(), Logger), Is.Null);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""gt"",""name"":""distance_gt"",""value"":10} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""distance_gt""."), Times.Once);
+            Assert.That(
+                GTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_gt", "invalid_type" } }.ToUserContext(),
+                    Logger), Is.Null);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""gt"",""name"":""distance_gt"",""value"":10} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""distance_gt""."),
+                Times.Once);
         }
 
         [Test]
         public void TestGTMatcherReturnsNullWhenAttributeValueIsOutOfBounds()
         {
-            Assert.That(GTCondition.Evaluate(null, new UserAttributes { { "distance_gt", double.PositiveInfinity } }.ToUserContext(), Logger), Is.Null);
-            Assert.That(GTCondition.Evaluate(null, new UserAttributes { { "distance_gt", Math.Pow(2, 53) + 2 } }.ToUserContext(), Logger), Is.Null);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""gt"",""name"":""distance_gt"",""value"":10} evaluated to UNKNOWN because the number value for user attribute ""distance_gt"" is not in the range [-2^53, +2^53]."), Times.Exactly(2));
+            Assert.That(
+                GTCondition.Evaluate(null,
+                    new UserAttributes
+                        { { "distance_gt", double.PositiveInfinity } }.ToUserContext(), Logger),
+                Is.Null);
+            Assert.That(
+                GTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_gt", Math.Pow(2, 53) + 2 } }.ToUserContext(),
+                    Logger), Is.Null);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""gt"",""name"":""distance_gt"",""value"":10} evaluated to UNKNOWN because the number value for user attribute ""distance_gt"" is not in the range [-2^53, +2^53]."),
+                Times.Exactly(2));
         }
 
         [Test]
         public void TestGTMatcherReturnsTrueWhenAttributeValueIsGreaterThanConditionValue()
         {
-            Assert.That(GTCondition.Evaluate(null, new UserAttributes { { "distance_gt", 15 } }.ToUserContext(), Logger), Is.True);
+            Assert.That(
+                GTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_gt", 15 } }.ToUserContext(), Logger), Is.True);
         }
 
         [Test]
         public void TestSemVerGTTargetBetaComplex()
         {
-            var semverGTCondition = new BaseCondition { Name = "semversion_gt", Value = "2.1.3-beta+1", Match = "semver_gt", Type = "custom_attribute" };
-            Assert.IsTrue(semverGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "2.1.3-beta+1.2.3" } }.ToUserContext(), Logger) ?? false);
+            var semverGTCondition = new BaseCondition
+            {
+                Name = "semversion_gt", Value = "2.1.3-beta+1", Match = "semver_gt",
+                Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverGTCondition.Evaluate(null,
+                new UserAttributes { { "semversion_gt", "2.1.3-beta+1.2.3" } }.ToUserContext(),
+                Logger) ?? false);
         }
 
         [Test]
         public void TestSemVerGTCompareAgainstPreReleaseToPreRelease()
         {
-            var semverGTCondition = new BaseCondition { Name = "semversion_gt", Value = "3.7.1-prerelease+build", Match = "semver_gt", Type = "custom_attribute" };
-            Assert.IsTrue(semverGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "3.7.1-prerelease+rc" } }.ToUserContext(), Logger) ?? false);
+            var semverGTCondition = new BaseCondition
+            {
+                Name = "semversion_gt", Value = "3.7.1-prerelease+build", Match = "semver_gt",
+                Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverGTCondition.Evaluate(null,
+                new UserAttributes { { "semversion_gt", "3.7.1-prerelease+rc" } }.ToUserContext(),
+                Logger) ?? false);
         }
 
         [Test]
         public void TestSemVerGTComparePrereleaseSmallerThanBuild()
         {
-            var semverGTCondition = new BaseCondition { Name = "semversion_gt", Value = "3.7.1-prerelease", Match = "semver_gt", Type = "custom_attribute" };
-            Assert.IsTrue(semverGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "3.7.1+build" } }.ToUserContext(), Logger) ?? false);
+            var semverGTCondition = new BaseCondition
+            {
+                Name = "semversion_gt", Value = "3.7.1-prerelease", Match = "semver_gt",
+                Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverGTCondition.Evaluate(null,
+                new UserAttributes { { "semversion_gt", "3.7.1+build" } }.ToUserContext(),
+                Logger) ?? false);
         }
+
         #endregion // GTMatcher Tests
 
         #region GEMatcher Tests
 
         [Test]
-        public void TestGEMatcherReturnsFalseWhenAttributeValueIsLessButTrueForEqualToConditionValue()
+        public void
+            TestGEMatcherReturnsFalseWhenAttributeValueIsLessButTrueForEqualToConditionValue()
         {
-            Assert.IsFalse(GECondition.Evaluate(null, new UserAttributes { { "distance_ge", 5 } }.ToUserContext(), Logger)?? true);
-            Assert.IsTrue(GECondition.Evaluate(null, new UserAttributes { { "distance_ge", 10 } }.ToUserContext(), Logger)?? false);
+            Assert.IsFalse(GECondition.Evaluate(null,
+                new UserAttributes { { "distance_ge", 5 } }.ToUserContext(), Logger) ?? true);
+            Assert.IsTrue(GECondition.Evaluate(null,
+                new UserAttributes { { "distance_ge", 10 } }.ToUserContext(), Logger) ?? false);
         }
 
         [Test]
         public void TestGEMatcherReturnsNullWhenAttributeValueIsNotANumericValue()
         {
-            Assert.IsNull(GECondition.Evaluate(null, new UserAttributes { { "distance_ge", "invalid_type" } }.ToUserContext(), Logger));
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""ge"",""name"":""distance_ge"",""value"":10} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""distance_ge""."), Times.Once);
+            Assert.IsNull(GECondition.Evaluate(null,
+                new UserAttributes { { "distance_ge", "invalid_type" } }.ToUserContext(), Logger));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""ge"",""name"":""distance_ge"",""value"":10} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""distance_ge""."),
+                Times.Once);
         }
 
         [Test]
         public void TestGEMatcherReturnsNullWhenAttributeValueIsOutOfBounds()
         {
-            Assert.IsNull(GECondition.Evaluate(null, new UserAttributes { { "distance_ge", double.PositiveInfinity } }.ToUserContext(), Logger));
-            Assert.IsNull(GECondition.Evaluate(null, new UserAttributes { { "distance_ge", Math.Pow(2, 53) + 2 } }.ToUserContext(), Logger));
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""ge"",""name"":""distance_ge"",""value"":10} evaluated to UNKNOWN because the number value for user attribute ""distance_ge"" is not in the range [-2^53, +2^53]."), Times.Exactly(2));
+            Assert.IsNull(GECondition.Evaluate(null,
+                new UserAttributes { { "distance_ge", double.PositiveInfinity } }.ToUserContext(),
+                Logger));
+            Assert.IsNull(GECondition.Evaluate(null,
+                new UserAttributes { { "distance_ge", Math.Pow(2, 53) + 2 } }.ToUserContext(),
+                Logger));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""ge"",""name"":""distance_ge"",""value"":10} evaluated to UNKNOWN because the number value for user attribute ""distance_ge"" is not in the range [-2^53, +2^53]."),
+                Times.Exactly(2));
         }
 
         [Test]
         public void TestGEMatcherReturnsTrueWhenAttributeValueIsGreaterThanConditionValue()
         {
-            Assert.IsTrue(GECondition.Evaluate(null, new UserAttributes { { "distance_ge", 15 } }.ToUserContext(), Logger)?? false);
+            Assert.IsTrue(GECondition.Evaluate(null,
+                new UserAttributes { { "distance_ge", 15 } }.ToUserContext(), Logger) ?? false);
         }
 
         #endregion // GEMatcher Tests
@@ -367,279 +708,555 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         #region LTMatcher Tests
 
         [Test]
-        public void TestLTMatcherReturnsFalseWhenAttributeValueIsGreaterThanOrEqualToConditionValue()
+        public void
+            TestLTMatcherReturnsFalseWhenAttributeValueIsGreaterThanOrEqualToConditionValue()
         {
-            Assert.That(LTCondition.Evaluate(null, new UserAttributes { { "distance_lt", 15 } }.ToUserContext(), Logger), Is.False);
-            Assert.That(LTCondition.Evaluate(null, new UserAttributes { { "distance_lt", 10 } }.ToUserContext(), Logger), Is.False);
+            Assert.That(
+                LTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_lt", 15 } }.ToUserContext(), Logger),
+                Is.False);
+            Assert.That(
+                LTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_lt", 10 } }.ToUserContext(), Logger),
+                Is.False);
         }
 
         [Test]
         public void TestLTMatcherReturnsNullWhenAttributeValueIsNotANumericValue()
         {
-            Assert.That(LTCondition.Evaluate(null, new UserAttributes { { "distance_lt", "invalid_type" } }.ToUserContext(), Logger), Is.Null);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""lt"",""name"":""distance_lt"",""value"":10} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""distance_lt""."), Times.Once);
+            Assert.That(
+                LTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_lt", "invalid_type" } }.ToUserContext(),
+                    Logger), Is.Null);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""lt"",""name"":""distance_lt"",""value"":10} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""distance_lt""."),
+                Times.Once);
         }
 
         [Test]
         public void TestLTMatcherReturnsNullWhenAttributeValueIsOutOfBounds()
         {
-            Assert.That(LTCondition.Evaluate(null, new UserAttributes { { "distance_lt", double.NegativeInfinity } }.ToUserContext(), Logger), Is.Null);
-            Assert.That(LTCondition.Evaluate(null, new UserAttributes { { "distance_lt", -Math.Pow(2, 53) - 2 } }.ToUserContext(), Logger), Is.Null);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""lt"",""name"":""distance_lt"",""value"":10} evaluated to UNKNOWN because the number value for user attribute ""distance_lt"" is not in the range [-2^53, +2^53]."), Times.Exactly(2));
+            Assert.That(
+                LTCondition.Evaluate(null,
+                    new UserAttributes
+                        { { "distance_lt", double.NegativeInfinity } }.ToUserContext(), Logger),
+                Is.Null);
+            Assert.That(
+                LTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_lt", -Math.Pow(2, 53) - 2 } }.ToUserContext(),
+                    Logger), Is.Null);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""lt"",""name"":""distance_lt"",""value"":10} evaluated to UNKNOWN because the number value for user attribute ""distance_lt"" is not in the range [-2^53, +2^53]."),
+                Times.Exactly(2));
         }
 
         [Test]
         public void TestLTMatcherReturnsTrueWhenAttributeValueIsLessThanConditionValue()
         {
-            Assert.That(LTCondition.Evaluate(null, new UserAttributes { { "distance_lt", 5 } }.ToUserContext(), Logger), Is.True);
+            Assert.That(
+                LTCondition.Evaluate(null,
+                    new UserAttributes { { "distance_lt", 5 } }.ToUserContext(), Logger), Is.True);
         }
 
         [Test]
         public void TestSemVerLTTargetBuildComplex()
         {
-            var semverLTCondition = new BaseCondition { Name = "semversion_lt", Value = "2.1.3-beta+1.2.3", Match = "semver_lt", Type = "custom_attribute" };
-            Assert.IsTrue(semverLTCondition.Evaluate(null, new UserAttributes { { "semversion_lt", "2.1.3-beta+1" } }.ToUserContext(), Logger) ?? false);
+            var semverLTCondition = new BaseCondition
+            {
+                Name = "semversion_lt", Value = "2.1.3-beta+1.2.3", Match = "semver_lt",
+                Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverLTCondition.Evaluate(null,
+                new UserAttributes { { "semversion_lt", "2.1.3-beta+1" } }.ToUserContext(),
+                Logger) ?? false);
         }
 
         [Test]
         public void TestSemVerLTCompareMultipleDash()
         {
-            var semverLTCondition = new BaseCondition { Name = "semversion_lt", Value = "2.1.3-beta-1.2.3", Match = "semver_lt", Type = "custom_attribute" };
-            Assert.IsTrue(semverLTCondition.Evaluate(null, new UserAttributes { { "semversion_lt", "2.1.3-beta-1" } }.ToUserContext(), Logger) ?? false);
+            var semverLTCondition = new BaseCondition
+            {
+                Name = "semversion_lt", Value = "2.1.3-beta-1.2.3", Match = "semver_lt",
+                Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverLTCondition.Evaluate(null,
+                new UserAttributes { { "semversion_lt", "2.1.3-beta-1" } }.ToUserContext(),
+                Logger) ?? false);
         }
 
         #endregion // LTMatcher Tests
 
         #region LEMatcher Tests
+
         [Test]
-        public void TestLEMatcherReturnsFalseWhenAttributeValueIsGreaterAndTrueIfEqualToConditionValue()
+        public void
+            TestLEMatcherReturnsFalseWhenAttributeValueIsGreaterAndTrueIfEqualToConditionValue()
         {
-            Assert.IsFalse(LECondition.Evaluate(null, new UserAttributes { { "distance_le", 15 } }.ToUserContext(), Logger)  ?? true);
-            Assert.IsTrue(LECondition.Evaluate(null, new UserAttributes { { "distance_le", 10 } }.ToUserContext(), Logger) ?? false);
+            Assert.IsFalse(LECondition.Evaluate(null,
+                new UserAttributes { { "distance_le", 15 } }.ToUserContext(), Logger) ?? true);
+            Assert.IsTrue(LECondition.Evaluate(null,
+                new UserAttributes { { "distance_le", 10 } }.ToUserContext(), Logger) ?? false);
         }
 
         [Test]
         public void TestLEMatcherReturnsNullWhenAttributeValueIsNotANumericValue()
         {
-            Assert.IsNull(LECondition.Evaluate(null, new UserAttributes { { "distance_le", "invalid_type" } }.ToUserContext(), Logger));
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""le"",""name"":""distance_le"",""value"":10} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""distance_le""."), Times.Once);
+            Assert.IsNull(LECondition.Evaluate(null,
+                new UserAttributes { { "distance_le", "invalid_type" } }.ToUserContext(), Logger));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""le"",""name"":""distance_le"",""value"":10} evaluated to UNKNOWN because a value of type ""String"" was passed for user attribute ""distance_le""."),
+                Times.Once);
         }
 
         [Test]
         public void TestLEMatcherReturnsNullWhenAttributeValueIsOutOfBounds()
         {
-            Assert.IsNull(LECondition.Evaluate(null, new UserAttributes { { "distance_le", double.NegativeInfinity } }.ToUserContext(), Logger));
-            Assert.IsNull(LECondition.Evaluate(null, new UserAttributes { { "distance_le", -Math.Pow(2, 53) - 2 } }.ToUserContext(), Logger));
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, @"Audience condition {""type"":""custom_attribute"",""match"":""le"",""name"":""distance_le"",""value"":10} evaluated to UNKNOWN because the number value for user attribute ""distance_le"" is not in the range [-2^53, +2^53]."), Times.Exactly(2));
+            Assert.IsNull(LECondition.Evaluate(null,
+                new UserAttributes { { "distance_le", double.NegativeInfinity } }.ToUserContext(),
+                Logger));
+            Assert.IsNull(LECondition.Evaluate(null,
+                new UserAttributes { { "distance_le", -Math.Pow(2, 53) - 2 } }.ToUserContext(),
+                Logger));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""le"",""name"":""distance_le"",""value"":10} evaluated to UNKNOWN because the number value for user attribute ""distance_le"" is not in the range [-2^53, +2^53]."),
+                Times.Exactly(2));
         }
 
         [Test]
         public void TestLEMatcherReturnsTrueWhenAttributeValueIsLessThanConditionValue()
         {
-            Assert.IsTrue(LECondition.Evaluate(null, new UserAttributes { { "distance_le", 5 } }.ToUserContext(), Logger) ?? false);
+            Assert.IsTrue(LECondition.Evaluate(null,
+                new UserAttributes { { "distance_le", 5 } }.ToUserContext(), Logger) ?? false);
         }
 
         #endregion // LEMatcher Tests
 
         #region SemVerLTMatcher Tests
+
         [Test]
-        public void TestSemVerLTMatcherReturnsFalseWhenAttributeValueIsGreaterThanOrEqualToConditionValue()
+        public void
+            TestSemVerLTMatcherReturnsFalseWhenAttributeValueIsGreaterThanOrEqualToConditionValue()
         {
-            Assert.IsFalse(SemVerLTCondition.Evaluate(null, new UserAttributes { { "semversion_lt", "3.7.2" } }.ToUserContext(), Logger) ?? true);
-            Assert.IsFalse(SemVerLTCondition.Evaluate(null, new UserAttributes { { "semversion_lt", "3.7.1" } }.ToUserContext(), Logger) ?? true);
-            Assert.IsFalse(SemVerLTCondition.Evaluate(null, new UserAttributes { { "semversion_lt", "3.8" } }.ToUserContext(), Logger) ?? true);
-            Assert.IsFalse(SemVerLTCondition.Evaluate(null, new UserAttributes { { "semversion_lt", "4" } }.ToUserContext(), Logger) ?? true);
+            Assert.IsFalse(SemVerLTCondition.Evaluate(null,
+                               new UserAttributes { { "semversion_lt", "3.7.2" } }.ToUserContext(),
+                               Logger) ??
+                           true);
+            Assert.IsFalse(SemVerLTCondition.Evaluate(null,
+                               new UserAttributes { { "semversion_lt", "3.7.1" } }.ToUserContext(),
+                               Logger) ??
+                           true);
+            Assert.IsFalse(SemVerLTCondition.Evaluate(null,
+                new UserAttributes { { "semversion_lt", "3.8" } }.ToUserContext(), Logger) ?? true);
+            Assert.IsFalse(SemVerLTCondition.Evaluate(null,
+                new UserAttributes { { "semversion_lt", "4" } }.ToUserContext(), Logger) ?? true);
         }
 
         [Test]
         public void TestSemVerLTMatcherReturnsTrueWhenAttributeValueIsLessThanConditionValue()
         {
-            Assert.IsTrue(SemVerLTCondition.Evaluate(null, new UserAttributes { { "semversion_lt", "3.7.0" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(SemVerLTCondition.Evaluate(null, new UserAttributes { { "semversion_lt", "3.7.1-beta" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(SemVerLTCondition.Evaluate(null, new UserAttributes { { "semversion_lt", "2.7.1" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(SemVerLTCondition.Evaluate(null, new UserAttributes { { "semversion_lt", "3.7" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(SemVerLTCondition.Evaluate(null, new UserAttributes { { "semversion_lt", "3" } }.ToUserContext(), Logger) ?? false);
+            Assert.IsTrue(SemVerLTCondition.Evaluate(null,
+                              new UserAttributes { { "semversion_lt", "3.7.0" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(SemVerLTCondition.Evaluate(null,
+                              new UserAttributes
+                                  { { "semversion_lt", "3.7.1-beta" } }.ToUserContext(), Logger) ??
+                          false);
+            Assert.IsTrue(SemVerLTCondition.Evaluate(null,
+                              new UserAttributes { { "semversion_lt", "2.7.1" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(SemVerLTCondition.Evaluate(null,
+                              new UserAttributes { { "semversion_lt", "3.7" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(SemVerLTCondition.Evaluate(null,
+                new UserAttributes { { "semversion_lt", "3" } }.ToUserContext(), Logger) ?? false);
         }
 
         [Test]
         public void TestSemVerLTMatcherReturnsTrueWhenAttributeValueIsLessThanConditionValueBeta()
         {
-            var semverLTCondition = new BaseCondition { Name = "semversion_lt", Value = "3.7.0-beta.2.3", Match = "semver_lt", Type = "custom_attribute" };
-            Assert.IsTrue(semverLTCondition.Evaluate(null, new UserAttributes { { "semversion_lt", "3.7.0-beta.2.1" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(semverLTCondition.Evaluate(null, new UserAttributes { { "semversion_lt", "3.7.0-beta" } }.ToUserContext(), Logger) ?? false);
+            var semverLTCondition = new BaseCondition
+            {
+                Name = "semversion_lt", Value = "3.7.0-beta.2.3", Match = "semver_lt",
+                Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverLTCondition.Evaluate(null,
+                new UserAttributes { { "semversion_lt", "3.7.0-beta.2.1" } }.ToUserContext(),
+                Logger) ?? false);
+            Assert.IsTrue(semverLTCondition.Evaluate(null,
+                              new UserAttributes
+                                  { { "semversion_lt", "3.7.0-beta" } }.ToUserContext(), Logger) ??
+                          false);
         }
+
         #endregion // SemVerLTMatcher Tests
 
         #region SemVerGTMatcher Tests
+
         [Test]
-        public void TestSemVerGTMatcherReturnsFalseWhenAttributeValueIsLessThanOrEqualToConditionValue()
+        public void
+            TestSemVerGTMatcherReturnsFalseWhenAttributeValueIsLessThanOrEqualToConditionValue()
         {
-            Assert.IsFalse(SemVerGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "3.7.0" } }.ToUserContext(), Logger)?? true);
-            Assert.IsFalse(SemVerGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "3.7.1" } }.ToUserContext(), Logger)?? true);
-            Assert.IsFalse(SemVerGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "3.6" } }.ToUserContext(), Logger)?? true);
-            Assert.IsFalse(SemVerGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "2" } }.ToUserContext(), Logger)?? true);
+            Assert.IsFalse(SemVerGTCondition.Evaluate(null,
+                               new UserAttributes { { "semversion_gt", "3.7.0" } }.ToUserContext(),
+                               Logger) ??
+                           true);
+            Assert.IsFalse(SemVerGTCondition.Evaluate(null,
+                               new UserAttributes { { "semversion_gt", "3.7.1" } }.ToUserContext(),
+                               Logger) ??
+                           true);
+            Assert.IsFalse(SemVerGTCondition.Evaluate(null,
+                new UserAttributes { { "semversion_gt", "3.6" } }.ToUserContext(), Logger) ?? true);
+            Assert.IsFalse(SemVerGTCondition.Evaluate(null,
+                new UserAttributes { { "semversion_gt", "2" } }.ToUserContext(), Logger) ?? true);
         }
 
         [Test]
         public void TestSemVerGTMatcherReturnsTrueWhenAttributeValueIsGreaterThanConditionValue()
         {
-            Assert.IsTrue(SemVerGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "3.7.2" } }.ToUserContext(), Logger)?? false);
-            Assert.IsTrue(SemVerGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "3.7.2-beta" } }.ToUserContext(), Logger)?? false);
-            Assert.IsTrue(SemVerGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "4.7.1" } }.ToUserContext(), Logger)?? false);
-            Assert.IsTrue(SemVerGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "3.8" } }.ToUserContext(), Logger)?? false);
-            Assert.IsTrue(SemVerGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "4" } }.ToUserContext(), Logger)?? false);
+            Assert.IsTrue(SemVerGTCondition.Evaluate(null,
+                              new UserAttributes { { "semversion_gt", "3.7.2" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(SemVerGTCondition.Evaluate(null,
+                              new UserAttributes
+                                  { { "semversion_gt", "3.7.2-beta" } }.ToUserContext(), Logger) ??
+                          false);
+            Assert.IsTrue(SemVerGTCondition.Evaluate(null,
+                              new UserAttributes { { "semversion_gt", "4.7.1" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(SemVerGTCondition.Evaluate(null,
+                              new UserAttributes { { "semversion_gt", "3.8" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(SemVerGTCondition.Evaluate(null,
+                new UserAttributes { { "semversion_gt", "4" } }.ToUserContext(), Logger) ?? false);
         }
 
         [Test]
-        public void TestSemVerGTMatcherReturnsTrueWhenAttributeValueIsGreaterThanConditionValueBeta()
+        public void
+            TestSemVerGTMatcherReturnsTrueWhenAttributeValueIsGreaterThanConditionValueBeta()
         {
-            var semverGTCondition = new BaseCondition { Name = "semversion_gt", Value = "3.7.0-beta.2.3", Match = "semver_gt", Type = "custom_attribute" };
-            Assert.IsTrue(semverGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "3.7.0-beta.2.4" } }.ToUserContext(), Logger)?? false);
-            Assert.IsTrue(semverGTCondition.Evaluate(null, new UserAttributes { { "semversion_gt", "3.7.0" } }.ToUserContext(), Logger)?? false);
+            var semverGTCondition = new BaseCondition
+            {
+                Name = "semversion_gt", Value = "3.7.0-beta.2.3", Match = "semver_gt",
+                Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverGTCondition.Evaluate(null,
+                new UserAttributes { { "semversion_gt", "3.7.0-beta.2.4" } }.ToUserContext(),
+                Logger) ?? false);
+            Assert.IsTrue(semverGTCondition.Evaluate(null,
+                              new UserAttributes { { "semversion_gt", "3.7.0" } }.ToUserContext(),
+                              Logger) ??
+                          false);
         }
+
         #endregion // SemVerGTMatcher Tests
 
         #region SemVerEQMatcher Tests
+
         [Test]
         public void TestSemVerEQMatcherReturnsFalseWhenAttributeValueIsNotEqualToConditionValue()
         {
-            Assert.IsFalse(SemVerEQCondition.Evaluate(null, new UserAttributes { { "semversion_eq", "3.7.0" } }.ToUserContext(), Logger) ?? true);
-            Assert.IsFalse(SemVerEQCondition.Evaluate(null, new UserAttributes { { "semversion_eq", "3.7.2" } }.ToUserContext(), Logger) ?? true);
-            Assert.IsFalse(SemVerEQCondition.Evaluate(null, new UserAttributes { { "semversion_eq", "3.6" } }.ToUserContext(), Logger)?? true);
-            Assert.IsFalse(SemVerEQCondition.Evaluate(null, new UserAttributes { { "semversion_eq", "2" } }.ToUserContext(), Logger)?? true);
-            Assert.IsFalse(SemVerEQCondition.Evaluate(null, new UserAttributes { { "semversion_eq", "4" } }.ToUserContext(), Logger)?? true);
-            Assert.IsFalse(SemVerEQCondition.Evaluate(null, new UserAttributes { { "semversion_eq", "3" } }.ToUserContext(), Logger)?? true);
+            Assert.IsFalse(SemVerEQCondition.Evaluate(null,
+                               new UserAttributes { { "semversion_eq", "3.7.0" } }.ToUserContext(),
+                               Logger) ??
+                           true);
+            Assert.IsFalse(SemVerEQCondition.Evaluate(null,
+                               new UserAttributes { { "semversion_eq", "3.7.2" } }.ToUserContext(),
+                               Logger) ??
+                           true);
+            Assert.IsFalse(SemVerEQCondition.Evaluate(null,
+                new UserAttributes { { "semversion_eq", "3.6" } }.ToUserContext(), Logger) ?? true);
+            Assert.IsFalse(SemVerEQCondition.Evaluate(null,
+                new UserAttributes { { "semversion_eq", "2" } }.ToUserContext(), Logger) ?? true);
+            Assert.IsFalse(SemVerEQCondition.Evaluate(null,
+                new UserAttributes { { "semversion_eq", "4" } }.ToUserContext(), Logger) ?? true);
+            Assert.IsFalse(SemVerEQCondition.Evaluate(null,
+                new UserAttributes { { "semversion_eq", "3" } }.ToUserContext(), Logger) ?? true);
         }
 
         [Test]
         public void TestSemVerEQMatcherReturnsTrueWhenAttributeValueIsEqualToConditionValue()
         {
-            Assert.IsTrue(SemVerEQCondition.Evaluate(null, new UserAttributes { { "semversion_eq", "3.7.1" } }.ToUserContext(), Logger) ?? false);
+            Assert.IsTrue(SemVerEQCondition.Evaluate(null,
+                              new UserAttributes { { "semversion_eq", "3.7.1" } }.ToUserContext(),
+                              Logger) ??
+                          false);
         }
 
         [Test]
-        public void TestSemVerEQMatcherReturnsTrueWhenAttributeValueIsEqualToConditionValueMajorOnly()
+        public void
+            TestSemVerEQMatcherReturnsTrueWhenAttributeValueIsEqualToConditionValueMajorOnly()
         {
-            var semverEQCondition = new BaseCondition { Name = "semversion_eq", Value = "3", Match = "semver_eq", Type = "custom_attribute" };
-            Assert.IsTrue(semverEQCondition.Evaluate(null, new UserAttributes { { "semversion_eq", "3.0.0" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(semverEQCondition.Evaluate(null, new UserAttributes { { "semversion_eq", "3.1" } }.ToUserContext(), Logger) ?? false);
+            var semverEQCondition = new BaseCondition
+            {
+                Name = "semversion_eq", Value = "3", Match = "semver_eq", Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverEQCondition.Evaluate(null,
+                              new UserAttributes { { "semversion_eq", "3.0.0" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(semverEQCondition.Evaluate(null,
+                              new UserAttributes { { "semversion_eq", "3.1" } }.ToUserContext(),
+                              Logger) ??
+                          false);
         }
 
         [Test]
-        public void TestSemVerEQMatcherReturnsFalseOrFalseWhenAttributeValueIsNotEqualToConditionValueMajorOnly()
+        public void
+            TestSemVerEQMatcherReturnsFalseOrFalseWhenAttributeValueIsNotEqualToConditionValueMajorOnly()
         {
-            var semverEQCondition = new BaseCondition { Name = "semversion_eq", Value = "3", Match = "semver_eq", Type = "custom_attribute" };
-            Assert.IsFalse(semverEQCondition.Evaluate(null, new UserAttributes { { "semversion_eq", "4.0" } }.ToUserContext(), Logger) ?? true);
-            Assert.IsFalse(semverEQCondition.Evaluate(null, new UserAttributes { { "semversion_eq", "2" } }.ToUserContext(), Logger) ?? true);
+            var semverEQCondition = new BaseCondition
+            {
+                Name = "semversion_eq", Value = "3", Match = "semver_eq", Type = "custom_attribute",
+            };
+            Assert.IsFalse(semverEQCondition.Evaluate(null,
+                new UserAttributes { { "semversion_eq", "4.0" } }.ToUserContext(), Logger) ?? true);
+            Assert.IsFalse(semverEQCondition.Evaluate(null,
+                new UserAttributes { { "semversion_eq", "2" } }.ToUserContext(), Logger) ?? true);
         }
 
         [Test]
         public void TestSemVerEQMatcherReturnsTrueWhenAttributeValueIsEqualToConditionValueBeta()
         {
-            var semverEQCondition = new BaseCondition { Name = "semversion_eq", Value = "3.7.0-beta.2.3", Match = "semver_eq", Type = "custom_attribute" };
-            Assert.IsTrue(semverEQCondition.Evaluate(null, new UserAttributes { { "semversion_eq", "3.7.0-beta.2.3" } }.ToUserContext(), Logger) ?? false);
+            var semverEQCondition = new BaseCondition
+            {
+                Name = "semversion_eq", Value = "3.7.0-beta.2.3", Match = "semver_eq",
+                Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverEQCondition.Evaluate(null,
+                new UserAttributes { { "semversion_eq", "3.7.0-beta.2.3" } }.ToUserContext(),
+                Logger) ?? false);
         }
 
         [Test]
         public void TestSemVerEQTargetBuildIgnores()
         {
-            var semverEQCondition = new BaseCondition { Name = "semversion_eq", Value = "2.1.3", Match = "semver_eq", Type = "custom_attribute" };
-            Assert.IsTrue(semverEQCondition.Evaluate(null, new UserAttributes { { "semversion_eq", "2.1.3+build" } }.ToUserContext(), Logger) ?? false);
+            var semverEQCondition = new BaseCondition
+            {
+                Name = "semversion_eq", Value = "2.1.3", Match = "semver_eq",
+                Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverEQCondition.Evaluate(null,
+                new UserAttributes { { "semversion_eq", "2.1.3+build" } }.ToUserContext(),
+                Logger) ?? false);
         }
+
         #endregion // SemVerEQMatcher Tests
 
         #region SemVerGEMatcher Tests
+
         [Test]
-        public void TestSemVerGEMatcherReturnsFalseWhenAttributeValueIsNotGreaterOrEqualToConditionValue()
+        public void
+            TestSemVerGEMatcherReturnsFalseWhenAttributeValueIsNotGreaterOrEqualToConditionValue()
         {
-            Assert.IsFalse(SemVerGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "3.7.0" } }.ToUserContext(), Logger) ?? true);
-            Assert.IsFalse(SemVerGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "3.7.1-beta" } }.ToUserContext(), Logger) ?? true);
-            Assert.IsFalse(SemVerGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "3.6" } }.ToUserContext(), Logger) ?? true);
-            Assert.IsFalse(SemVerGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "2" } }.ToUserContext(), Logger) ?? true);
-            Assert.IsFalse(SemVerGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "3" } }.ToUserContext(), Logger) ?? true);
+            Assert.IsFalse(SemVerGECondition.Evaluate(null,
+                               new UserAttributes { { "semversion_ge", "3.7.0" } }.ToUserContext(),
+                               Logger) ??
+                           true);
+            Assert.IsFalse(SemVerGECondition.Evaluate(null,
+                               new UserAttributes { { "semversion_ge", "3.7.1-beta" } }.
+                                   ToUserContext(), Logger) ??
+                           true);
+            Assert.IsFalse(SemVerGECondition.Evaluate(null,
+                new UserAttributes { { "semversion_ge", "3.6" } }.ToUserContext(), Logger) ?? true);
+            Assert.IsFalse(SemVerGECondition.Evaluate(null,
+                new UserAttributes { { "semversion_ge", "2" } }.ToUserContext(), Logger) ?? true);
+            Assert.IsFalse(SemVerGECondition.Evaluate(null,
+                new UserAttributes { { "semversion_ge", "3" } }.ToUserContext(), Logger) ?? true);
         }
 
         [Test]
-        public void TestSemVerGEMatcherReturnsTrueWhenAttributeValueIsGreaterOrEqualToConditionValue()
+        public void
+            TestSemVerGEMatcherReturnsTrueWhenAttributeValueIsGreaterOrEqualToConditionValue()
         {
-            Assert.IsTrue(SemVerGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "3.7.1" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(SemVerGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "3.7.2" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(SemVerGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "3.8.1" } }.ToUserContext(), Logger) ?? false); ;
-            Assert.IsTrue(SemVerGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "4.7.1" } }.ToUserContext(), Logger) ?? false);
+            Assert.IsTrue(SemVerGECondition.Evaluate(null,
+                              new UserAttributes { { "semversion_ge", "3.7.1" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(SemVerGECondition.Evaluate(null,
+                              new UserAttributes { { "semversion_ge", "3.7.2" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(SemVerGECondition.Evaluate(null,
+                              new UserAttributes { { "semversion_ge", "3.8.1" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            ;
+            Assert.IsTrue(SemVerGECondition.Evaluate(null,
+                              new UserAttributes { { "semversion_ge", "4.7.1" } }.ToUserContext(),
+                              Logger) ??
+                          false);
         }
 
         [Test]
-        public void TestSemVerGEMatcherReturnsTrueWhenAttributeValueIsGreaterOrEqualToConditionValueMajorOnly()
+        public void
+            TestSemVerGEMatcherReturnsTrueWhenAttributeValueIsGreaterOrEqualToConditionValueMajorOnly()
         {
-            var semverGECondition = new BaseCondition { Name = "semversion_ge", Value = "3", Match = "semver_ge", Type = "custom_attribute" };
-            Assert.IsTrue(semverGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "3.7.0" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(semverGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "3.0.0" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(semverGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "4.0" } }.ToUserContext(), Logger) ?? false);
+            var semverGECondition = new BaseCondition
+            {
+                Name = "semversion_ge", Value = "3", Match = "semver_ge", Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverGECondition.Evaluate(null,
+                              new UserAttributes { { "semversion_ge", "3.7.0" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(semverGECondition.Evaluate(null,
+                              new UserAttributes { { "semversion_ge", "3.0.0" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(semverGECondition.Evaluate(null,
+                              new UserAttributes { { "semversion_ge", "4.0" } }.ToUserContext(),
+                              Logger) ??
+                          false);
         }
 
         [Test]
-        public void TestSemVerGEMatcherReturnsFalseWhenAttributeValueIsNotGreaterOrEqualToConditionValueMajorOnly()
+        public void
+            TestSemVerGEMatcherReturnsFalseWhenAttributeValueIsNotGreaterOrEqualToConditionValueMajorOnly()
         {
-            var semverGECondition = new BaseCondition { Name = "semversion_ge", Value = "3", Match = "semver_ge", Type = "custom_attribute" };
-            Assert.IsFalse(semverGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "2" } }.ToUserContext(), Logger) ?? true);
+            var semverGECondition = new BaseCondition
+            {
+                Name = "semversion_ge", Value = "3", Match = "semver_ge", Type = "custom_attribute",
+            };
+            Assert.IsFalse(semverGECondition.Evaluate(null,
+                new UserAttributes { { "semversion_ge", "2" } }.ToUserContext(), Logger) ?? true);
         }
 
         [Test]
-        public void TestSemVerGEMatcherReturnsTrueWhenAttributeValueIsGreaterOrEqualToConditionValueBeta()
+        public void
+            TestSemVerGEMatcherReturnsTrueWhenAttributeValueIsGreaterOrEqualToConditionValueBeta()
         {
-            var semverGECondition = new BaseCondition { Name = "semversion_ge", Value = "3.7.0-beta.2.3", Match = "semver_ge", Type = "custom_attribute" };
-            Assert.IsTrue(semverGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "3.7.0-beta.2.3" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(semverGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "3.7.0-beta.2.4" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(semverGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "3.7.0-beta.2.3+1.2.3" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(semverGECondition.Evaluate(null, new UserAttributes { { "semversion_ge", "3.7.1-beta.2.3" } }.ToUserContext(), Logger) ?? false);
+            var semverGECondition = new BaseCondition
+            {
+                Name = "semversion_ge", Value = "3.7.0-beta.2.3", Match = "semver_ge",
+                Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverGECondition.Evaluate(null,
+                new UserAttributes { { "semversion_ge", "3.7.0-beta.2.3" } }.ToUserContext(),
+                Logger) ?? false);
+            Assert.IsTrue(semverGECondition.Evaluate(null,
+                new UserAttributes { { "semversion_ge", "3.7.0-beta.2.4" } }.ToUserContext(),
+                Logger) ?? false);
+            Assert.IsTrue(semverGECondition.Evaluate(null,
+                new UserAttributes { { "semversion_ge", "3.7.0-beta.2.3+1.2.3" } }.ToUserContext(),
+                Logger) ?? false);
+            Assert.IsTrue(semverGECondition.Evaluate(null,
+                new UserAttributes { { "semversion_ge", "3.7.1-beta.2.3" } }.ToUserContext(),
+                Logger) ?? false);
         }
+
         #endregion // SemVerGEMatcher Tests
 
         #region SemVerLEMatcher Tests
+
         [Test]
-        public void TestSemVerLEMatcherReturnsFalseWhenAttributeValueIsNotLessOrEqualToConditionValue()
+        public void
+            TestSemVerLEMatcherReturnsFalseWhenAttributeValueIsNotLessOrEqualToConditionValue()
         {
-            Assert.IsFalse(SemVerLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "3.7.2" } }.ToUserContext(), Logger) ?? true);
-            Assert.IsFalse(SemVerLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "3.8" } }.ToUserContext(), Logger) ?? true);
-            Assert.IsFalse(SemVerLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "4" } }.ToUserContext(), Logger) ?? true);
+            Assert.IsFalse(SemVerLECondition.Evaluate(null,
+                               new UserAttributes { { "semversion_le", "3.7.2" } }.ToUserContext(),
+                               Logger) ??
+                           true);
+            Assert.IsFalse(SemVerLECondition.Evaluate(null,
+                new UserAttributes { { "semversion_le", "3.8" } }.ToUserContext(), Logger) ?? true);
+            Assert.IsFalse(SemVerLECondition.Evaluate(null,
+                new UserAttributes { { "semversion_le", "4" } }.ToUserContext(), Logger) ?? true);
         }
 
         [Test]
         public void TestSemVerLEMatcherReturnsTrueWhenAttributeValueIsLessOrEqualToConditionValue()
         {
-            Assert.IsTrue(SemVerLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "3.7.1" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(SemVerLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "3.7.0" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(SemVerLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "3.6.1" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(SemVerLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "2.7.1" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(SemVerLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "3.7.1-beta" } }.ToUserContext(), Logger) ?? false);
+            Assert.IsTrue(SemVerLECondition.Evaluate(null,
+                              new UserAttributes { { "semversion_le", "3.7.1" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(SemVerLECondition.Evaluate(null,
+                              new UserAttributes { { "semversion_le", "3.7.0" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(SemVerLECondition.Evaluate(null,
+                              new UserAttributes { { "semversion_le", "3.6.1" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(SemVerLECondition.Evaluate(null,
+                              new UserAttributes { { "semversion_le", "2.7.1" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(SemVerLECondition.Evaluate(null,
+                              new UserAttributes
+                                  { { "semversion_le", "3.7.1-beta" } }.ToUserContext(), Logger) ??
+                          false);
         }
 
         [Test]
-        public void TestSemVerLEMatcherReturnsTrueWhenAttributeValueIsLessOrEqualToConditionValueMajorOnly()
+        public void
+            TestSemVerLEMatcherReturnsTrueWhenAttributeValueIsLessOrEqualToConditionValueMajorOnly()
         {
-            var semverLECondition = new BaseCondition { Name = "semversion_le", Value = "3", Match = "semver_le", Type = "custom_attribute" };
-            Assert.IsTrue(semverLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "3.7.0-beta.2.4" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(semverLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "3.7.1-beta" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(semverLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "3.0.0" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(semverLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "2.0" } }.ToUserContext(), Logger) ?? false);
+            var semverLECondition = new BaseCondition
+            {
+                Name = "semversion_le", Value = "3", Match = "semver_le", Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverLECondition.Evaluate(null,
+                new UserAttributes { { "semversion_le", "3.7.0-beta.2.4" } }.ToUserContext(),
+                Logger) ?? false);
+            Assert.IsTrue(semverLECondition.Evaluate(null,
+                              new UserAttributes
+                                  { { "semversion_le", "3.7.1-beta" } }.ToUserContext(), Logger) ??
+                          false);
+            Assert.IsTrue(semverLECondition.Evaluate(null,
+                              new UserAttributes { { "semversion_le", "3.0.0" } }.ToUserContext(),
+                              Logger) ??
+                          false);
+            Assert.IsTrue(semverLECondition.Evaluate(null,
+                              new UserAttributes { { "semversion_le", "2.0" } }.ToUserContext(),
+                              Logger) ??
+                          false);
         }
 
         [Test]
-        public void TestSemVerLEMatcherReturnsFalseWhenAttributeValueIsNotLessOrEqualToConditionValueMajorOnly()
+        public void
+            TestSemVerLEMatcherReturnsFalseWhenAttributeValueIsNotLessOrEqualToConditionValueMajorOnly()
         {
-            var semverLECondition = new BaseCondition { Name = "semversion_le", Value = "3", Match = "semver_le", Type = "custom_attribute" };
-            Assert.IsFalse(semverLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "4" } }.ToUserContext(), Logger) ?? true);
+            var semverLECondition = new BaseCondition
+            {
+                Name = "semversion_le", Value = "3", Match = "semver_le", Type = "custom_attribute",
+            };
+            Assert.IsFalse(semverLECondition.Evaluate(null,
+                new UserAttributes { { "semversion_le", "4" } }.ToUserContext(), Logger) ?? true);
         }
 
         [Test]
-        public void TestSemVerLEMatcherReturnsTrueWhenAttributeValueIsLessOrEqualToConditionValueBeta()
+        public void
+            TestSemVerLEMatcherReturnsTrueWhenAttributeValueIsLessOrEqualToConditionValueBeta()
         {
-            var semverLECondition = new BaseCondition { Name = "semversion_le", Value = "3.7.0-beta.2.3", Match = "semver_le", Type = "custom_attribute" };
-            Assert.IsTrue(semverLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "3.7.0-beta.2.2" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(semverLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "3.7.0-beta.2.3" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(semverLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "3.7.0-beta.2.2+1.2.3" } }.ToUserContext(), Logger) ?? false);
-            Assert.IsTrue(semverLECondition.Evaluate(null, new UserAttributes { { "semversion_le", "3.6.1-beta.2.3+1.2" } }.ToUserContext(), Logger) ?? false);
+            var semverLECondition = new BaseCondition
+            {
+                Name = "semversion_le", Value = "3.7.0-beta.2.3", Match = "semver_le",
+                Type = "custom_attribute",
+            };
+            Assert.IsTrue(semverLECondition.Evaluate(null,
+                new UserAttributes { { "semversion_le", "3.7.0-beta.2.2" } }.ToUserContext(),
+                Logger) ?? false);
+            Assert.IsTrue(semverLECondition.Evaluate(null,
+                new UserAttributes { { "semversion_le", "3.7.0-beta.2.3" } }.ToUserContext(),
+                Logger) ?? false);
+            Assert.IsTrue(semverLECondition.Evaluate(null,
+                new UserAttributes { { "semversion_le", "3.7.0-beta.2.2+1.2.3" } }.ToUserContext(),
+                Logger) ?? false);
+            Assert.IsTrue(semverLECondition.Evaluate(null,
+                new UserAttributes { { "semversion_le", "3.6.1-beta.2.3+1.2" } }.ToUserContext(),
+                Logger) ?? false);
         }
+
         #endregion // SemVerLEMatcher Tests
 
         #region SemVer Invalid Scenarios
@@ -647,16 +1264,26 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestInvalidSemVersions()
         {
-            var invalidValues = new string[] {"-", ".", "..", "+", "+test", " ", "2 .3. 0", "2.",
-                ".2.2", "3.7.2.2", "3.x", ",", "+build-prerelese"};
-            var semverLECondition = new BaseCondition { Name = "semversion_le", Value = "3", Match = "semver_le", Type = "custom_attribute" };
-            foreach(var invalidValue in invalidValues) {
-                Assert.IsNull(semverLECondition.Evaluate(null, new UserAttributes { { "semversion_le", invalidValue } }.ToUserContext(), Logger), $"returned for {invalidValue}");
+            var invalidValues = new string[]
+            {
+                "-", ".", "..", "+", "+test", " ", "2 .3. 0", "2.",
+                ".2.2", "3.7.2.2", "3.x", ",", "+build-prerelese",
+            };
+            var semverLECondition = new BaseCondition
+            {
+                Name = "semversion_le", Value = "3", Match = "semver_le", Type = "custom_attribute",
+            };
+            foreach (var invalidValue in invalidValues)
+            {
+                Assert.IsNull(
+                    semverLECondition.Evaluate(null,
+                        new UserAttributes { { "semversion_le", invalidValue } }.ToUserContext(),
+                        Logger), $"returned for {invalidValue}");
             }
         }
 
         #endregion
-        
+
         #region Qualified Tests
 
         [Test]
@@ -670,13 +1297,17 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
             };
 
             var result = condition.Evaluate(null, null, Logger);
-            
+
             Assert.That(result, Is.Null);
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, $@"Audience condition ""{condition}"" has a qualified match but invalid value."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.WARN,
+                    $@"Audience condition ""{condition
+                    }"" has a qualified match but invalid value."), Times.Once);
         }
-        
-        
+
+
         private const string QUALIFIED_VALUE = "part-of-the-rebellion";
+
         private readonly List<string> _qualifiedSegments = new List<string>()
         {
             QUALIFIED_VALUE,
@@ -693,7 +1324,7 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
             };
 
             var result = condition.Evaluate(null, _qualifiedSegments.ToUserContext(), Logger);
-            
+
             Assert.True(result.HasValue && result.Value);
             LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Never);
         }
@@ -709,11 +1340,11 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
             };
 
             var result = condition.Evaluate(null, _qualifiedSegments.ToUserContext(), Logger);
-            
+
             Assert.True(result.HasValue && result.Value == false);
-            LoggerMock.Verify(l => l.Log( It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Never);
+            LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Never);
         }
-        
+
         #endregion
     }
 }

--- a/OptimizelySDK.Tests/AudienceConditionsTests/ConditionsTest.cs
+++ b/OptimizelySDK.Tests/AudienceConditionsTests/ConditionsTest.cs
@@ -41,11 +41,17 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         public void Initialize()
         {
             TrueConditionMock = new Mock<ICondition>();
-            TrueConditionMock.Setup(condition => condition.Evaluate(It.IsAny<ProjectConfig>(), It.IsAny<OptimizelyUserContext>(), It.IsAny<ILogger>())).Returns(true);
+            TrueConditionMock.Setup(condition => condition.Evaluate(It.IsAny<ProjectConfig>(),
+                    It.IsAny<OptimizelyUserContext>(), It.IsAny<ILogger>())).
+                Returns(true);
             FalseConditionMock = new Mock<ICondition>();
-            FalseConditionMock.Setup(condition => condition.Evaluate(It.IsAny<ProjectConfig>(), It.IsAny<OptimizelyUserContext>(), It.IsAny<ILogger>())).Returns(false);
+            FalseConditionMock.Setup(condition => condition.Evaluate(It.IsAny<ProjectConfig>(),
+                    It.IsAny<OptimizelyUserContext>(), It.IsAny<ILogger>())).
+                Returns(false);
             NullConditionMock = new Mock<ICondition>();
-            NullConditionMock.Setup(condition => condition.Evaluate(It.IsAny<ProjectConfig>(), It.IsAny<OptimizelyUserContext>(), It.IsAny<ILogger>())).Returns((bool?)null);
+            NullConditionMock.Setup(condition => condition.Evaluate(It.IsAny<ProjectConfig>(),
+                    It.IsAny<OptimizelyUserContext>(), It.IsAny<ILogger>())).
+                Returns((bool?)null);
 
             TrueCondition = TrueConditionMock.Object;
             FalseCondition = FalseConditionMock.Object;
@@ -61,7 +67,7 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestAndEvaluatorReturnsTrueWhenAllOperandsEvaluateToTrue()
         {
-            ICondition[] conditions = new ICondition[] { TrueCondition, TrueCondition };
+            var conditions = new ICondition[] { TrueCondition, TrueCondition };
             var andCondition = new AndCondition { Conditions = conditions };
 
             Assert.That(andCondition.Evaluate(null, null, Logger), Is.True);
@@ -70,19 +76,21 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestAndEvaluatorReturnsFalseWhenAnyOperandEvaluatesToFalse()
         {
-            ICondition[] conditions = new ICondition[] { FalseCondition, TrueCondition };
+            var conditions = new ICondition[] { FalseCondition, TrueCondition };
             var andCondition = new AndCondition { Conditions = conditions };
 
             Assert.That(andCondition.Evaluate(null, null, Logger), Is.False);
 
             // Should not be called due to short circuiting.
-            TrueConditionMock.Verify(condition => condition.Evaluate(It.IsAny<ProjectConfig>(), It.IsAny<OptimizelyUserContext>(), Logger), Times.Never);
+            TrueConditionMock.Verify(
+                condition => condition.Evaluate(It.IsAny<ProjectConfig>(),
+                    It.IsAny<OptimizelyUserContext>(), Logger), Times.Never);
         }
 
         [Test]
         public void TestAndEvaluatorReturnsNullWhenAllOperandsEvaluateToNull()
         {
-            ICondition[] conditions = new ICondition[] { NullCondition, NullCondition };
+            var conditions = new ICondition[] { NullCondition, NullCondition };
             var andCondition = new AndCondition { Conditions = conditions };
 
             Assert.That(andCondition.Evaluate(null, null, Logger), Is.Null);
@@ -91,7 +99,7 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestAndEvaluatorReturnsNullWhenOperandsEvaluateToTrueAndNull()
         {
-            ICondition[] conditions = new ICondition[] { TrueCondition, NullCondition, TrueCondition };
+            var conditions = new ICondition[] { TrueCondition, NullCondition, TrueCondition };
             var andCondition = new AndCondition { Conditions = conditions };
 
             Assert.That(andCondition.Evaluate(null, null, Logger), Is.Null);
@@ -100,7 +108,7 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestAndEvaluatorReturnsFalseWhenOperandsEvaluateToFalseAndNull()
         {
-            ICondition[] conditions = new ICondition[] { NullCondition, FalseCondition, NullCondition };
+            var conditions = new ICondition[] { NullCondition, FalseCondition, NullCondition };
             var andCondition = new AndCondition { Conditions = conditions };
 
             Assert.That(andCondition.Evaluate(null, null, Logger), Is.False);
@@ -109,7 +117,7 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestAndEvaluatorReturnsFalseWhenOperandsEvaluateToTrueFalseAndNull()
         {
-            ICondition[] conditions = new ICondition[] { TrueCondition, FalseCondition, NullCondition };
+            var conditions = new ICondition[] { TrueCondition, FalseCondition, NullCondition };
             var andCondition = new AndCondition { Conditions = conditions };
 
             Assert.That(andCondition.Evaluate(null, null, Logger), Is.False);
@@ -122,7 +130,7 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestOrEvaluatorReturnsTrueWhenAnyOperandEvaluatesToTrue()
         {
-            ICondition[] conditions = new ICondition[] { TrueCondition, FalseCondition, NullCondition };
+            var conditions = new ICondition[] { TrueCondition, FalseCondition, NullCondition };
             var orCondition = new OrCondition { Conditions = conditions };
 
             Assert.That(orCondition.Evaluate(null, null, Logger), Is.True);
@@ -131,7 +139,7 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestOrEvaluatorReturnsFalseWhenAllOperandsEvaluatesToFalse()
         {
-            ICondition[] conditions = new ICondition[] { FalseCondition, FalseCondition };
+            var conditions = new ICondition[] { FalseCondition, FalseCondition };
             var orCondition = new OrCondition { Conditions = conditions };
 
             Assert.That(orCondition.Evaluate(null, null, Logger), Is.False);
@@ -140,7 +148,7 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestOrEvaluatorReturnsNullWhenOperandsEvaluateToFalseAndNull()
         {
-            ICondition[] conditions = new ICondition[] { FalseCondition, NullCondition, FalseCondition };
+            var conditions = new ICondition[] { FalseCondition, NullCondition, FalseCondition };
             var orCondition = new OrCondition { Conditions = conditions };
 
             Assert.That(orCondition.Evaluate(null, null, Logger), Is.Null);
@@ -149,7 +157,7 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestOrEvaluatorReturnsTrueWhenOperandsEvaluateToTrueAndNull()
         {
-            ICondition[] conditions = new ICondition[] { TrueCondition, NullCondition, TrueCondition };
+            var conditions = new ICondition[] { TrueCondition, NullCondition, TrueCondition };
             var orCondition = new OrCondition { Conditions = conditions };
 
             Assert.That(orCondition.Evaluate(null, null, Logger), Is.True);
@@ -158,7 +166,7 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
         [Test]
         public void TestOrEvaluatorReturnsTrueWhenOperandsEvaluateToFalseTrueAndNull()
         {
-            ICondition[] conditions = new ICondition[] { FalseCondition, NullCondition, TrueCondition };
+            var conditions = new ICondition[] { FalseCondition, NullCondition, TrueCondition };
             var orCondition = new OrCondition { Conditions = conditions };
 
             Assert.That(orCondition.Evaluate(null, null, Logger), Is.True);

--- a/OptimizelySDK.Tests/AudienceConditionsTests/SegmentsTests.cs
+++ b/OptimizelySDK.Tests/AudienceConditionsTests/SegmentsTests.cs
@@ -128,7 +128,8 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
             {
                 Conditions = new[]
                 {
-                    _customExactMatchCondition, _customExactMatchCondition, _customExactMatchCondition,
+                    _customExactMatchCondition, _customExactMatchCondition,
+                    _customExactMatchCondition,
                 },
             };
 
@@ -151,7 +152,8 @@ namespace OptimizelySDK.Tests.AudienceConditionsTests
             {
                 Conditions = new ICondition[]
                 {
-                    _secondThirdPartyOdpQualifiedMatchCondition, _firstThirdPartyOdpQualifiedMatchCondition,
+                    _secondThirdPartyOdpQualifiedMatchCondition,
+                    _firstThirdPartyOdpQualifiedMatchCondition,
                 },
             };
             var orConditions = new OrCondition

--- a/OptimizelySDK.Tests/AudienceConditionsTests/SegmentsTests.cs
+++ b/OptimizelySDK.Tests/AudienceConditionsTests/SegmentsTests.cs
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
+using System.Linq;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.AudienceConditions;
 using OptimizelySDK.Entity;
 using OptimizelySDK.Logger;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace OptimizelySDK.Tests.AudienceConditionsTests
 {

--- a/OptimizelySDK.Tests/BucketerTest.cs
+++ b/OptimizelySDK.Tests/BucketerTest.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.Bucketing;
@@ -30,8 +31,13 @@ namespace OptimizelySDK.Tests
         private ProjectConfig Config;
         private DecisionReasons DecisionReasonsObj;
         private const string TestUserId = "testUserId";
-        public string TestBucketingIdControl { get; } = "testBucketingIdControl!"; // generates bucketing number 3741
-        public string TestBucketingIdVariation { get; } = "123456789'"; // generates bucketing number 4567
+
+        public string TestBucketingIdControl { get; } =
+            "testBucketingIdControl!"; // generates bucketing number 3741
+
+        public string TestBucketingIdVariation { get; } =
+            "123456789'"; // generates bucketing number 4567
+
         public string TestBucketingIdGroupExp2Var2 { get; } = "123456789"; // group_exp_2_var_2
         public string TestUserIdBucketsToVariation { get; } = "bucketsToVariation!";
         public string TestUserIdBucketsToNoGroup { get; } = "testUserId";
@@ -44,15 +50,13 @@ namespace OptimizelySDK.Tests
             public string UserId { get; set; }
             public string ExperimentId { get; set; }
             public int ExpectedBucketValue { get; set; }
-            
-            public string BucketingId
-            {
-                get { return UserId + ExperimentId; }
-            }
+
+            public string BucketingId => UserId + ExperimentId;
 
             public override string ToString()
             {
-                return string.Format("UserId: {0}, ExperimentId: {1}, BucketId: {2}, ExpectedBucketValue {3}",
+                return string.Format(
+                    "UserId: {0}, ExperimentId: {1}, BucketId: {2}, ExpectedBucketValue {3}",
                     UserId, ExperimentId, BucketingId, ExpectedBucketValue);
             }
         }
@@ -62,7 +66,8 @@ namespace OptimizelySDK.Tests
         {
             LoggerMock = new Mock<ILogger>();
             DecisionReasonsObj = new DecisionReasons();
-            Config = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object, new ErrorHandler.NoOpErrorHandler());
+            Config = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object,
+                new ErrorHandler.NoOpErrorHandler());
         }
 
         [TestFixtureSetUp]
@@ -78,17 +83,37 @@ namespace OptimizelySDK.Tests
             var bucketer = new Bucketer(LoggerMock.Object);
 
             foreach (var item in new[]
+                     {
+                         new BucketerTestItem
+                         {
+                             UserId = "ppid1", ExperimentId = "1886780721",
+                             ExpectedBucketValue = 5254,
+                         },
+                         new BucketerTestItem
+                         {
+                             UserId = "ppid2", ExperimentId = "1886780721",
+                             ExpectedBucketValue = 4299,
+                         },
+                         new BucketerTestItem
+                         {
+                             UserId = "ppid2", ExperimentId = "1886780722",
+                             ExpectedBucketValue = 2434,
+                         },
+                         new BucketerTestItem
+                         {
+                             UserId = "ppid3", ExperimentId = "1886780721",
+                             ExpectedBucketValue = 5439,
+                         },
+                         new BucketerTestItem
+                         {
+                             UserId =
+                                 "a very very very very very very very very very very very very very very very long ppd string",
+                             ExperimentId = "1886780721", ExpectedBucketValue = 6128,
+                         },
+                     })
             {
-                new BucketerTestItem { UserId = "ppid1", ExperimentId = "1886780721", ExpectedBucketValue = 5254 },
-                new BucketerTestItem { UserId = "ppid2", ExperimentId = "1886780721", ExpectedBucketValue = 4299 },
-                new BucketerTestItem { UserId = "ppid2", ExperimentId = "1886780722", ExpectedBucketValue = 2434 },
-                new BucketerTestItem { UserId = "ppid3", ExperimentId = "1886780721", ExpectedBucketValue = 5439 },
-                new BucketerTestItem { UserId = "a very very very very very very very very very very very very very very very long ppd string",
-                    ExperimentId = "1886780721", ExpectedBucketValue = 6128 },
-            })
-            {
-                int result = bucketer.GenerateBucketValue(item.BucketingId);
-                Assert.AreEqual(item.ExpectedBucketValue, result, 
+                var result = bucketer.GenerateBucketValue(item.BucketingId);
+                Assert.AreEqual(item.ExpectedBucketValue, result,
                     string.Format("Unexpected Bucket Value: [{0}] for [{1}]", result, item));
             }
         }
@@ -96,90 +121,126 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestBucketValidExperimentNotInGroup()
         {
-            TestBucketer bucketer = new TestBucketer(LoggerMock.Object);
+            var bucketer = new TestBucketer(LoggerMock.Object);
             bucketer.SetBucketValues(new[] { 3000, 7000, 9000 });
-            var variation = bucketer.Bucket(Config, Config.GetExperimentFromKey("test_experiment"), TestBucketingIdControl, TestUserId);
+            var variation = bucketer.Bucket(Config, Config.GetExperimentFromKey("test_experiment"),
+                TestBucketingIdControl, TestUserId);
             // control
             Assert.AreEqual(new Variation { Id = "7722370027", Key = "control" },
                 variation.ResultObject);
 
-            LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(2));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [3000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [testUserId] is in variation [control] of experiment [test_experiment]."));
-            Assert.AreEqual(variation.DecisionReasons.ToReport(true)[0], "User [testUserId] is in variation [control] of experiment [test_experiment].");
+            LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()),
+                Times.Exactly(2));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                "Assigned bucket [3000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "User [testUserId] is in variation [control] of experiment [test_experiment]."));
+            Assert.AreEqual(variation.DecisionReasons.ToReport(true)[0],
+                "User [testUserId] is in variation [control] of experiment [test_experiment].");
 
             // variation
-            variation = bucketer.Bucket(Config, Config.GetExperimentFromKey("test_experiment"), TestBucketingIdControl, TestUserId);
+            variation = bucketer.Bucket(Config, Config.GetExperimentFromKey("test_experiment"),
+                TestBucketingIdControl, TestUserId);
             Assert.AreEqual(new Variation { Id = "7721010009", Key = "variation" },
                 variation.ResultObject);
 
-            LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(4));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [7000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [testUserId] is in variation [variation] of experiment [test_experiment]."));
-            Assert.AreEqual(variation.DecisionReasons.ToReport(true)[0], "User [testUserId] is in variation [variation] of experiment [test_experiment].");
+            LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()),
+                Times.Exactly(4));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                "Assigned bucket [7000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "User [testUserId] is in variation [variation] of experiment [test_experiment]."));
+            Assert.AreEqual(variation.DecisionReasons.ToReport(true)[0],
+                "User [testUserId] is in variation [variation] of experiment [test_experiment].");
 
             // no variation
-            variation = bucketer.Bucket(Config, Config.GetExperimentFromKey("test_experiment"), TestBucketingIdControl, TestUserId);
+            variation = bucketer.Bucket(Config, Config.GetExperimentFromKey("test_experiment"),
+                TestBucketingIdControl, TestUserId);
             Assert.AreEqual(new Variation { },
-               variation.ResultObject);
+                variation.ResultObject);
 
-            LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(6));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [9000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
+            LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()),
+                Times.Exactly(6));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                "Assigned bucket [9000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
             LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [testUserId] is in no variation."));
             Assert.AreEqual(variation.DecisionReasons.ToReport(true).Count, 1);
-            Assert.AreEqual(variation.DecisionReasons.ToReport(true)[0], "User [testUserId] is in no variation.");
+            Assert.AreEqual(variation.DecisionReasons.ToReport(true)[0],
+                "User [testUserId] is in no variation.");
         }
 
         [Test]
         public void TestBucketValidExperimentInGroup()
         {
-            TestBucketer bucketer = new TestBucketer(LoggerMock.Object);
-            
+            var bucketer = new TestBucketer(LoggerMock.Object);
+
             // group_experiment_1 (20% experiment)
             // variation 1
             bucketer.SetBucketValues(new[] { 1000, 4000 });
-            var variation = bucketer.Bucket(Config, Config.GetExperimentFromKey("group_experiment_1"), TestBucketingIdControl, TestUserId);
+            var variation = bucketer.Bucket(Config,
+                Config.GetExperimentFromKey("group_experiment_1"), TestBucketingIdControl,
+                TestUserId);
             Assert.AreEqual(new Variation { Id = "7722260071", Key = "group_exp_1_var_1" },
                 variation.ResultObject);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [1000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [testUserId] is in experiment [group_experiment_1] of group [7722400015]."));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [4000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [testUserId] is in variation [group_exp_1_var_1] of experiment [group_experiment_1]."));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                "Assigned bucket [1000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "User [testUserId] is in experiment [group_experiment_1] of group [7722400015]."));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                "Assigned bucket [4000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "User [testUserId] is in variation [group_exp_1_var_1] of experiment [group_experiment_1]."));
             Assert.AreEqual(variation.DecisionReasons.ToReport(true).Count, 2);
-            Assert.AreEqual(variation.DecisionReasons.ToReport(true)[0], "User [testUserId] is in experiment [group_experiment_1] of group [7722400015].");
-            Assert.AreEqual(variation.DecisionReasons.ToReport(true)[1], "User [testUserId] is in variation [group_exp_1_var_1] of experiment [group_experiment_1].");
+            Assert.AreEqual(variation.DecisionReasons.ToReport(true)[0],
+                "User [testUserId] is in experiment [group_experiment_1] of group [7722400015].");
+            Assert.AreEqual(variation.DecisionReasons.ToReport(true)[1],
+                "User [testUserId] is in variation [group_exp_1_var_1] of experiment [group_experiment_1].");
 
             // variation 2
             bucketer.SetBucketValues(new[] { 1500, 7000 });
-            var variation1 = bucketer.Bucket(Config, Config.GetExperimentFromKey("group_experiment_1"), TestBucketingIdControl, TestUserId);
+            var variation1 = bucketer.Bucket(Config,
+                Config.GetExperimentFromKey("group_experiment_1"), TestBucketingIdControl,
+                TestUserId);
             Assert.AreEqual(new Variation { Id = "7722360022", Key = "group_exp_1_var_2" },
                 variation1.ResultObject);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [1500] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [testUserId] is in experiment [group_experiment_1] of group [7722400015]."));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [7000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [testUserId] is in variation [group_exp_1_var_1] of experiment [group_experiment_1]."));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                "Assigned bucket [1500] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "User [testUserId] is in experiment [group_experiment_1] of group [7722400015]."));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                "Assigned bucket [7000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "User [testUserId] is in variation [group_exp_1_var_1] of experiment [group_experiment_1]."));
             Assert.AreEqual(variation1.DecisionReasons.ToReport(true).Count, 2);
-            Assert.AreEqual(variation1.DecisionReasons.ToReport(true)[0], "User [testUserId] is in experiment [group_experiment_1] of group [7722400015].");
-            Assert.AreEqual(variation1.DecisionReasons.ToReport(true)[1], "User [testUserId] is in variation [group_exp_1_var_2] of experiment [group_experiment_1].");
+            Assert.AreEqual(variation1.DecisionReasons.ToReport(true)[0],
+                "User [testUserId] is in experiment [group_experiment_1] of group [7722400015].");
+            Assert.AreEqual(variation1.DecisionReasons.ToReport(true)[1],
+                "User [testUserId] is in variation [group_exp_1_var_2] of experiment [group_experiment_1].");
 
             // User not in experiment
             bucketer.SetBucketValues(new[] { 5000, 7000 });
-            var variation2 = bucketer.Bucket(Config, Config.GetExperimentFromKey("group_experiment_1"), TestBucketingIdControl, TestUserId);
+            var variation2 = bucketer.Bucket(Config,
+                Config.GetExperimentFromKey("group_experiment_1"), TestBucketingIdControl,
+                TestUserId);
             Assert.AreEqual(new Variation { },
                 variation2.ResultObject);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Assigned bucket [5000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "User [testUserId] is not in experiment [group_experiment_1] of group [7722400015]."));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                "Assigned bucket [5000] to user [testUserId] with bucketing ID [testBucketingIdControl!]."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "User [testUserId] is not in experiment [group_experiment_1] of group [7722400015]."));
             Assert.AreEqual(variation2.DecisionReasons.ToReport(true).Count, 1);
-            Assert.AreEqual(variation2.DecisionReasons.ToReport(true)[0], "User [testUserId] is not in experiment [group_experiment_1] of group [7722400015].");
+            Assert.AreEqual(variation2.DecisionReasons.ToReport(true)[0],
+                "User [testUserId] is not in experiment [group_experiment_1] of group [7722400015].");
         }
 
         [Test]
         public void TestBucketInvalidExperiment()
         {
             var bucketer = new Bucketer(LoggerMock.Object);
-            
+
             Assert.AreEqual(new Variation { },
-                bucketer.Bucket(Config, new Experiment(), TestBucketingIdControl, TestUserId).ResultObject);
+                bucketer.Bucket(Config, new Experiment(), TestBucketingIdControl, TestUserId).
+                    ResultObject);
 
             LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Never);
         }
@@ -193,15 +254,18 @@ namespace OptimizelySDK.Tests
             var expectedVariation2 = new Variation { Id = "7721010009", Key = "variation" };
 
             // make sure that the bucketing ID is used for the variation bucketing and not the user ID
-            var variationResult = bucketer.Bucket(Config, experiment, TestBucketingIdControl, TestUserIdBucketsToVariation);
+            var variationResult = bucketer.Bucket(Config, experiment, TestBucketingIdControl,
+                TestUserIdBucketsToVariation);
             Assert.AreEqual(expectedVariation,
                 variationResult.ResultObject);
             Assert.AreEqual(variationResult.DecisionReasons.ToReport().Count, 0);
-            variationResult = bucketer.Bucket(Config, experiment, TestBucketingIdControl, TestUserIdBucketsToVariation);
+            variationResult = bucketer.Bucket(Config, experiment, TestBucketingIdControl,
+                TestUserIdBucketsToVariation);
             Assert.AreEqual(expectedVariation,
                 variationResult.ResultObject);
             Assert.AreEqual(variationResult.DecisionReasons.ToReport(true).Count, 1);
-            Assert.AreEqual(variationResult.DecisionReasons.ToReport(true)[0], "User [bucketsToVariation!] is in variation [control] of experiment [test_experiment].");
+            Assert.AreEqual(variationResult.DecisionReasons.ToReport(true)[0],
+                "User [bucketsToVariation!] is in variation [control] of experiment [test_experiment].");
         }
 
         // Test for invalid experiment keys, null variation should be returned
@@ -210,8 +274,10 @@ namespace OptimizelySDK.Tests
         {
             var bucketer = new Bucketer(LoggerMock.Object);
             var expectedVariation = new Variation();
-            var variationResult = bucketer.Bucket(Config, Config.GetExperimentFromKey("invalid_experiment"), TestBucketingIdVariation, TestUserId);
-            Assert.AreEqual(expectedVariation, 
+            var variationResult = bucketer.Bucket(Config,
+                Config.GetExperimentFromKey("invalid_experiment"), TestBucketingIdVariation,
+                TestUserId);
+            Assert.AreEqual(expectedVariation,
                 variationResult.ResultObject);
             Assert.AreEqual(variationResult.DecisionReasons.ToReport().Count, 0);
         }
@@ -222,18 +288,22 @@ namespace OptimizelySDK.Tests
         {
             var bucketer = new Bucketer(LoggerMock.Object);
             var expectedVariation = new Variation();
-            var expectedGroupVariation = new Variation{ Id = "7725250007", Key = "group_exp_2_var_2" };
-            var variationResult = bucketer.Bucket(Config, Config.GetExperimentFromKey("group_experiment_2"),
+            var expectedGroupVariation = new Variation
+                { Id = "7725250007", Key = "group_exp_2_var_2" };
+            var variationResult = bucketer.Bucket(Config,
+                Config.GetExperimentFromKey("group_experiment_2"),
                 TestBucketingIdGroupExp2Var2, TestUserIdBucketsToNoGroup);
             Assert.AreEqual(expectedGroupVariation,
                 variationResult.ResultObject);
             Assert.AreEqual(variationResult.DecisionReasons.ToReport().Count, 0);
-                bucketer.Bucket(Config, Config.GetExperimentFromKey("group_experiment_2"), 
+            bucketer.Bucket(Config, Config.GetExperimentFromKey("group_experiment_2"),
                 TestBucketingIdGroupExp2Var2, TestUserIdBucketsToNoGroup);
             var report = variationResult.DecisionReasons.ToReport(true);
             Assert.AreEqual(report.Count, 2);
-            Assert.AreEqual(report[0], "User [testUserId] is in experiment [group_experiment_2] of group [7722400015].");
-            Assert.AreEqual(report[1], "User [testUserId] is in variation [group_exp_2_var_2] of experiment [group_experiment_2].");
+            Assert.AreEqual(report[0],
+                "User [testUserId] is in experiment [group_experiment_2] of group [7722400015].");
+            Assert.AreEqual(report[1],
+                "User [testUserId] is in variation [group_exp_2_var_2] of experiment [group_experiment_2].");
         }
 
         // Make sure that user gets bucketed into the rollout rule.
@@ -244,16 +314,19 @@ namespace OptimizelySDK.Tests
             var rollout = Config.GetRolloutFromId("166660");
             var rolloutRule = rollout.Experiments[1];
             var expectedVariation = Config.GetVariationFromId(rolloutRule.Key, "177773");
-            
-            var variationResult = bucketer.Bucket(Config, rolloutRule, "testBucketingId", TestUserId);
+
+            var variationResult =
+                bucketer.Bucket(Config, rolloutRule, "testBucketingId", TestUserId);
             Assert.True(TestData.CompareObjects(expectedVariation,
                 variationResult.ResultObject));
             Assert.AreEqual(variationResult.DecisionReasons.ToReport().Count, 0);
-            var variationsResult = bucketer.Bucket(Config, rolloutRule, "testBucketingId", TestUserId);
+            var variationsResult =
+                bucketer.Bucket(Config, rolloutRule, "testBucketingId", TestUserId);
             Assert.True(TestData.CompareObjects(expectedVariation,
                 variationsResult.ResultObject));
             Assert.AreEqual(variationsResult.DecisionReasons.ToReport(true).Count, 1);
-            Assert.AreEqual(variationsResult.DecisionReasons.ToReport(true)[0], "User [testUserId] is in variation [177773] of experiment [177772].");
+            Assert.AreEqual(variationsResult.DecisionReasons.ToReport(true)[0],
+                "User [testUserId] is in variation [177773] of experiment [177772].");
         }
     }
 }

--- a/OptimizelySDK.Tests/BucketerTest.cs
+++ b/OptimizelySDK.Tests/BucketerTest.cs
@@ -289,7 +289,7 @@ namespace OptimizelySDK.Tests
             var bucketer = new Bucketer(LoggerMock.Object);
             var expectedVariation = new Variation();
             var expectedGroupVariation = new Variation
-                { Id = "7725250007", Key = "group_exp_2_var_2" };
+            { Id = "7725250007", Key = "group_exp_2_var_2" };
             var variationResult = bucketer.Bucket(Config,
                 Config.GetExperimentFromKey("group_experiment_2"),
                 TestBucketingIdGroupExp2Var2, TestUserIdBucketsToNoGroup);

--- a/OptimizelySDK.Tests/ClientConfigHandlerTest.cs
+++ b/OptimizelySDK.Tests/ClientConfigHandlerTest.cs
@@ -16,8 +16,8 @@
 
 #if !NETSTANDARD1_6 && !NET35
 
-using NUnit.Framework;
 using System.Configuration;
+using NUnit.Framework;
 
 namespace OptimizelySDK.Tests
 {

--- a/OptimizelySDK.Tests/ClientConfigHandlerTest.cs
+++ b/OptimizelySDK.Tests/ClientConfigHandlerTest.cs
@@ -24,11 +24,12 @@ namespace OptimizelySDK.Tests
     [TestFixture]
     public class ClientConfigHandlerTest
     {
-
         [Test]
         public void TestHTTPAppConfigSection()
         {
-            var configSection = ConfigurationManager.GetSection("optlySDKConfigSection") as OptimizelySDKConfigSection;
+            var configSection =
+                ConfigurationManager.GetSection("optlySDKConfigSection") as
+                    OptimizelySDKConfigSection;
             var httpSetting = configSection.HttpProjectConfig;
             Assert.IsNotNull(httpSetting);
             Assert.IsTrue(httpSetting.AutoUpdate);
@@ -44,7 +45,9 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestBatchEventAppConfigSection()
         {
-            var configSection = ConfigurationManager.GetSection("optlySDKConfigSection") as OptimizelySDKConfigSection;
+            var configSection =
+                ConfigurationManager.GetSection("optlySDKConfigSection") as
+                    OptimizelySDKConfigSection;
             var batchSetting = configSection.BatchEventProcessor;
             Assert.IsNotNull(batchSetting);
             Assert.AreEqual(batchSetting.BatchSize, 10);
@@ -52,7 +55,6 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(batchSetting.TimeoutInterval, 10000);
             Assert.IsTrue(batchSetting.DefaultStart);
         }
-
     }
 }
 #endif

--- a/OptimizelySDK.Tests/ConfigTest/FallbackProjectConfigManagerTest.cs
+++ b/OptimizelySDK.Tests/ConfigTest/FallbackProjectConfigManagerTest.cs
@@ -27,7 +27,8 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         [Test]
         public void TestStaticProjectConfigManagerReturnsCorrectProjectConfig()
         {
-            var expectedConfig = DatafileProjectConfig.Create(TestData.TypedAudienceDatafile, null, null);
+            var expectedConfig =
+                DatafileProjectConfig.Create(TestData.TypedAudienceDatafile, null, null);
             ConfigManager = new FallbackProjectConfigManager(expectedConfig);
 
             Assert.True(TestData.CompareObjects(expectedConfig, ConfigManager.GetConfig()));

--- a/OptimizelySDK.Tests/ConfigTest/HttpProjectConfigManagerTest.cs
+++ b/OptimizelySDK.Tests/ConfigTest/HttpProjectConfigManagerTest.cs
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-using Moq;
-using NUnit.Framework;
-using OptimizelySDK.Config;
-using OptimizelySDK.Logger;
-using OptimizelySDK.Tests.NotificationTests;
-using OptimizelySDK.Tests.Utils;
 using System;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using OptimizelySDK.Config;
+using OptimizelySDK.Logger;
+using OptimizelySDK.Tests.NotificationTests;
+using OptimizelySDK.Tests.Utils;
 
 namespace OptimizelySDK.Tests.DatafileManagement_Tests
 {

--- a/OptimizelySDK.Tests/ConfigTest/HttpProjectConfigManagerTest.cs
+++ b/OptimizelySDK.Tests/ConfigTest/HttpProjectConfigManagerTest.cs
@@ -34,7 +34,9 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
     {
         private Mock<ILogger> LoggerMock;
         private Mock<HttpProjectConfigManager.HttpClient> HttpClientMock;
-        private Mock<TestNotificationCallbacks> NotificationCallbackMock = new Mock<TestNotificationCallbacks>();
+
+        private Mock<TestNotificationCallbacks> NotificationCallbackMock =
+            new Mock<TestNotificationCallbacks>();
 
         [SetUp]
         public void Setup()
@@ -45,28 +47,28 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             TestHttpProjectConfigManagerUtil.SetClientFieldValue(HttpClientMock.Object);
             LoggerMock.Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()));
             NotificationCallbackMock.Setup(nc => nc.TestConfigUpdateCallback());
-
         }
 
         [Test]
         public void TestHttpConfigManagerRetreiveProjectConfigByURL()
         {
             var t = MockSendAsync(TestData.Datafile);
-            HttpProjectConfigManager httpManager = new HttpProjectConfigManager.Builder()
-                .WithUrl("https://cdn.optimizely.com/datafiles/QBw9gFM8oTn7ogY9ANCC1z.json")
-                .WithLogger(LoggerMock.Object)
-                .WithPollingInterval(TimeSpan.FromMilliseconds(1000))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500))
-                .WithStartByDefault()
-                .Build();
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithUrl("https://cdn.optimizely.com/datafiles/QBw9gFM8oTn7ogY9ANCC1z.json").
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromMilliseconds(1000)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500)).
+                WithStartByDefault().
+                Build();
 
             // This method waits until SendAsync is not triggered.
             // Time is given here to avoid hanging-up in any worst case.
             t.Wait(1000);
 
             HttpClientMock.Verify(_ => _.SendAsync(
-                It.Is<System.Net.Http.HttpRequestMessage>(requestMessage =>
-                requestMessage.RequestUri.ToString() == "https://cdn.optimizely.com/datafiles/QBw9gFM8oTn7ogY9ANCC1z.json"
+                It.Is<HttpRequestMessage>(requestMessage =>
+                    requestMessage.RequestUri.ToString() ==
+                    "https://cdn.optimizely.com/datafiles/QBw9gFM8oTn7ogY9ANCC1z.json"
                 )));
             httpManager.Dispose();
         }
@@ -76,15 +78,17 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         {
             var t = MockSendAsync(statusCode: HttpStatusCode.Forbidden);
 
-            HttpProjectConfigManager httpManager = new HttpProjectConfigManager.Builder()
-                .WithUrl("https://cdn.optimizely.com/datafiles/QBw9gFM8oTn7ogY9ANCC1z.json")
-                .WithLogger(LoggerMock.Object)
-                .WithPollingInterval(TimeSpan.FromMilliseconds(1000))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500))
-                .WithStartByDefault()
-                .Build();
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithUrl("https://cdn.optimizely.com/datafiles/QBw9gFM8oTn7ogY9ANCC1z.json").
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromMilliseconds(1000)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500)).
+                WithStartByDefault().
+                Build();
 
-            LoggerMock.Verify(_ => _.Log(LogLevel.ERROR, $"Error fetching datafile \"{HttpStatusCode.Forbidden}\""), Times.AtLeastOnce);
+            LoggerMock.Verify(
+                _ => _.Log(LogLevel.ERROR,
+                    $"Error fetching datafile \"{HttpStatusCode.Forbidden}\""), Times.AtLeastOnce);
 
             httpManager.Dispose();
         }
@@ -93,7 +97,8 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         public void TestHttpClientHandler()
         {
             var httpConfigHandler = HttpProjectConfigManager.HttpClient.GetHttpClientHandler();
-            Assert.IsTrue(httpConfigHandler.AutomaticDecompression == (System.Net.DecompressionMethods.Deflate | System.Net.DecompressionMethods.GZip));
+            Assert.IsTrue(httpConfigHandler.AutomaticDecompression ==
+                          (DecompressionMethods.Deflate | DecompressionMethods.GZip));
         }
 
         [Test]
@@ -101,21 +106,22 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         {
             var t = MockSendAsync(TestData.Datafile);
 
-            HttpProjectConfigManager httpManager = new HttpProjectConfigManager.Builder()
-                 .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                 .WithFormat("")
-                 .WithLogger(LoggerMock.Object)
-                 .WithPollingInterval(TimeSpan.FromMilliseconds(1000))
-                 .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500))
-                 .WithStartByDefault()
-                 .Build();
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithFormat("").
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromMilliseconds(1000)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500)).
+                WithStartByDefault().
+                Build();
 
             // This "Wait" notifies When SendAsync is triggered.
             // Time is given here to avoid hanging-up in any worst case.
             t.Wait(1000);
             HttpClientMock.Verify(_ => _.SendAsync(
-                It.Is<System.Net.Http.HttpRequestMessage>(requestMessage =>
-                requestMessage.RequestUri.ToString() == "https://cdn.optimizely.com/datafiles/QBw9gFM8oTn7ogY9ANCC1z.json"
+                It.Is<HttpRequestMessage>(requestMessage =>
+                    requestMessage.RequestUri.ToString() ==
+                    "https://cdn.optimizely.com/datafiles/QBw9gFM8oTn7ogY9ANCC1z.json"
                 )));
             httpManager.Dispose();
         }
@@ -125,18 +131,19 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         {
             var t = MockSendAsync(TestData.Datafile);
 
-            HttpProjectConfigManager httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithLogger(LoggerMock.Object)
-                .WithPollingInterval(TimeSpan.FromMilliseconds(1000))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500))
-                .WithStartByDefault()
-                .Build();
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromMilliseconds(1000)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500)).
+                WithStartByDefault().
+                Build();
 
             t.Wait(1000);
             HttpClientMock.Verify(_ => _.SendAsync(
-                It.Is<System.Net.Http.HttpRequestMessage>(requestMessage =>
-                requestMessage.RequestUri.ToString() == "https://cdn.optimizely.com/datafiles/QBw9gFM8oTn7ogY9ANCC1z.json"
+                It.Is<HttpRequestMessage>(requestMessage =>
+                    requestMessage.RequestUri.ToString() ==
+                    "https://cdn.optimizely.com/datafiles/QBw9gFM8oTn7ogY9ANCC1z.json"
                 )));
             Assert.IsNotNull(httpManager.GetConfig());
             httpManager.Dispose();
@@ -147,24 +154,25 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         {
             var t = MockSendAsync(TestData.Datafile);
 
-            HttpProjectConfigManager httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("10192104166")
-                .WithFormat("https://cdn.optimizely.com/json/{0}.json")
-                .WithLogger(LoggerMock.Object)
-                .WithPollingInterval(TimeSpan.FromMilliseconds(1000))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500))
-                .WithStartByDefault()
-                .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().WithSdkKey("10192104166").
+                WithFormat("https://cdn.optimizely.com/json/{0}.json").
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromMilliseconds(1000)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500)).
+                WithStartByDefault().
+                Build(true);
 
             t.Wait(1000);
             HttpClientMock.Verify(_ => _.SendAsync(
-                It.Is<System.Net.Http.HttpRequestMessage>(requestMessage =>
-                requestMessage.RequestUri.ToString() == "https://cdn.optimizely.com/json/10192104166.json"
+                It.Is<HttpRequestMessage>(requestMessage =>
+                    requestMessage.RequestUri.ToString() ==
+                    "https://cdn.optimizely.com/json/10192104166.json"
                 )));
-            
+
             Assert.IsNotNull(httpManager.GetConfig());
 
-            LoggerMock.Verify(_ => _.Log(LogLevel.DEBUG, "Making datafile request to url \"https://cdn.optimizely.com/json/10192104166.json\""));
+            LoggerMock.Verify(_ => _.Log(LogLevel.DEBUG,
+                "Making datafile request to url \"https://cdn.optimizely.com/json/10192104166.json\""));
             httpManager.Dispose();
         }
 
@@ -173,24 +181,25 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         {
             var t = MockSendAsync(TestData.Datafile);
 
-            HttpProjectConfigManager httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("10192104166")
-                .WithFormat("https://cdn.optimizely.com/json/{0}.json")
-                .WithLogger(LoggerMock.Object)
-                .WithPollingInterval(TimeSpan.FromMilliseconds(1000))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500))
-                .WithStartByDefault()
-                .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().WithSdkKey("10192104166").
+                WithFormat("https://cdn.optimizely.com/json/{0}.json").
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromMilliseconds(1000)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500)).
+                WithStartByDefault().
+                Build(true);
 
             t.Wait(1000);
             HttpClientMock.Verify(_ => _.SendAsync(
-                It.Is<System.Net.Http.HttpRequestMessage>(requestMessage =>
-                requestMessage.RequestUri.ToString() == "https://cdn.optimizely.com/json/10192104166.json"
+                It.Is<HttpRequestMessage>(requestMessage =>
+                    requestMessage.RequestUri.ToString() ==
+                    "https://cdn.optimizely.com/json/10192104166.json"
                 )));
             var datafileConfig = httpManager.GetConfig();
             Assert.IsNotNull(datafileConfig);
             Assert.IsNull(datafileConfig.GetExperimentFromKey("project_config_not_valid").Key);
-            LoggerMock.Verify(_ => _.Log(LogLevel.DEBUG, "Making datafile request to url \"https://cdn.optimizely.com/json/10192104166.json\""));
+            LoggerMock.Verify(_ => _.Log(LogLevel.DEBUG,
+                "Making datafile request to url \"https://cdn.optimizely.com/json/10192104166.json\""));
             httpManager.Dispose();
         }
 
@@ -198,17 +207,18 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         public void TestOnReadyPromiseResolvedImmediatelyWhenDatafileIsProvided()
         {
             // Revision - 42
-            var t = MockSendAsync(TestData.SimpleABExperimentsDatafile, TimeSpan.FromMilliseconds(100));
+            var t = MockSendAsync(TestData.SimpleABExperimentsDatafile,
+                TimeSpan.FromMilliseconds(100));
 
-            HttpProjectConfigManager httpManager = new HttpProjectConfigManager.Builder()
+            var httpManager = new HttpProjectConfigManager.Builder()
                 // Revision - 15
-                .WithSdkKey("10192104166")
-                .WithDatafile(TestData.Datafile)
-                .WithLogger(LoggerMock.Object)
-                .WithPollingInterval(TimeSpan.FromMilliseconds(1000))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500))
-                .WithStartByDefault()
-                .Build();
+                .WithSdkKey("10192104166").
+                WithDatafile(TestData.Datafile).
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromMilliseconds(1000)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500)).
+                WithStartByDefault().
+                Build();
 
             // OnReady waits until is resolved, need to add time in case of deadlock.
             httpManager.OnReady().Wait(10000);
@@ -227,15 +237,16 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         public void TestOnReadyPromiseWaitsForProjectConfigRetrievalWhenDatafileIsNotProvided()
         {
             // Revision - 42
-            var t = MockSendAsync(TestData.SimpleABExperimentsDatafile, TimeSpan.FromMilliseconds(1000));
+            var t = MockSendAsync(TestData.SimpleABExperimentsDatafile,
+                TimeSpan.FromMilliseconds(1000));
 
-            HttpProjectConfigManager httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithLogger(LoggerMock.Object)
-                .WithPollingInterval(TimeSpan.FromSeconds(2))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromSeconds(1))
-                .WithStartByDefault(true)
-                .Build();
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromSeconds(2)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromSeconds(1)).
+                WithStartByDefault(true).
+                Build();
             t.Wait();
 
             // OnReady waits until is resolved, need to add time in case of deadlock.
@@ -249,14 +260,15 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         {
             var t = MockSendAsync(TestData.Datafile, TimeSpan.FromMilliseconds(150));
 
-            var httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithLogger(LoggerMock.Object)
-                .WithPollingInterval(TimeSpan.FromSeconds(2))
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromSeconds(2))
                 // negligible timeout
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(50))
-                .WithStartByDefault()
-                .Build(false);
+                .
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(50)).
+                WithStartByDefault().
+                Build(false);
 
             // When blocking timeout is 0 and defer is false and getconfig immediately called
             // should return null
@@ -265,7 +277,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             t.Wait();
             // in case deadlock, it will release after 3sec.
             httpManager.OnReady().Wait(8000);
-                
+
             HttpClientMock.Verify(_ => _.SendAsync(It.IsAny<HttpRequestMessage>()));
             Assert.NotNull(httpManager.GetConfig());
 
@@ -273,20 +285,22 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         }
 
         #region Notification
+
         [Test]
         public void TestHttpConfigManagerSendConfigUpdateNotificationWhenProjectConfigGetsUpdated()
-        {            
+        {
             var t = MockSendAsync(TestData.Datafile);
 
-            var httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithLogger(LoggerMock.Object)
-                .WithPollingInterval(TimeSpan.FromMilliseconds(1000))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(1000))
-                .WithStartByDefault(false)
-                .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromMilliseconds(1000)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(1000)).
+                WithStartByDefault(false).
+                Build(true);
 
-            httpManager.NotifyOnProjectConfigUpdate += NotificationCallbackMock.Object.TestConfigUpdateCallback;
+            httpManager.NotifyOnProjectConfigUpdate +=
+                NotificationCallbackMock.Object.TestConfigUpdateCallback;
             httpManager.Start();
 
             Assert.NotNull(httpManager.GetConfig());
@@ -297,130 +311,148 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
 
         [Test]
         public void TestHttpConfigManagerDoesNotSendConfigUpdateNotificationWhenDatafileIsProvided()
-        {            
+        {
             var t = MockSendAsync(TestData.Datafile, TimeSpan.FromMilliseconds(100));
 
-            var httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithDatafile(TestData.Datafile)
-                .WithLogger(LoggerMock.Object)
-                .WithPollingInterval(TimeSpan.FromMilliseconds(1000))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500))
-                .Build();
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithDatafile(TestData.Datafile).
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromMilliseconds(1000)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500)).
+                Build();
 
 
-            httpManager.NotifyOnProjectConfigUpdate += NotificationCallbackMock.Object.TestConfigUpdateCallback;
+            httpManager.NotifyOnProjectConfigUpdate +=
+                NotificationCallbackMock.Object.TestConfigUpdateCallback;
 
             NotificationCallbackMock.Verify(nc => nc.TestConfigUpdateCallback(), Times.Never);
-            Assert.NotNull(httpManager.GetConfig()); Assert.NotNull(httpManager.GetConfig());
+            Assert.NotNull(httpManager.GetConfig());
+            Assert.NotNull(httpManager.GetConfig());
             httpManager.Dispose();
         }
 
         [Test]
         public void TestDefaultBlockingTimeoutWhileProvidingZero()
         {
-            var httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithDatafile(TestData.Datafile)
-                .WithLogger(LoggerMock.Object)
-                .WithPollingInterval(TimeSpan.FromMilliseconds(1000))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(0))
-                .WithStartByDefault(true)
-                .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithDatafile(TestData.Datafile).
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromMilliseconds(1000)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(0)).
+                WithStartByDefault(true).
+                Build(true);
 
-            var fieldInfo = httpManager.GetType().GetField("BlockingTimeout", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var fieldInfo = httpManager.GetType().
+                GetField("BlockingTimeout",
+                    System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.NonPublic);
             var expectedBlockingTimeout = (TimeSpan)fieldInfo.GetValue(httpManager);
             Assert.AreNotEqual(expectedBlockingTimeout.TotalSeconds, TimeSpan.Zero.TotalSeconds);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"Blocking timeout is not valid, using default blocking timeout {TimeSpan.FromSeconds(15).TotalMilliseconds}ms"));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                $"Blocking timeout is not valid, using default blocking timeout {TimeSpan.FromSeconds(15).TotalMilliseconds}ms"));
             httpManager.Dispose();
         }
 
         [Test]
         public void TestDefaultPeriodWhileProvidingZero()
         {
-            var httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithDatafile(TestData.Datafile)
-                .WithLogger(LoggerMock.Object)
-                .WithPollingInterval(TimeSpan.FromMilliseconds(0))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(1000))
-                .WithStartByDefault(true)
-                .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithDatafile(TestData.Datafile).
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromMilliseconds(0)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(1000)).
+                WithStartByDefault(true).
+                Build(true);
 
-            var fieldInfo = typeof(PollingProjectConfigManager).GetField("PollingInterval", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var fieldInfo = typeof(PollingProjectConfigManager).GetField("PollingInterval",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             var expectedPollingInterval = (TimeSpan)fieldInfo.GetValue(httpManager);
             Assert.AreNotEqual(expectedPollingInterval.TotalSeconds, TimeSpan.Zero.TotalSeconds);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"Polling interval is not valid for periodic calls, using default period {TimeSpan.FromMinutes(5).TotalMilliseconds}ms"));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                $"Polling interval is not valid for periodic calls, using default period {TimeSpan.FromMinutes(5).TotalMilliseconds}ms"));
             httpManager.Dispose();
         }
 
         [Test]
         public void TestDefaultPeriodWhileProvidingNegative()
         {
-            var httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithDatafile(TestData.Datafile)
-                .WithLogger(LoggerMock.Object)
-                .WithPollingInterval(TimeSpan.FromMilliseconds(-1))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(1000))
-                .WithStartByDefault(true)
-                .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithDatafile(TestData.Datafile).
+                WithLogger(LoggerMock.Object).
+                WithPollingInterval(TimeSpan.FromMilliseconds(-1)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(1000)).
+                WithStartByDefault(true).
+                Build(true);
 
-            var fieldInfo = typeof(PollingProjectConfigManager).GetField("PollingInterval", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var fieldInfo = typeof(PollingProjectConfigManager).GetField("PollingInterval",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             var expectedPollingInterval = (TimeSpan)fieldInfo.GetValue(httpManager);
             Assert.AreNotEqual(expectedPollingInterval.TotalSeconds, TimeSpan.Zero.TotalSeconds);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"Polling interval is not valid for periodic calls, using default period {TimeSpan.FromMinutes(5).TotalMilliseconds}ms"));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                $"Polling interval is not valid for periodic calls, using default period {TimeSpan.FromMinutes(5).TotalMilliseconds}ms"));
             httpManager.Dispose();
         }
 
         [Test]
         public void TestDefaultPeriodWhileNotProvidingValue()
         {
-            var httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithDatafile(TestData.Datafile)
-                .WithLogger(LoggerMock.Object)
-                .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithDatafile(TestData.Datafile).
+                WithLogger(LoggerMock.Object).
+                Build(true);
 
-            var fieldInfo = typeof(PollingProjectConfigManager).GetField("PollingInterval", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var fieldInfo = typeof(PollingProjectConfigManager).GetField("PollingInterval",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
             var expectedPollingInterval = (TimeSpan)fieldInfo.GetValue(httpManager);
             Assert.AreNotEqual(expectedPollingInterval.TotalSeconds, TimeSpan.Zero.TotalSeconds);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"No polling interval provided, using default period {TimeSpan.FromMinutes(5).TotalMilliseconds}ms"));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                $"No polling interval provided, using default period {TimeSpan.FromMinutes(5).TotalMilliseconds}ms"));
             httpManager.Dispose();
         }
 
         [Test]
         public void TestDefaultBlockingTimeoutWhileNotProvidingValue()
         {
-            var httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithDatafile(TestData.Datafile)
-                .WithLogger(LoggerMock.Object)
-                .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithDatafile(TestData.Datafile).
+                WithLogger(LoggerMock.Object).
+                Build(true);
 
-            var fieldInfo = httpManager.GetType().GetField("BlockingTimeout", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            var fieldInfo = httpManager.GetType().
+                GetField("BlockingTimeout",
+                    System.Reflection.BindingFlags.Instance |
+                    System.Reflection.BindingFlags.NonPublic);
             var expectedBlockingTimeout = (TimeSpan)fieldInfo.GetValue(httpManager);
             Assert.AreNotEqual(expectedBlockingTimeout.TotalSeconds, TimeSpan.Zero.TotalSeconds);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"No Blocking timeout provided, using default blocking timeout {TimeSpan.FromSeconds(15).TotalMilliseconds}ms"));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                $"No Blocking timeout provided, using default blocking timeout {TimeSpan.FromSeconds(15).TotalMilliseconds}ms"));
             httpManager.Dispose();
         }
 
         [Test]
         public void TestDefaultValuesWhenNotProvided()
         {
-            var httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithDatafile(TestData.Datafile)
-                .WithLogger(LoggerMock.Object)
-                .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithDatafile(TestData.Datafile).
+                WithLogger(LoggerMock.Object).
+                Build(true);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"No polling interval provided, using default period {TimeSpan.FromMinutes(5).TotalMilliseconds}ms"));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"No Blocking timeout provided, using default blocking timeout {TimeSpan.FromSeconds(15).TotalMilliseconds}ms"));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                $"No polling interval provided, using default period {TimeSpan.FromMinutes(5).TotalMilliseconds}ms"));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                $"No Blocking timeout provided, using default blocking timeout {TimeSpan.FromSeconds(15).TotalMilliseconds}ms"));
             httpManager.Dispose();
         }
 
@@ -429,19 +461,20 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         {
             var t = MockSendAsync();
 
-            var httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithLogger(LoggerMock.Object)
-                .WithAccessToken("datafile1")
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(50))
-                .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithLogger(LoggerMock.Object).
+                WithAccessToken("datafile1").
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(50)).
+                Build(true);
 
             // it's to wait if SendAsync is not triggered.
             t.Wait(2000);
 
             HttpClientMock.Verify(_ => _.SendAsync(
-                It.Is<System.Net.Http.HttpRequestMessage>(requestMessage =>
-                requestMessage.RequestUri.ToString() == "https://config.optimizely.com/datafiles/auth/QBw9gFM8oTn7ogY9ANCC1z.json"
+                It.Is<HttpRequestMessage>(requestMessage =>
+                    requestMessage.RequestUri.ToString() ==
+                    "https://config.optimizely.com/datafiles/auth/QBw9gFM8oTn7ogY9ANCC1z.json"
                 )));
             httpManager.Dispose();
         }
@@ -451,17 +484,18 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         {
             var t = MockSendAsync();
 
-            var httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithLogger(LoggerMock.Object)
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(50))
-                .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithLogger(LoggerMock.Object).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(50)).
+                Build(true);
 
             // it's to wait if SendAsync is not triggered.
             t.Wait(2000);
             HttpClientMock.Verify(_ => _.SendAsync(
-                It.Is<System.Net.Http.HttpRequestMessage>(requestMessage =>
-                requestMessage.RequestUri.ToString() == "https://cdn.optimizely.com/datafiles/QBw9gFM8oTn7ogY9ANCC1z.json"
+                It.Is<HttpRequestMessage>(requestMessage =>
+                    requestMessage.RequestUri.ToString() ==
+                    "https://cdn.optimizely.com/datafiles/QBw9gFM8oTn7ogY9ANCC1z.json"
                 )));
             httpManager.Dispose();
         }
@@ -471,19 +505,19 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         {
             var t = MockSendAsync();
 
-            var httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithLogger(LoggerMock.Object)
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(50))
-                .WithAccessToken("datafile1")
-                .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithLogger(LoggerMock.Object).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(50)).
+                WithAccessToken("datafile1").
+                Build(true);
 
             // it's to wait if SendAsync is not triggered.
             t.Wait(2000);
 
             HttpClientMock.Verify(_ => _.SendAsync(
-                It.Is<System.Net.Http.HttpRequestMessage>(requestMessage =>
-                requestMessage.Headers.Authorization.ToString() == "Bearer datafile1"
+                It.Is<HttpRequestMessage>(requestMessage =>
+                    requestMessage.Headers.Authorization.ToString() == "Bearer datafile1"
                 )));
             httpManager.Dispose();
         }
@@ -492,27 +526,31 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         public void TestFormatUrlHigherPriorityThanDefaultUrl()
         {
             var t = MockSendAsync();
-            var httpManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                .WithLogger(LoggerMock.Object)
-                .WithFormat("http://customformat/{0}.json")
-                .WithAccessToken("datafile1")
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(50))
-                .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithLogger(LoggerMock.Object).
+                WithFormat("http://customformat/{0}.json").
+                WithAccessToken("datafile1").
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(50)).
+                Build(true);
             // it's to wait if SendAsync is not triggered.
             t.Wait(2000);
             HttpClientMock.Verify(_ => _.SendAsync(
-                It.Is<System.Net.Http.HttpRequestMessage>(requestMessage =>
-                requestMessage.RequestUri.ToString() == "http://customformat/QBw9gFM8oTn7ogY9ANCC1z.json"
+                It.Is<HttpRequestMessage>(requestMessage =>
+                    requestMessage.RequestUri.ToString() ==
+                    "http://customformat/QBw9gFM8oTn7ogY9ANCC1z.json"
                 )));
             httpManager.Dispose();
-
         }
 
-        public Task MockSendAsync(string datafile = null, TimeSpan? delay = null, HttpStatusCode statusCode = HttpStatusCode.OK)
+        public Task MockSendAsync(string datafile = null, TimeSpan? delay = null,
+            HttpStatusCode statusCode = HttpStatusCode.OK
+        )
         {
-            return TestHttpProjectConfigManagerUtil.MockSendAsync(HttpClientMock, datafile, delay, statusCode);
+            return TestHttpProjectConfigManagerUtil.MockSendAsync(HttpClientMock, datafile, delay,
+                statusCode);
         }
+
         #endregion
     }
 }

--- a/OptimizelySDK.Tests/ConfigTest/PollingProjectConfigManagerTest.cs
+++ b/OptimizelySDK.Tests/ConfigTest/PollingProjectConfigManagerTest.cs
@@ -85,7 +85,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             var configManager = new TestPollingProjectConfigManager(TimeSpan.FromSeconds(1),
                 TimeSpan.FromMilliseconds(1500), true, LoggerMock.Object, new int[]
                 {
-                    1200, 500, 500
+                    1200, 500, 500,
                 });
 
             configManager.Start();
@@ -110,7 +110,7 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             var configManager = new TestPollingProjectConfigManager(TimeSpan.FromSeconds(3),
                 TimeSpan.FromMilliseconds(1000), true, LoggerMock.Object, new int[]
                 {
-                    1300, 500, 500
+                    1300, 500, 500,
                 });
 
             configManager.Start();
@@ -128,9 +128,9 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             var configManager = new TestPollingProjectConfigManager(TimeSpan.FromSeconds(3),
                 TimeSpan.FromMilliseconds(1000), true, LoggerMock.Object, new int[]
                 {
-                    1300, 500, 500
+                    1300, 500, 500,
                 });
-            Stopwatch sw = new Stopwatch();
+            var sw = new Stopwatch();
             sw.Start();
             var config = configManager.GetConfig();
             sw.Stop();
@@ -146,9 +146,9 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             var configManager = new TestPollingProjectConfigManager(TimeSpan.FromSeconds(3),
                 TimeSpan.FromMilliseconds(1000), true, LoggerMock.Object, new int[]
                 {
-                    1300, 500, 500
+                    1300, 500, 500,
                 });
-            Stopwatch sw = new Stopwatch();
+            var sw = new Stopwatch();
             sw.Start();
             var config = configManager.GetConfig();
             sw.Stop();
@@ -167,14 +167,14 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
                 {
                     PollingTime = 500,
                     ChangeVersion = false,
-                    ConfigDatafile = projConfig
+                    ConfigDatafile = projConfig,
                 },
                 new TestPollingData
                 {
                     PollingTime = 500,
                     ChangeVersion = false,
-                    ConfigDatafile = projConfig
-                }
+                    ConfigDatafile = projConfig,
+                },
             };
 
             var configManager = new TestPollingProjectConfigManager(TimeSpan.FromSeconds(3),
@@ -204,20 +204,20 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
                 {
                     PollingTime = 50,
                     ChangeVersion = false,
-                    ConfigDatafile = null
+                    ConfigDatafile = null,
                 },
                 new TestPollingData
                 {
                     PollingTime = 50,
                     ChangeVersion = false,
-                    ConfigDatafile = null
+                    ConfigDatafile = null,
                 },
                 new TestPollingData
                 {
                     PollingTime = 50,
                     ChangeVersion = false,
-                    ConfigDatafile = projConfig
-                }
+                    ConfigDatafile = projConfig,
+                },
             };
 
 
@@ -241,20 +241,20 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
                 {
                     PollingTime = 50,
                     ChangeVersion = false,
-                    ConfigDatafile = null
+                    ConfigDatafile = null,
                 },
                 new TestPollingData
                 {
                     PollingTime = 50,
                     ChangeVersion = false,
-                    ConfigDatafile = null
+                    ConfigDatafile = null,
                 },
                 new TestPollingData
                 {
                     PollingTime = 50,
                     ChangeVersion = false,
-                    ConfigDatafile = null
-                }
+                    ConfigDatafile = null,
+                },
             };
 
             var configManager = new TestPollingProjectConfigManager(TimeSpan.FromMilliseconds(1000),

--- a/OptimizelySDK.Tests/ConfigTest/PollingProjectConfigManagerTest.cs
+++ b/OptimizelySDK.Tests/ConfigTest/PollingProjectConfigManagerTest.cs
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.Config;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Tests.DatafileManagementTests;
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace OptimizelySDK.Tests.DatafileManagement_Tests
 {

--- a/OptimizelySDK.Tests/ConfigTest/ProjectConfigProps.cs
+++ b/OptimizelySDK.Tests/ConfigTest/ProjectConfigProps.cs
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 using System;
 using OptimizelySDK.Config;
 using OptimizelySDK.Tests.Utils;
@@ -34,27 +35,37 @@ namespace OptimizelySDK.Tests.ConfigTest
 
         public ProjectConfigManagerProps(HttpProjectConfigManager projectConfigManager)
         {
-            LastModified = Reflection.GetFieldValue<string, HttpProjectConfigManager>(projectConfigManager, "LastModifiedSince");
-            Url = Reflection.GetFieldValue<string, HttpProjectConfigManager>(projectConfigManager, "Url");
-            DatafileAccessToken = Reflection.GetFieldValue<string, HttpProjectConfigManager>(projectConfigManager, "DatafileAccessToken");
+            LastModified =
+                Reflection.GetFieldValue<string, HttpProjectConfigManager>(projectConfigManager,
+                    "LastModifiedSince");
+            Url = Reflection.GetFieldValue<string, HttpProjectConfigManager>(projectConfigManager,
+                "Url");
+            DatafileAccessToken =
+                Reflection.GetFieldValue<string, HttpProjectConfigManager>(projectConfigManager,
+                    "DatafileAccessToken");
 
-            AutoUpdate = Reflection.GetPropertyValue<bool, HttpProjectConfigManager>(projectConfigManager, "AutoUpdate");
-            PollingInterval = Reflection.GetFieldValue<TimeSpan, HttpProjectConfigManager>(projectConfigManager, "PollingInterval");
-            BlockingTimeout = Reflection.GetFieldValue<TimeSpan, HttpProjectConfigManager>(projectConfigManager, "BlockingTimeout");
+            AutoUpdate =
+                Reflection.GetPropertyValue<bool, HttpProjectConfigManager>(projectConfigManager,
+                    "AutoUpdate");
+            PollingInterval =
+                Reflection.GetFieldValue<TimeSpan, HttpProjectConfigManager>(projectConfigManager,
+                    "PollingInterval");
+            BlockingTimeout =
+                Reflection.GetFieldValue<TimeSpan, HttpProjectConfigManager>(projectConfigManager,
+                    "BlockingTimeout");
         }
 
         /// <summary>
         /// To create default instance of expected values.
         /// </summary>
-        public ProjectConfigManagerProps()
-        {
-
-        }
+        public ProjectConfigManagerProps() { }
 
         public override bool Equals(object obj)
         {
             if (obj == null)
+            {
                 return false;
+            }
 
             var projectConfigManager = obj as ProjectConfigManagerProps;
             if (projectConfigManager == null)

--- a/OptimizelySDK.Tests/ConfigTest/TestPollingProjectConfigManager.cs
+++ b/OptimizelySDK.Tests/ConfigTest/TestPollingProjectConfigManager.cs
@@ -1,4 +1,4 @@
-/* 
+﻿/* 
  * Copyright 2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/OptimizelySDK.Tests/ConfigTest/TestPollingProjectConfigManager.cs
+++ b/OptimizelySDK.Tests/ConfigTest/TestPollingProjectConfigManager.cs
@@ -24,51 +24,70 @@ namespace OptimizelySDK.Tests.DatafileManagementTests
     {
         public int PollingTime { get; set; }
         public ProjectConfig ConfigDatafile { get; set; }
-        public ProjectConfig ConfigVersioned { 
-            get {
+
+        public ProjectConfig ConfigVersioned
+        {
+            get
+            {
                 if (ConfigDatafile == null)
+                {
                     return null;
+                }
+
                 if (ChangeVersion)
+                {
                     ConfigDatafile.Version = DateTime.Now.Ticks.ToString();
+                }
 
                 return ConfigDatafile;
             }
         }
+
         public bool ChangeVersion { get; set; }
     }
 
     public class TestPollingProjectConfigManager : PollingProjectConfigManager
     {
-        TestPollingData[] PollingData;
+        private TestPollingData[] PollingData;
         public int Counter = 0;
 
-        public TestPollingProjectConfigManager(TimeSpan period, TimeSpan blockingTimeout, bool autoUpdate, ILogger logger, int[] pollingSequence) 
+        public TestPollingProjectConfigManager(TimeSpan period, TimeSpan blockingTimeout,
+            bool autoUpdate, ILogger logger, int[] pollingSequence
+        )
             : base(period, blockingTimeout, autoUpdate, logger, null)
         {
-            if (pollingSequence != null) {
-                System.Collections.Generic.List<TestPollingData> pollingData = new System.Collections.Generic.List<TestPollingData>();
-                foreach (var pollingTime in pollingSequence) {
+            if (pollingSequence != null)
+            {
+                var pollingData = new System.Collections.Generic.List<TestPollingData>();
+                foreach (var pollingTime in pollingSequence)
+                {
                     pollingData.Add(new TestPollingData { PollingTime = pollingTime });
                 }
-                this.PollingData = pollingData.ToArray();
+
+                PollingData = pollingData.ToArray();
             }
         }
 
-        public TestPollingProjectConfigManager(TimeSpan period, TimeSpan blockingTimeout, bool autoUpdate, ILogger logger, TestPollingData[] pollingData, bool startByDefault = true) 
+        public TestPollingProjectConfigManager(TimeSpan period, TimeSpan blockingTimeout,
+            bool autoUpdate, ILogger logger, TestPollingData[] pollingData,
+            bool startByDefault = true
+        )
             : base(period, blockingTimeout, autoUpdate, logger, null)
         {
-            if (pollingData != null) {
-                this.PollingData = pollingData;
+            if (pollingData != null)
+            {
+                PollingData = pollingData;
             }
         }
 
 
         protected override ProjectConfig Poll()
         {
-            TimeSpan waitingTime = TimeSpan.FromMilliseconds(500);
+            var waitingTime = TimeSpan.FromMilliseconds(500);
             ProjectConfig response = null;
 
-            if (PollingData.Length > Counter) {
+            if (PollingData.Length > Counter)
+            {
                 waitingTime = TimeSpan.FromMilliseconds(PollingData[Counter].PollingTime);
                 // Will automatically change version if ChangeVersion is true.
                 response = PollingData[Counter].ConfigVersioned;

--- a/OptimizelySDK.Tests/DecisionServiceTest.cs
+++ b/OptimizelySDK.Tests/DecisionServiceTest.cs
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+using System.Collections.Generic;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.Bucketing;
@@ -24,7 +25,6 @@ using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
 using OptimizelySDK.OptimizelyDecisions;
 using OptimizelySDK.Utils;
-using System.Collections.Generic;
 
 namespace OptimizelySDK.Tests
 {
@@ -65,7 +65,8 @@ namespace OptimizelySDK.Tests
             DecisionService = new DecisionService(new Bucketer(LoggerMock.Object),
                 ErrorHandlerMock.Object, null, LoggerMock.Object);
             DecisionServiceMock = new Mock<DecisionService>(BucketerMock.Object,
-                ErrorHandlerMock.Object, null, LoggerMock.Object) { CallBase = true };
+                ErrorHandlerMock.Object, null, LoggerMock.Object)
+            { CallBase = true };
             DecisionReasons = new DecisionReasons();
 
             VariationWithKeyControl =

--- a/OptimizelySDK.Tests/DecisionServiceTest.cs
+++ b/OptimizelySDK.Tests/DecisionServiceTest.cs
@@ -57,29 +57,38 @@ namespace OptimizelySDK.Tests
             ErrorHandlerMock = new Mock<IErrorHandler>();
             UserProfileServiceMock = new Mock<UserProfileService>();
             BucketerMock = new Mock<Bucketer>(LoggerMock.Object);
-            ProjectConfig = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object, ErrorHandlerMock.Object);
+            ProjectConfig = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object,
+                ErrorHandlerMock.Object);
             WhitelistedExperiment = ProjectConfig.ExperimentIdMap["224"];
             WhitelistedVariation = WhitelistedExperiment.VariationKeyToVariationMap["vtag5"];
 
-            DecisionService = new DecisionService(new Bucketer(LoggerMock.Object), ErrorHandlerMock.Object, null, LoggerMock.Object);
-            DecisionServiceMock = new Mock<DecisionService>(BucketerMock.Object, ErrorHandlerMock.Object, null, LoggerMock.Object) { CallBase = true };
-            DecisionReasons = new OptimizelySDK.OptimizelyDecisions.DecisionReasons();
+            DecisionService = new DecisionService(new Bucketer(LoggerMock.Object),
+                ErrorHandlerMock.Object, null, LoggerMock.Object);
+            DecisionServiceMock = new Mock<DecisionService>(BucketerMock.Object,
+                ErrorHandlerMock.Object, null, LoggerMock.Object) { CallBase = true };
+            DecisionReasons = new DecisionReasons();
 
-            VariationWithKeyControl = ProjectConfig.GetVariationFromKey("test_experiment", "control");
-            VariationWithKeyVariation = ProjectConfig.GetVariationFromKey("test_experiment", "variation");
+            VariationWithKeyControl =
+                ProjectConfig.GetVariationFromKey("test_experiment", "control");
+            VariationWithKeyVariation =
+                ProjectConfig.GetVariationFromKey("test_experiment", "variation");
 
-            Config = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object, ErrorHandlerMock.Object);
+            Config = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object,
+                ErrorHandlerMock.Object);
         }
 
         [Test]
         public void TestFindValidatedForcedDecisionReturnsCorrectDecisionWithNullVariation()
         {
-            DecisionService decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, null, LoggerMock.Object);
+            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object,
+                null, LoggerMock.Object);
 
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
 
             var decisionReasons = new DecisionReasons();
-            decisionReasons.AddInfo("{0}", "Invalid variation is mapped to flag: flagKey and rule: rule forced decision map.");
+            decisionReasons.AddInfo("{0}",
+                "Invalid variation is mapped to flag: flagKey and rule: rule forced decision map.");
             var expectedResult = Result<Variation>.NullResult(decisionReasons);
             var user = optlyObject.CreateUserContext(GenericUserId);
 
@@ -93,115 +102,151 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetVariationForcedVariationPrecedesAudienceEval()
         {
-            DecisionService decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, null, LoggerMock.Object);
-            Experiment experiment = ProjectConfig.Experiments[8];
-            Variation expectedVariation = experiment.Variations[0];
+            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object,
+                null, LoggerMock.Object);
+            var experiment = ProjectConfig.Experiments[8];
+            var expectedVariation = experiment.Variations[0];
 
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
-            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject, WhitelistedUserId, new UserAttributes(), ErrorHandlerMock.Object, LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
+            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject,
+                WhitelistedUserId, new UserAttributes(), ErrorHandlerMock.Object,
+                LoggerMock.Object);
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns(GenericUserId);
             // user excluded without audiences and whitelisting
-            Assert.IsNull(decisionService.GetVariation(experiment, OptimizelyUserContextMock.Object, ProjectConfig).ResultObject);
+            Assert.IsNull(decisionService.
+                GetVariation(experiment, OptimizelyUserContextMock.Object, ProjectConfig).
+                ResultObject);
 
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns(WhitelistedUserId);
-            var actualVariation = decisionService.GetVariation(experiment, OptimizelyUserContextMock.Object, ProjectConfig);
+            var actualVariation = decisionService.GetVariation(experiment,
+                OptimizelyUserContextMock.Object, ProjectConfig);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, string.Format("User \"{0}\" is forced in variation \"vtag5\".", WhitelistedUserId)), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    string.Format("User \"{0}\" is forced in variation \"vtag5\".",
+                        WhitelistedUserId)), Times.Once);
 
             // no attributes provided for a experiment that has an audience
             Assertions.AreEqual(expectedVariation, actualVariation.ResultObject);
 
-            BucketerMock.Verify(_ => _.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            BucketerMock.Verify(
+                _ => _.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(),
+                    It.IsAny<string>()), Times.Never);
         }
 
         [Test]
         public void TestGetVariationLogsErrorWhenUserProfileMapItsNull()
         {
-            Experiment experiment = ProjectConfig.Experiments[8];
-            Variation variation = experiment.Variations[0];
+            var experiment = ProjectConfig.Experiments[8];
+            var variation = experiment.Variations[0];
 
-            Decision decision = new Decision(variation.Id);
+            var decision = new Decision(variation.Id);
             Dictionary<string, object> userProfile = null;
 
             UserProfileServiceMock.Setup(up => up.Lookup(WhitelistedUserId)).Returns(userProfile);
 
-            DecisionService decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, UserProfileServiceMock.Object, LoggerMock.Object);
+            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object,
+                UserProfileServiceMock.Object, LoggerMock.Object);
             var options = new OptimizelyDecideOption[] { OptimizelyDecideOption.INCLUDE_REASONS };
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns(GenericUserId);
 
-            var variationResult = decisionService.GetVariation(experiment, OptimizelyUserContextMock.Object, ProjectConfig, options);
-            Assert.AreEqual(variationResult.DecisionReasons.ToReport(true)[0], "We were unable to get a user profile map from the UserProfileService.");
-            Assert.AreEqual(variationResult.DecisionReasons.ToReport(true)[1], "Audiences for experiment \"etag3\" collectively evaluated to FALSE");
-            Assert.AreEqual(variationResult.DecisionReasons.ToReport(true)[2], "User \"genericUserId\" does not meet conditions to be in experiment \"etag3\".");
+            var variationResult = decisionService.GetVariation(experiment,
+                OptimizelyUserContextMock.Object, ProjectConfig, options);
+            Assert.AreEqual(variationResult.DecisionReasons.ToReport(true)[0],
+                "We were unable to get a user profile map from the UserProfileService.");
+            Assert.AreEqual(variationResult.DecisionReasons.ToReport(true)[1],
+                "Audiences for experiment \"etag3\" collectively evaluated to FALSE");
+            Assert.AreEqual(variationResult.DecisionReasons.ToReport(true)[2],
+                "User \"genericUserId\" does not meet conditions to be in experiment \"etag3\".");
         }
 
         [Test]
         public void TestGetVariationEvaluatesUserProfileBeforeAudienceTargeting()
         {
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
-            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject, WhitelistedUserId, new UserAttributes(), ErrorHandlerMock.Object, LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
+            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject,
+                WhitelistedUserId, new UserAttributes(), ErrorHandlerMock.Object,
+                LoggerMock.Object);
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns(GenericUserId);
 
-            Experiment experiment = ProjectConfig.Experiments[8];
-            Variation variation = experiment.Variations[0];
+            var experiment = ProjectConfig.Experiments[8];
+            var variation = experiment.Variations[0];
 
-            Decision decision = new Decision(variation.Id);
-            UserProfile userProfile = new UserProfile(UserProfileId, new Dictionary<string, Decision>
+            var decision = new Decision(variation.Id);
+            var userProfile = new UserProfile(UserProfileId, new Dictionary<string, Decision>
             {
-                { experiment.Id, decision }
+                { experiment.Id, decision },
             });
 
-            UserProfileServiceMock.Setup(up => up.Lookup(WhitelistedUserId)).Returns(userProfile.ToMap());
+            UserProfileServiceMock.Setup(up => up.Lookup(WhitelistedUserId)).
+                Returns(userProfile.ToMap());
 
-            DecisionService decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, UserProfileServiceMock.Object, LoggerMock.Object);
+            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object,
+                UserProfileServiceMock.Object, LoggerMock.Object);
 
-            decisionService.GetVariation(experiment, OptimizelyUserContextMock.Object, ProjectConfig);
+            decisionService.GetVariation(experiment, OptimizelyUserContextMock.Object,
+                ProjectConfig);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, string.Format("User \"{0}\" does not meet conditions to be in experiment \"{1}\".",
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, string.Format(
+                "User \"{0}\" does not meet conditions to be in experiment \"{1}\".",
                 GenericUserId, experiment.Key)), Times.Once);
 
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns(UserProfileId);
 
             // ensure that a user with a saved user profile, sees the same variation regardless of audience evaluation
-            decisionService.GetVariation(experiment, OptimizelyUserContextMock.Object, ProjectConfig);
+            decisionService.GetVariation(experiment, OptimizelyUserContextMock.Object,
+                ProjectConfig);
 
-            BucketerMock.Verify(_ => _.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            BucketerMock.Verify(
+                _ => _.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(),
+                    It.IsAny<string>()), Times.Never);
         }
 
         [Test]
         public void TestGetForcedVariationReturnsForcedVariation()
         {
-            DecisionService decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, null, LoggerMock.Object);
-            var expectedVariation = decisionService.GetWhitelistedVariation(WhitelistedExperiment, WhitelistedUserId).ResultObject;
+            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object,
+                null, LoggerMock.Object);
+            var expectedVariation = decisionService.
+                GetWhitelistedVariation(WhitelistedExperiment, WhitelistedUserId).
+                ResultObject;
 
             Assertions.AreEqual(WhitelistedVariation, expectedVariation);
-            Assert.IsTrue(TestData.CompareObjects(WhitelistedVariation, decisionService.GetWhitelistedVariation(WhitelistedExperiment, WhitelistedUserId).ResultObject));
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, string.Format("User \"{0}\" is forced in variation \"{1}\".",
+            Assert.IsTrue(TestData.CompareObjects(WhitelistedVariation,
+                decisionService.GetWhitelistedVariation(WhitelistedExperiment, WhitelistedUserId).
+                    ResultObject));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, string.Format(
+                "User \"{0}\" is forced in variation \"{1}\".",
                 WhitelistedUserId, WhitelistedVariation.Key)), Times.Exactly(2));
 
-            BucketerMock.Verify(_ => _.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            BucketerMock.Verify(
+                _ => _.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(),
+                    It.IsAny<string>()), Times.Never);
         }
 
         [Test]
         public void TestGetForcedVariationWithInvalidVariation()
         {
-            string userId = "testUser1";
-            string invalidVariationKey = "invalidVarKey";
+            var userId = "testUser1";
+            var invalidVariationKey = "invalidVarKey";
 
-            DecisionService decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, null, LoggerMock.Object);
+            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object,
+                null, LoggerMock.Object);
 
             var variations = new Variation[]
             {
-                new Variation {Id = "1", Key = "var1" }
+                new Variation { Id = "1", Key = "var1" },
             };
             var trafficAllocation = new TrafficAllocation[]
             {
-                new TrafficAllocation {EntityId = "1", EndOfRange = 1000 }
+                new TrafficAllocation { EntityId = "1", EndOfRange = 1000 },
             };
 
             var userIdToVariationKeyMap = new Dictionary<string, string>
             {
-                {userId, invalidVariationKey }
+                { userId, invalidVariationKey },
             };
 
             var experiment = new Experiment
@@ -213,54 +258,68 @@ namespace OptimizelySDK.Tests
                 AudienceIds = new string[0],
                 Variations = variations,
                 TrafficAllocation = trafficAllocation,
-                ForcedVariations = userIdToVariationKeyMap
+                ForcedVariations = userIdToVariationKeyMap,
             };
 
             Assert.IsNull(decisionService.GetWhitelistedVariation(experiment, userId).ResultObject);
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR,
-                string.Format("Variation \"{0}\" is not in the datafile. Not activating user \"{1}\".", invalidVariationKey, userId)),
+                    string.Format(
+                        "Variation \"{0}\" is not in the datafile. Not activating user \"{1}\".",
+                        invalidVariationKey, userId)),
                 Times.Once);
 
-            BucketerMock.Verify(_ => _.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(), It.IsAny<string>()), Times.Never);
+            BucketerMock.Verify(
+                _ => _.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(),
+                    It.IsAny<string>()), Times.Never);
         }
 
         [Test]
         public void TestGetForcedVariationReturnsNullWhenUserIsNotWhitelisted()
         {
-            Bucketer bucketer = new Bucketer(LoggerMock.Object);
-            DecisionService decisionService = new DecisionService(bucketer, ErrorHandlerMock.Object, null, LoggerMock.Object);
+            var bucketer = new Bucketer(LoggerMock.Object);
+            var decisionService = new DecisionService(bucketer, ErrorHandlerMock.Object, null,
+                LoggerMock.Object);
 
-            Assert.IsNull(decisionService.GetWhitelistedVariation(WhitelistedExperiment, GenericUserId).ResultObject);
+            Assert.IsNull(decisionService.
+                GetWhitelistedVariation(WhitelistedExperiment, GenericUserId).
+                ResultObject);
         }
 
         [Test]
         public void TestBucketReturnsVariationStoredInUserProfile()
         {
-            Experiment experiment = ProjectConfig.Experiments[6];
-            Variation variation = experiment.Variations[0];
-            Decision decision = new Decision(variation.Id);
+            var experiment = ProjectConfig.Experiments[6];
+            var variation = experiment.Variations[0];
+            var decision = new Decision(variation.Id);
 
-            UserProfile userProfile = new UserProfile(UserProfileId, new Dictionary<string, Decision>
+            var userProfile = new UserProfile(UserProfileId, new Dictionary<string, Decision>
             {
-                { experiment.Id, decision }
+                { experiment.Id, decision },
             });
 
             UserProfileServiceMock.Setup(_ => _.Lookup(UserProfileId)).Returns(userProfile.ToMap());
 
-            DecisionService decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, UserProfileServiceMock.Object, LoggerMock.Object);
+            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object,
+                UserProfileServiceMock.Object, LoggerMock.Object);
 
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
-            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject, WhitelistedUserId, new UserAttributes(), ErrorHandlerMock.Object, LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
+            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject,
+                WhitelistedUserId, new UserAttributes(), ErrorHandlerMock.Object,
+                LoggerMock.Object);
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns(UserProfileId);
 
-            var actualVariation = decisionService.GetVariation(experiment, OptimizelyUserContextMock.Object, ProjectConfig);
+            var actualVariation = decisionService.GetVariation(experiment,
+                OptimizelyUserContextMock.Object, ProjectConfig);
 
             Assertions.AreEqual(variation, actualVariation.ResultObject);
 
             Assert.AreEqual(actualVariation.DecisionReasons.ToReport(true).Count, 1);
-            Assert.AreEqual(actualVariation.DecisionReasons.ToReport(true)[0], "Returning previously activated variation \"vtag1\" of experiment \"etag1\" for user \"userProfileId\" from user profile.");
+            Assert.AreEqual(actualVariation.DecisionReasons.ToReport(true)[0],
+                "Returning previously activated variation \"vtag1\" of experiment \"etag1\" for user \"userProfileId\" from user profile.");
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, string.Format("Returning previously activated variation \"{0}\" of experiment \"{1}\" for user \"{2}\" from user profile.",
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, string.Format(
+                "Returning previously activated variation \"{0}\" of experiment \"{1}\" for user \"{2}\" from user profile.",
                 variation.Key, experiment.Key, UserProfileId)));
 
             //BucketerMock.Verify(_ => _.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>()), Times.Once);
@@ -269,135 +328,162 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetStoredVariationLogsWhenLookupReturnsNull()
         {
-            Experiment experiment = ProjectConfig.Experiments[6];
+            var experiment = ProjectConfig.Experiments[6];
 
-            UserProfileService userProfileService = UserProfileServiceMock.Object;
-            UserProfile userProfile = new UserProfile(UserProfileId, new Dictionary<string, Decision>());
+            var userProfileService = UserProfileServiceMock.Object;
+            var userProfile = new UserProfile(UserProfileId, new Dictionary<string, Decision>());
 
-            Bucketer bucketer = new Bucketer(LoggerMock.Object);
+            var bucketer = new Bucketer(LoggerMock.Object);
             UserProfileServiceMock.Setup(_ => _.Lookup(UserProfileId)).Returns(userProfile.ToMap());
 
-            DecisionService decisionService = new DecisionService(bucketer,
-                 ErrorHandlerMock.Object, userProfileService, LoggerMock.Object);
+            var decisionService = new DecisionService(bucketer,
+                ErrorHandlerMock.Object, userProfileService, LoggerMock.Object);
 
-            Assert.IsNull(decisionService.GetStoredVariation(experiment, userProfile, ProjectConfig).ResultObject);
+            Assert.IsNull(decisionService.
+                GetStoredVariation(experiment, userProfile, ProjectConfig).
+                ResultObject);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, string.Format("No previously activated variation of experiment \"{0}\" for user \"{1}\" found in user profile."
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, string.Format(
+                "No previously activated variation of experiment \"{0}\" for user \"{1}\" found in user profile."
                 , experiment.Key, UserProfileId)), Times.Once);
         }
 
         [Test]
         public void TestGetStoredVariationReturnsNullWhenVariationIsNoLongerInConfig()
         {
-            Experiment experiment = ProjectConfig.Experiments[6];
-            string storedVariationId = "missingVariation";
-            Decision storedDecision = new Decision(storedVariationId);
+            var experiment = ProjectConfig.Experiments[6];
+            var storedVariationId = "missingVariation";
+            var storedDecision = new Decision(storedVariationId);
 
             var storedDecisions = new Dictionary<string, Decision>();
 
             storedDecisions[experiment.Id] = storedDecision;
 
-            UserProfile storedUserProfile = new UserProfile(UserProfileId, storedDecisions);
+            var storedUserProfile = new UserProfile(UserProfileId, storedDecisions);
 
-            Bucketer bucketer = new Bucketer(LoggerMock.Object);
+            var bucketer = new Bucketer(LoggerMock.Object);
 
-            UserProfileServiceMock.Setup(up => up.Lookup(UserProfileId)).Returns(storedUserProfile.ToMap());
+            UserProfileServiceMock.Setup(up => up.Lookup(UserProfileId)).
+                Returns(storedUserProfile.ToMap());
 
-            DecisionService decisionService = new DecisionService(bucketer, ErrorHandlerMock.Object,
+            var decisionService = new DecisionService(bucketer, ErrorHandlerMock.Object,
                 UserProfileServiceMock.Object, LoggerMock.Object);
-            Assert.IsNull(decisionService.GetStoredVariation(experiment, storedUserProfile, ProjectConfig).ResultObject);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, string.Format("User \"{0}\" was previously bucketed into variation with ID \"{1}\" for experiment \"{2}\", but no matching variation was found for that user. We will re-bucket the user."
+            Assert.IsNull(decisionService.
+                GetStoredVariation(experiment, storedUserProfile, ProjectConfig).
+                ResultObject);
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, string.Format(
+                "User \"{0}\" was previously bucketed into variation with ID \"{1}\" for experiment \"{2}\", but no matching variation was found for that user. We will re-bucket the user."
                 , UserProfileId, storedVariationId, experiment.Id)), Times.Once);
         }
 
         [Test]
         public void TestGetVariationSavesBucketedVariationIntoUserProfile()
         {
-            Experiment experiment = ProjectConfig.Experiments[6];
+            var experiment = ProjectConfig.Experiments[6];
             var variation = Result<Variation>.NewResult(experiment.Variations[0], DecisionReasons);
 
-            Decision decision = new Decision(variation.ResultObject.Id);
+            var decision = new Decision(variation.ResultObject.Id);
 
-            UserProfile originalUserProfile = new UserProfile(UserProfileId,
+            var originalUserProfile = new UserProfile(UserProfileId,
                 new Dictionary<string, Decision>());
-            UserProfileServiceMock.Setup(ups => ups.Lookup(UserProfileId)).Returns(originalUserProfile.ToMap());
+            UserProfileServiceMock.Setup(ups => ups.Lookup(UserProfileId)).
+                Returns(originalUserProfile.ToMap());
 
-            UserProfile expectedUserProfile = new UserProfile(UserProfileId,
+            var expectedUserProfile = new UserProfile(UserProfileId,
                 new Dictionary<string, Decision>
                 {
-                    {experiment.Id, decision }
+                    { experiment.Id, decision },
                 });
 
             var mockBucketer = new Mock<Bucketer>(LoggerMock.Object);
-            mockBucketer.Setup(m => m.Bucket(ProjectConfig, experiment, UserProfileId, UserProfileId)).Returns(variation);
+            mockBucketer.
+                Setup(m => m.Bucket(ProjectConfig, experiment, UserProfileId, UserProfileId)).
+                Returns(variation);
 
-            DecisionService decisionService = new DecisionService(mockBucketer.Object, ErrorHandlerMock.Object, UserProfileServiceMock.Object, LoggerMock.Object);
+            var decisionService = new DecisionService(mockBucketer.Object, ErrorHandlerMock.Object,
+                UserProfileServiceMock.Object, LoggerMock.Object);
 
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns(UserProfileId);
 
-            Assert.IsTrue(TestData.CompareObjects(variation.ResultObject, decisionService.GetVariation(experiment, OptimizelyUserContextMock.Object, ProjectConfig).ResultObject));
+            Assert.IsTrue(TestData.CompareObjects(variation.ResultObject,
+                decisionService.
+                    GetVariation(experiment, OptimizelyUserContextMock.Object, ProjectConfig).
+                    ResultObject));
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, string.Format("Saved variation \"{0}\" of experiment \"{1}\" for user \"{2}\".", variation.ResultObject.Id,
-                        experiment.Id, UserProfileId)), Times.Once);
-            UserProfileServiceMock.Verify(_ => _.Save(It.IsAny<Dictionary<string, object>>()), Times.Once);
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO, string.Format(
+                "Saved variation \"{0}\" of experiment \"{1}\" for user \"{2}\".",
+                variation.ResultObject.Id,
+                experiment.Id, UserProfileId)), Times.Once);
+            UserProfileServiceMock.Verify(_ => _.Save(It.IsAny<Dictionary<string, object>>()),
+                Times.Once);
         }
 
         [Test]
         public void TestBucketLogsCorrectlyWhenUserProfileFailsToSave()
         {
-            Experiment experiment = ProjectConfig.Experiments[6];
-            Variation variation = experiment.Variations[0];
-            Decision decision = new Decision(variation.Id);
-            Bucketer bucketer = new Bucketer(LoggerMock.Object);
+            var experiment = ProjectConfig.Experiments[6];
+            var variation = experiment.Variations[0];
+            var decision = new Decision(variation.Id);
+            var bucketer = new Bucketer(LoggerMock.Object);
 
-            UserProfileServiceMock.Setup(up => up.Save(It.IsAny<Dictionary<string, object>>())).Throws(new System.Exception());
+            UserProfileServiceMock.Setup(up => up.Save(It.IsAny<Dictionary<string, object>>())).
+                Throws(new System.Exception());
 
             var experimentBucketMap = new Dictionary<string, Decision>();
 
             experimentBucketMap[experiment.Id] = decision;
 
-            UserProfile expectedUserProfile = new UserProfile(UserProfileId, experimentBucketMap);
-            UserProfile saveUserProfile = new UserProfile(UserProfileId, new Dictionary<string, Decision>());
+            var expectedUserProfile = new UserProfile(UserProfileId, experimentBucketMap);
+            var saveUserProfile =
+                new UserProfile(UserProfileId, new Dictionary<string, Decision>());
 
-            DecisionService decisionService = new DecisionService(bucketer,
+            var decisionService = new DecisionService(bucketer,
                 ErrorHandlerMock.Object, UserProfileServiceMock.Object, LoggerMock.Object);
 
             decisionService.SaveVariation(experiment, variation, saveUserProfile);
 
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, string.Format
-                ("Failed to save variation \"{0}\" of experiment \"{1}\" for user \"{2}\".", variation.Id, experiment.Id, UserProfileId))
+                ("Failed to save variation \"{0}\" of experiment \"{1}\" for user \"{2}\".",
+                    variation.Id, experiment.Id, UserProfileId))
                 , Times.Once);
-            ErrorHandlerMock.Verify(er => er.HandleError(It.IsAny<OptimizelySDK.Exceptions.OptimizelyRuntimeException>()), Times.Once);
+            ErrorHandlerMock.Verify(
+                er => er.HandleError(It.IsAny<Exceptions.OptimizelyRuntimeException>()),
+                Times.Once);
         }
 
         [Test]
         public void TestGetVariationSavesANewUserProfile()
         {
-            Experiment experiment = ProjectConfig.Experiments[6];
+            var experiment = ProjectConfig.Experiments[6];
             var variation = Result<Variation>.NewResult(experiment.Variations[0], DecisionReasons);
-            Decision decision = new Decision(variation.ResultObject.Id);
+            var decision = new Decision(variation.ResultObject.Id);
 
-            UserProfile expectedUserProfile = new UserProfile(UserProfileId, new Dictionary<string, Decision>
-            {
-                { experiment.Id, decision }
-            });
+            var expectedUserProfile = new UserProfile(UserProfileId,
+                new Dictionary<string, Decision>
+                {
+                    { experiment.Id, decision },
+                });
 
             var mockBucketer = new Mock<Bucketer>(LoggerMock.Object);
-            mockBucketer.Setup(m => m.Bucket(ProjectConfig, experiment, UserProfileId, UserProfileId)).Returns(variation);
+            mockBucketer.
+                Setup(m => m.Bucket(ProjectConfig, experiment, UserProfileId, UserProfileId)).
+                Returns(variation);
 
             Dictionary<string, object> userProfile = null;
 
             UserProfileServiceMock.Setup(up => up.Lookup(UserProfileId)).Returns(userProfile);
 
-            DecisionService decisionService = new DecisionService(mockBucketer.Object, ErrorHandlerMock.Object,
+            var decisionService = new DecisionService(mockBucketer.Object, ErrorHandlerMock.Object,
                 UserProfileServiceMock.Object, LoggerMock.Object);
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns(UserProfileId);
 
-            var actualVariation = decisionService.GetVariation(experiment, OptimizelyUserContextMock.Object, ProjectConfig);
+            var actualVariation = decisionService.GetVariation(experiment,
+                OptimizelyUserContextMock.Object, ProjectConfig);
 
             Assertions.AreEqual(variation.ResultObject, actualVariation.ResultObject);
 
-            UserProfileServiceMock.Verify(_ => _.Save(It.IsAny<Dictionary<string, object>>()), Times.Once);
+            UserProfileServiceMock.Verify(_ => _.Save(It.IsAny<Dictionary<string, object>>()),
+                Times.Once);
         }
 
         [Test]
@@ -407,12 +493,13 @@ namespace OptimizelySDK.Tests
             var pausedExperimentKey = "paused_experiment";
             var userId = "test_user";
             var expectedForcedVariationKey = "variation";
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
 
             var userAttributes = new UserAttributes
             {
-                {"device_type", "iPhone" },
-                {"location", "San Francisco" }
+                { "device_type", "iPhone" },
+                { "location", "San Francisco" },
             };
 
             optlyObject.Activate(experimentKey, userId, userAttributes);
@@ -422,9 +509,12 @@ namespace OptimizelySDK.Tests
             Assertions.AreEqual(VariationWithKeyControl, actualVariation);
 
             // test valid experiment
-            Assert.IsTrue(optlyObject.SetForcedVariation(experimentKey, userId, expectedForcedVariationKey), string.Format(@"Set variation to ""{0}"" failed.", expectedForcedVariationKey));
+            Assert.IsTrue(
+                optlyObject.SetForcedVariation(experimentKey, userId, expectedForcedVariationKey),
+                string.Format(@"Set variation to ""{0}"" failed.", expectedForcedVariationKey));
 
-            var actualForcedVariation = optlyObject.GetVariation(experimentKey, userId, userAttributes);
+            var actualForcedVariation =
+                optlyObject.GetVariation(experimentKey, userId, userAttributes);
 
             Assertions.AreEqual(VariationWithKeyVariation, actualForcedVariation);
 
@@ -435,8 +525,12 @@ namespace OptimizelySDK.Tests
             Assertions.AreEqual(VariationWithKeyControl, actualVariation);
 
             // check that a paused experiment returns null
-            Assert.IsTrue(optlyObject.SetForcedVariation(pausedExperimentKey, userId, expectedForcedVariationKey), string.Format(@"Set variation to ""{0}"" failed.", expectedForcedVariationKey));
-            actualForcedVariation = optlyObject.GetVariation(pausedExperimentKey, userId, userAttributes);
+            Assert.IsTrue(
+                optlyObject.SetForcedVariation(pausedExperimentKey, userId,
+                    expectedForcedVariationKey),
+                string.Format(@"Set variation to ""{0}"" failed.", expectedForcedVariationKey));
+            actualForcedVariation =
+                optlyObject.GetVariation(pausedExperimentKey, userId, userAttributes);
 
             Assert.IsNull(actualForcedVariation);
         }
@@ -448,57 +542,65 @@ namespace OptimizelySDK.Tests
             var userId = "test_user";
             var testUserIdWhitelisted = "user1";
             var experimentKey = "test_experiment";
-            var testBucketingIdControl = "testBucketingIdControl!";  // generates bucketing number 3741
+            var testBucketingIdControl =
+                "testBucketingIdControl!"; // generates bucketing number 3741
             var testBucketingIdVariation = "123456789"; // generates bucketing number 4567
             var variationKeyControl = "control";
 
             var testUserAttributes = new UserAttributes
             {
-                {"device_type", "iPhone" },
-                {"company", "Optimizely" },
-                {"location", "San Francisco" }
+                { "device_type", "iPhone" },
+                { "company", "Optimizely" },
+                { "location", "San Francisco" },
             };
 
             var userAttributesWithBucketingId = new UserAttributes
             {
-                {"device_type", "iPhone"},
-                {"company", "Optimizely"},
-                {"location", "San Francisco"},
-                {ControlAttributes.BUCKETING_ID_ATTRIBUTE, testBucketingIdVariation}
+                { "device_type", "iPhone" },
+                { "company", "Optimizely" },
+                { "location", "San Francisco" },
+                { ControlAttributes.BUCKETING_ID_ATTRIBUTE, testBucketingIdVariation },
             };
 
             var userAttributesWithInvalidBucketingId = new UserAttributes
             {
-                {"device_type", "iPhone"},
-                {"company", "Optimizely"},
-                {"location", "San Francisco"},
-                {ControlAttributes.BUCKETING_ID_ATTRIBUTE, 1.59}
+                { "device_type", "iPhone" },
+                { "company", "Optimizely" },
+                { "location", "San Francisco" },
+                { ControlAttributes.BUCKETING_ID_ATTRIBUTE, 1.59 },
             };
 
             var invalidUserAttributesWithBucketingId = new UserAttributes
             {
-                {"company", "Optimizely"},
-                {ControlAttributes.BUCKETING_ID_ATTRIBUTE, testBucketingIdControl}
+                { "company", "Optimizely" },
+                { ControlAttributes.BUCKETING_ID_ATTRIBUTE, testBucketingIdControl },
             };
 
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
 
             // confirm normal bucketing occurs before setting the bucketing ID
-            var actualVariation = optlyObject.GetVariation(experimentKey, userId, testUserAttributes);
+            var actualVariation =
+                optlyObject.GetVariation(experimentKey, userId, testUserAttributes);
             Assert.IsTrue(TestData.CompareObjects(VariationWithKeyControl, actualVariation));
 
             // confirm valid bucketing with bucketing ID set in attributes
-            actualVariation = optlyObject.GetVariation(experimentKey, userId, userAttributesWithBucketingId);
+            actualVariation =
+                optlyObject.GetVariation(experimentKey, userId, userAttributesWithBucketingId);
             Assert.IsTrue(TestData.CompareObjects(VariationWithKeyVariation, actualVariation));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"BucketingId is valid: \"{testBucketingIdVariation}\""));
+            LoggerMock.Verify(l =>
+                l.Log(LogLevel.DEBUG, $"BucketingId is valid: \"{testBucketingIdVariation}\""));
 
             // check audience with invalid bucketing Id
-            actualVariation = optlyObject.GetVariation(experimentKey, userId, userAttributesWithInvalidBucketingId);
+            actualVariation = optlyObject.GetVariation(experimentKey, userId,
+                userAttributesWithInvalidBucketingId);
             Assert.IsTrue(TestData.CompareObjects(VariationWithKeyControl, actualVariation));
-            LoggerMock.Verify(l => l.Log(LogLevel.WARN, "BucketingID attribute is not a string. Defaulted to userId"));
+            LoggerMock.Verify(l => l.Log(LogLevel.WARN,
+                "BucketingID attribute is not a string. Defaulted to userId"));
 
             // check invalid audience with bucketing ID
-            actualVariation = optlyObject.GetVariation(experimentKey, userId, invalidUserAttributesWithBucketingId);
+            actualVariation = optlyObject.GetVariation(experimentKey, userId,
+                invalidUserAttributesWithBucketingId);
             Assert.Null(actualVariation);
 
             // check null audience with bucketing Id
@@ -506,30 +608,41 @@ namespace OptimizelySDK.Tests
             Assert.Null(actualVariation);
 
             // test that an experiment that's not running returns a null variation
-            actualVariation = optlyObject.GetVariation(pausedExperimentKey, userId, userAttributesWithBucketingId);
+            actualVariation = optlyObject.GetVariation(pausedExperimentKey, userId,
+                userAttributesWithBucketingId);
             Assert.Null(actualVariation);
 
             // check forced variation
-            Assert.IsTrue(optlyObject.SetForcedVariation(experimentKey, userId, variationKeyControl), string.Format("Set variation to \"{0}\" failed.", variationKeyControl));
-            actualVariation = optlyObject.GetVariation(experimentKey, userId, userAttributesWithBucketingId);
+            Assert.IsTrue(
+                optlyObject.SetForcedVariation(experimentKey, userId, variationKeyControl),
+                string.Format("Set variation to \"{0}\" failed.", variationKeyControl));
+            actualVariation =
+                optlyObject.GetVariation(experimentKey, userId, userAttributesWithBucketingId);
             Assert.IsTrue(TestData.CompareObjects(VariationWithKeyControl, actualVariation));
 
             // check whitelisted variation
-            actualVariation = optlyObject.GetVariation(experimentKey, testUserIdWhitelisted, userAttributesWithBucketingId);
+            actualVariation = optlyObject.GetVariation(experimentKey, testUserIdWhitelisted,
+                userAttributesWithBucketingId);
             Assert.IsTrue(TestData.CompareObjects(VariationWithKeyControl, actualVariation));
 
             var bucketerMock = new Mock<Bucketer>(LoggerMock.Object);
             var decision = new Decision("7722370027");
-            UserProfile storedUserProfile = new UserProfile(userId, new Dictionary<string, Decision>
+            var storedUserProfile = new UserProfile(userId, new Dictionary<string, Decision>
             {
-                { "7716830082", decision }
+                { "7716830082", decision },
             });
 
-            UserProfileServiceMock.Setup(up => up.Lookup(userId)).Returns(storedUserProfile.ToMap());
-            DecisionService decisionService = new DecisionService(bucketerMock.Object, ErrorHandlerMock.Object, UserProfileServiceMock.Object, LoggerMock.Object);
+            UserProfileServiceMock.Setup(up => up.Lookup(userId)).
+                Returns(storedUserProfile.ToMap());
+            var decisionService = new DecisionService(bucketerMock.Object, ErrorHandlerMock.Object,
+                UserProfileServiceMock.Object, LoggerMock.Object);
 
-            actualVariation = optlyObject.GetVariation(experimentKey, userId, userAttributesWithBucketingId);
-            Assert.IsTrue(TestData.CompareObjects(VariationWithKeyControl, actualVariation), string.Format("Variation \"{0}\" does not match expected user profile variation \"{1}\".", actualVariation?.Key, variationKeyControl));
+            actualVariation =
+                optlyObject.GetVariation(experimentKey, userId, userAttributesWithBucketingId);
+            Assert.IsTrue(TestData.CompareObjects(VariationWithKeyControl, actualVariation),
+                string.Format(
+                    "Variation \"{0}\" does not match expected user profile variation \"{1}\".",
+                    actualVariation?.Key, variationKeyControl));
         }
 
         #region GetVariationForFeatureExperiment Tests
@@ -541,11 +654,14 @@ namespace OptimizelySDK.Tests
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("empty_feature");
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns(GenericUserId);
 
-            var decision = DecisionService.GetVariationForFeatureExperiment(featureFlag, OptimizelyUserContextMock.Object, new UserAttributes() { }, ProjectConfig, new OptimizelyDecideOption[] { });
+            var decision = DecisionService.GetVariationForFeatureExperiment(featureFlag,
+                OptimizelyUserContextMock.Object, new UserAttributes() { }, ProjectConfig,
+                new OptimizelyDecideOption[] { });
 
             Assert.IsNull(decision.ResultObject);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, $"The feature flag \"{featureFlag.Key}\" is not used in any experiments."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                $"The feature flag \"{featureFlag.Key}\" is not used in any experiments."));
         }
 
         // Should return null and log when the experiment is not in the datafile
@@ -558,32 +674,42 @@ namespace OptimizelySDK.Tests
                 Id = booleanFeature.Id,
                 Key = booleanFeature.Key,
                 RolloutId = booleanFeature.RolloutId,
-                ExperimentIds = new List<string> { "29039203" }
+                ExperimentIds = new List<string> { "29039203" },
             };
 
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns(GenericUserId);
 
-            var decision = DecisionService.GetVariationForFeatureExperiment(featureFlag, OptimizelyUserContextMock.Object, new UserAttributes() { }, ProjectConfig, new OptimizelyDecideOption[] { });
+            var decision = DecisionService.GetVariationForFeatureExperiment(featureFlag,
+                OptimizelyUserContextMock.Object, new UserAttributes() { }, ProjectConfig,
+                new OptimizelyDecideOption[] { });
             Assert.IsNull(decision.ResultObject);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Experiment ID \"29039203\" is not in datafile."));
+            LoggerMock.Verify(l =>
+                l.Log(LogLevel.ERROR, "Experiment ID \"29039203\" is not in datafile."));
         }
 
         // Should return null and log when the user is not bucketed into the feature flag's experiments
         [Test]
         public void TestGetVariationForFeatureExperimentGivenNonMutexGroupAndUserNotBucketed()
         {
-            var multiVariateExp = ProjectConfig.GetExperimentFromKey("test_experiment_multivariate");
+            var multiVariateExp =
+                ProjectConfig.GetExperimentFromKey("test_experiment_multivariate");
 
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns("user1");
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(multiVariateExp, OptimizelyUserContextMock.Object, ProjectConfig, null)).Returns<Variation>(null);
+            DecisionServiceMock.
+                Setup(ds => ds.GetVariation(multiVariateExp, OptimizelyUserContextMock.Object,
+                    ProjectConfig, null)).
+                Returns<Variation>(null);
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("multi_variate_feature");
 
-            var decision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, OptimizelyUserContextMock.Object, new UserAttributes(), ProjectConfig, new OptimizelyDecideOption[] { });
+            var decision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag,
+                OptimizelyUserContextMock.Object, new UserAttributes(), ProjectConfig,
+                new OptimizelyDecideOption[] { });
             Assert.IsNull(decision.ResultObject);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"user1\" is not bucketed into any of the experiments on the feature \"multi_variate_feature\"."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "The user \"user1\" is not bucketed into any of the experiments on the feature \"multi_variate_feature\"."));
         }
 
         // Should return the variation when the user is bucketed into a variation for the experiment on the feature flag
@@ -591,25 +717,36 @@ namespace OptimizelySDK.Tests
         public void TestGetVariationForFeatureExperimentGivenNonMutexGroupAndUserIsBucketed()
         {
             var experiment = ProjectConfig.GetExperimentFromKey("test_experiment_multivariate");
-            var variation = Result<Variation>.NewResult(ProjectConfig.GetVariationFromId("test_experiment_multivariate", "122231"), DecisionReasons);
-            var expectedDecision = new FeatureDecision(experiment, variation.ResultObject, FeatureDecision.DECISION_SOURCE_FEATURE_TEST);
+            var variation = Result<Variation>.NewResult(
+                ProjectConfig.GetVariationFromId("test_experiment_multivariate", "122231"),
+                DecisionReasons);
+            var expectedDecision = new FeatureDecision(experiment, variation.ResultObject,
+                FeatureDecision.DECISION_SOURCE_FEATURE_TEST);
             var userAttributes = new UserAttributes();
 
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
 
-            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject, WhitelistedUserId, userAttributes, ErrorHandlerMock.Object, LoggerMock.Object);
+            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject,
+                WhitelistedUserId, userAttributes, ErrorHandlerMock.Object, LoggerMock.Object);
 
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns("user1");
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(ProjectConfig.GetExperimentFromKey("test_experiment_multivariate"),
-                OptimizelyUserContextMock.Object, ProjectConfig, It.IsAny<OptimizelyDecideOption[]>())).Returns(variation);
+            DecisionServiceMock.Setup(ds => ds.GetVariation(
+                    ProjectConfig.GetExperimentFromKey("test_experiment_multivariate"),
+                    OptimizelyUserContextMock.Object, ProjectConfig,
+                    It.IsAny<OptimizelyDecideOption[]>())).
+                Returns(variation);
 
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("multi_variate_feature");
-            var decision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, OptimizelyUserContextMock.Object, userAttributes, ProjectConfig, new OptimizelyDecideOption[] { });
+            var decision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag,
+                OptimizelyUserContextMock.Object, userAttributes, ProjectConfig,
+                new OptimizelyDecideOption[] { });
 
             Assert.IsTrue(TestData.CompareObjects(expectedDecision, decision.ResultObject));
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"user1\" is bucketed into experiment \"test_experiment_multivariate\" of feature \"multi_variate_feature\"."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "The user \"user1\" is bucketed into experiment \"test_experiment_multivariate\" of feature \"multi_variate_feature\"."));
         }
 
         // Should return the variation the user is bucketed into when the user is bucketed into one of the experiments
@@ -617,23 +754,34 @@ namespace OptimizelySDK.Tests
         public void TestGetVariationForFeatureExperimentGivenMutexGroupAndUserIsBucketed()
         {
             var mutexExperiment = ProjectConfig.GetExperimentFromKey("group_experiment_1");
-            var variation = Result<Variation>.NewResult(mutexExperiment.Variations[0], DecisionReasons);
+            var variation =
+                Result<Variation>.NewResult(mutexExperiment.Variations[0], DecisionReasons);
             var userAttributes = new UserAttributes();
-            var expectedDecision = new FeatureDecision(mutexExperiment, variation.ResultObject, FeatureDecision.DECISION_SOURCE_FEATURE_TEST);
+            var expectedDecision = new FeatureDecision(mutexExperiment, variation.ResultObject,
+                FeatureDecision.DECISION_SOURCE_FEATURE_TEST);
 
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
 
-            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject, WhitelistedUserId, userAttributes, ErrorHandlerMock.Object, LoggerMock.Object);
+            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject,
+                WhitelistedUserId, userAttributes, ErrorHandlerMock.Object, LoggerMock.Object);
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns("user1");
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(ProjectConfig.GetExperimentFromKey("group_experiment_1"), OptimizelyUserContextMock.Object, ProjectConfig)).Returns(variation);
+            DecisionServiceMock.
+                Setup(ds =>
+                    ds.GetVariation(ProjectConfig.GetExperimentFromKey("group_experiment_1"),
+                        OptimizelyUserContextMock.Object, ProjectConfig)).
+                Returns(variation);
 
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("boolean_feature");
-            var actualDecision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, OptimizelyUserContextMock.Object, userAttributes, ProjectConfig, new OptimizelyDecideOption[] { });
+            var actualDecision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(
+                featureFlag, OptimizelyUserContextMock.Object, userAttributes, ProjectConfig,
+                new OptimizelyDecideOption[] { });
 
             Assertions.AreEqual(expectedDecision, actualDecision.ResultObject);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"user1\" is bucketed into experiment \"group_experiment_1\" of feature \"boolean_feature\"."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "The user \"user1\" is bucketed into experiment \"group_experiment_1\" of feature \"boolean_feature\"."));
         }
 
         // Should return null and log a message when the user is not bucketed into any of the mutex experiments
@@ -643,15 +791,21 @@ namespace OptimizelySDK.Tests
             var mutexExperiment = ProjectConfig.GetExperimentFromKey("group_experiment_1");
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns("user1");
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(It.IsAny<Experiment>(), It.IsAny<OptimizelyUserContext>(), ProjectConfig, It.IsAny<OptimizelyDecideOption[]>()))
-                .Returns(Result<Variation>.NullResult(null));
+            DecisionServiceMock.
+                Setup(ds => ds.GetVariation(It.IsAny<Experiment>(),
+                    It.IsAny<OptimizelyUserContext>(), ProjectConfig,
+                    It.IsAny<OptimizelyDecideOption[]>())).
+                Returns(Result<Variation>.NullResult(null));
 
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("boolean_feature");
-            var actualDecision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, OptimizelyUserContextMock.Object, new UserAttributes(), ProjectConfig, new OptimizelyDecideOption[] { });
+            var actualDecision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(
+                featureFlag, OptimizelyUserContextMock.Object, new UserAttributes(), ProjectConfig,
+                new OptimizelyDecideOption[] { });
 
             Assert.IsNull(actualDecision.ResultObject);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"user1\" is not bucketed into any of the experiments on the feature \"boolean_feature\"."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "The user \"user1\" is not bucketed into any of the experiments on the feature \"boolean_feature\"."));
         }
 
         #endregion GetVariationForFeatureExperiment Tests
@@ -662,18 +816,24 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetVariationForFeatureRolloutWhenNoRuleInRollouts()
         {
-            var projectConfig = DatafileProjectConfig.Create(TestData.EmptyRolloutDatafile, new NoOpLogger(), new NoOpErrorHandler());
+            var projectConfig = DatafileProjectConfig.Create(TestData.EmptyRolloutDatafile,
+                new NoOpLogger(), new NoOpErrorHandler());
 
             Assert.IsNotNull(projectConfig);
             var featureFlag = projectConfig.FeatureKeyMap["empty_rollout"];
             var rollout = projectConfig.GetRolloutFromId(featureFlag.RolloutId);
 
             Assert.AreEqual(rollout.Experiments.Count, 0);
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
-            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, "userId1", null, ErrorHandlerMock.Object, LoggerMock.Object);
-            var decisionService = new DecisionService(new Bucketer(new NoOpLogger()), new NoOpErrorHandler(), null, new NoOpLogger());
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
+            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, "userId1", null,
+                ErrorHandlerMock.Object, LoggerMock.Object);
+            var decisionService = new DecisionService(new Bucketer(new NoOpLogger()),
+                new NoOpErrorHandler(), null, new NoOpLogger());
 
-            var variation = decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext, projectConfig);
+            var variation =
+                decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext,
+                    projectConfig);
 
             Assert.IsNull(variation.ResultObject);
         }
@@ -681,7 +841,6 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetVariationForFeatureRolloutWhenRolloutIsNotInDataFile()
         {
-
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("boolean_feature");
             var invalidRolloutFeature = new FeatureFlag
             {
@@ -689,89 +848,135 @@ namespace OptimizelySDK.Tests
                 Id = featureFlag.Id,
                 Key = featureFlag.Key,
                 ExperimentIds = new List<string>(featureFlag.ExperimentIds),
-                Variables = featureFlag.Variables
+                Variables = featureFlag.Variables,
             };
 
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureExperiment(It.IsAny<FeatureFlag>(), It.IsAny<OptimizelyUserContext>(), It.IsAny<UserAttributes>(), ProjectConfig, new OptimizelyDecideOption[] { })).Returns<Variation>(null);
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
-            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, "user1", new UserAttributes(), ErrorHandlerMock.Object, LoggerMock.Object);
-            var actualDecision = DecisionServiceMock.Object.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext, ProjectConfig);
+            DecisionServiceMock.Setup(ds =>
+                    ds.GetVariationForFeatureExperiment(It.IsAny<FeatureFlag>(),
+                        It.IsAny<OptimizelyUserContext>(), It.IsAny<UserAttributes>(),
+                        ProjectConfig,
+                        new OptimizelyDecideOption[] { })).
+                Returns<Variation>(null);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
+            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, "user1",
+                new UserAttributes(), ErrorHandlerMock.Object, LoggerMock.Object);
+            var actualDecision =
+                DecisionServiceMock.Object.GetVariationForFeatureRollout(featureFlag,
+                    optimizelyUserContext, ProjectConfig);
             Assert.IsNull(actualDecision.ResultObject);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The feature flag \"boolean_feature\" is not used in a rollout."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "The feature flag \"boolean_feature\" is not used in a rollout."));
         }
 
         // Should return the variation the user is bucketed into when the user is bucketed into the targeting rule
         [Test]
         public void TestGetVariationForFeatureRolloutWhenUserIsBucketedInTheTargetingRule()
         {
-            var featureFlag = ProjectConfig.GetFeatureFlagFromKey("boolean_single_variable_feature");
+            var featureFlag =
+                ProjectConfig.GetFeatureFlagFromKey("boolean_single_variable_feature");
             var rolloutId = featureFlag.RolloutId;
             var rollout = ProjectConfig.GetRolloutFromId(rolloutId);
             var experiment = rollout.Experiments[0];
             var variation = Result<Variation>.NewResult(experiment.Variations[0], DecisionReasons);
-            var expectedDecision = new FeatureDecision(experiment, variation.ResultObject, FeatureDecision.DECISION_SOURCE_ROLLOUT);
+            var expectedDecision = new FeatureDecision(experiment, variation.ResultObject,
+                FeatureDecision.DECISION_SOURCE_ROLLOUT);
 
-            var userAttributes = new UserAttributes {
-                { "browser_type", "chrome" }
+            var userAttributes = new UserAttributes
+            {
+                { "browser_type", "chrome" },
             };
 
-            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(),
-                It.IsAny<string>())).Returns(variation);
-            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, null, LoggerMock.Object);
+            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>())).
+                Returns(variation);
+            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object,
+                null, LoggerMock.Object);
 
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
-            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, "user_1", userAttributes, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
+            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, "user_1",
+                userAttributes, ErrorHandlerMock.Object, LoggerMock.Object);
 
-            var actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext, ProjectConfig);
+            var actualDecision =
+                decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext,
+                    ProjectConfig);
             Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision.ResultObject));
         }
 
         // Should return the variation the user is bucketed into when the user is bucketed into the "Everyone Else" rule
         // and the user is not bucketed into the targeting rule
         [Test]
-        public void TestGetVariationForFeatureRolloutWhenUserIsNotBucketedInTheTargetingRuleButBucketedToEveryoneElseRule()
+        public void
+            TestGetVariationForFeatureRolloutWhenUserIsNotBucketedInTheTargetingRuleButBucketedToEveryoneElseRule()
         {
-            var featureFlag = ProjectConfig.GetFeatureFlagFromKey("boolean_single_variable_feature");
+            var featureFlag =
+                ProjectConfig.GetFeatureFlagFromKey("boolean_single_variable_feature");
             var rolloutId = featureFlag.RolloutId;
             var rollout = ProjectConfig.GetRolloutFromId(rolloutId);
             var experiment = rollout.Experiments[0];
             var everyoneElseRule = rollout.Experiments[rollout.Experiments.Count - 1];
-            var variation = Result<Variation>.NewResult(everyoneElseRule.Variations[0], DecisionReasons);
-            var expectedDecision = new FeatureDecision(everyoneElseRule, variation.ResultObject, FeatureDecision.DECISION_SOURCE_ROLLOUT);
+            var variation =
+                Result<Variation>.NewResult(everyoneElseRule.Variations[0], DecisionReasons);
+            var expectedDecision = new FeatureDecision(everyoneElseRule, variation.ResultObject,
+                FeatureDecision.DECISION_SOURCE_ROLLOUT);
 
-            var userAttributes = new UserAttributes {
-                { "browser_type", "chrome" }
+            var userAttributes = new UserAttributes
+            {
+                { "browser_type", "chrome" },
             };
 
-            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), experiment, It.IsAny<string>(), It.IsAny<string>())).Returns(Result<Variation>.NullResult(null));
-            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), everyoneElseRule, It.IsAny<string>(), It.IsAny<string>())).Returns(variation);
-            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, null, LoggerMock.Object);
+            BucketerMock.
+                Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), experiment, It.IsAny<string>(),
+                    It.IsAny<string>())).
+                Returns(Result<Variation>.NullResult(null));
+            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), everyoneElseRule,
+                    It.IsAny<string>(), It.IsAny<string>())).
+                Returns(variation);
+            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object,
+                null, LoggerMock.Object);
 
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
-            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, "user_1", userAttributes, ErrorHandlerMock.Object, LoggerMock.Object);
-            var actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext, ProjectConfig);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
+            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, "user_1",
+                userAttributes, ErrorHandlerMock.Object, LoggerMock.Object);
+            var actualDecision =
+                decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext,
+                    ProjectConfig);
             Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision.ResultObject));
         }
 
         // Should log and return null when  the user is not bucketed into the targeting rule
         // as well as "Everyone Else" rule.
         [Test]
-        public void TestGetVariationForFeatureRolloutWhenUserIsNeitherBucketedInTheTargetingRuleNorToEveryoneElseRule()
+        public void
+            TestGetVariationForFeatureRolloutWhenUserIsNeitherBucketedInTheTargetingRuleNorToEveryoneElseRule()
         {
-            var featureFlag = ProjectConfig.GetFeatureFlagFromKey("boolean_single_variable_feature");
+            var featureFlag =
+                ProjectConfig.GetFeatureFlagFromKey("boolean_single_variable_feature");
             var rolloutId = featureFlag.RolloutId;
             var rollout = ProjectConfig.GetRolloutFromId(rolloutId);
-            var userAttributes = new UserAttributes {
-                { "browser_type", "chrome" }
+            var userAttributes = new UserAttributes
+            {
+                { "browser_type", "chrome" },
             };
 
-            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(), It.IsAny<string>())).Returns(Result<Variation>.NullResult(null));
-            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, null, LoggerMock.Object);
+            BucketerMock.
+                Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(),
+                    It.IsAny<string>(), It.IsAny<string>())).
+                Returns(Result<Variation>.NullResult(null));
+            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object,
+                null, LoggerMock.Object);
 
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
-            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, "user_1", userAttributes, ErrorHandlerMock.Object, LoggerMock.Object);
-            var actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext, ProjectConfig);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
+            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, "user_1",
+                userAttributes, ErrorHandlerMock.Object, LoggerMock.Object);
+            var actualDecision =
+                decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext,
+                    ProjectConfig);
             Assert.IsNull(actualDecision.ResultObject);
         }
 
@@ -780,34 +985,51 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetVariationForFeatureRolloutWhenUserDoesNotQualifyForAnyTargetingRule()
         {
-            var featureFlag = ProjectConfig.GetFeatureFlagFromKey("boolean_single_variable_feature");
+            var featureFlag =
+                ProjectConfig.GetFeatureFlagFromKey("boolean_single_variable_feature");
             var rolloutId = featureFlag.RolloutId;
             var rollout = ProjectConfig.GetRolloutFromId(rolloutId);
             var experiment0 = rollout.Experiments[0];
             var experiment1 = rollout.Experiments[1];
             var everyoneElseRule = rollout.Experiments[rollout.Experiments.Count - 1];
-            var variation = Result<Variation>.NewResult(everyoneElseRule.Variations[0], DecisionReasons);
-            var expectedDecision = new FeatureDecision(everyoneElseRule, variation.ResultObject, FeatureDecision.DECISION_SOURCE_ROLLOUT);
+            var variation =
+                Result<Variation>.NewResult(everyoneElseRule.Variations[0], DecisionReasons);
+            var expectedDecision = new FeatureDecision(everyoneElseRule, variation.ResultObject,
+                FeatureDecision.DECISION_SOURCE_ROLLOUT);
             //BucketerMock.CallBase = true;
-            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), It.IsNotIn<Experiment>(everyoneElseRule), It.IsAny<string>(), It.IsAny<string>())).Returns(Result<Variation>.NullResult(null));
-            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), everyoneElseRule, It.IsAny<string>(), It.IsAny<string>())).Returns(variation);
-            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, null, LoggerMock.Object);
+            BucketerMock.
+                Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(),
+                    It.IsNotIn<Experiment>(everyoneElseRule), It.IsAny<string>(),
+                    It.IsAny<string>())).
+                Returns(Result<Variation>.NullResult(null));
+            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), everyoneElseRule,
+                    It.IsAny<string>(), It.IsAny<string>())).
+                Returns(variation);
+            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object,
+                null, LoggerMock.Object);
 
             // Provide null attributes so that user does not qualify for audience.
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
-            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, "user_1", null, ErrorHandlerMock.Object, LoggerMock.Object);
-            var actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext, ProjectConfig);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
+            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, "user_1", null,
+                ErrorHandlerMock.Object, LoggerMock.Object);
+            var actualDecision =
+                decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext,
+                    ProjectConfig);
 
             Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision.ResultObject));
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"User \"user_1\" does not meet the conditions for targeting rule \"1\"."));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $"User \"user_1\" does not meet the conditions for targeting rule \"2\"."));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                $"User \"user_1\" does not meet the conditions for targeting rule \"1\"."));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                $"User \"user_1\" does not meet the conditions for targeting rule \"2\"."));
         }
 
         [Test]
         public void TestGetVariationForFeatureRolloutAudienceAndTrafficeAllocationCheck()
         {
-            var featureFlag = ProjectConfig.GetFeatureFlagFromKey("boolean_single_variable_feature");
+            var featureFlag =
+                ProjectConfig.GetFeatureFlagFromKey("boolean_single_variable_feature");
             var rolloutId = featureFlag.RolloutId;
             var rollout = ProjectConfig.GetRolloutFromId(rolloutId);
             var expWithAudienceiPhoneUsers = rollout.Experiments[1];
@@ -819,48 +1041,65 @@ namespace OptimizelySDK.Tests
 
             var mockBucketer = new Mock<Bucketer>(LoggerMock.Object) { CallBase = true };
             mockBucketer.Setup(bm => bm.GenerateBucketValue(It.IsAny<string>())).Returns(980);
-            var decisionService = new DecisionService(mockBucketer.Object, ErrorHandlerMock.Object, null, LoggerMock.Object);
+            var decisionService = new DecisionService(mockBucketer.Object, ErrorHandlerMock.Object,
+                null, LoggerMock.Object);
 
             // Calling with audience iPhone users in San Francisco.
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
-            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, GenericUserId, new UserAttributes
-            {
-                { "device_type", "iPhone" },
-                { "location", "San Francisco" }
-            }, ErrorHandlerMock.Object, LoggerMock.Object);
-            var actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext, ProjectConfig);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
+            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, GenericUserId,
+                new UserAttributes
+                {
+                    { "device_type", "iPhone" },
+                    { "location", "San Francisco" },
+                }, ErrorHandlerMock.Object, LoggerMock.Object);
+            var actualDecision =
+                decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext,
+                    ProjectConfig);
 
             // Returned variation id should be '177773' because of audience 'iPhone users in San Francisco'.
-            var expectedDecision = new FeatureDecision(expWithAudienceiPhoneUsers, varWithAudienceiPhoneUsers, FeatureDecision.DECISION_SOURCE_ROLLOUT);
+            var expectedDecision = new FeatureDecision(expWithAudienceiPhoneUsers,
+                varWithAudienceiPhoneUsers, FeatureDecision.DECISION_SOURCE_ROLLOUT);
             Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision.ResultObject));
 
             // Calling with audience Chrome users.
-            var optimizelyUserContext2 = new OptimizelyUserContext(optlyObject, GenericUserId, new UserAttributes
-            {
-                { "browser_type", "chrome" }
-            }, ErrorHandlerMock.Object, LoggerMock.Object);
-            actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext2, ProjectConfig);
+            var optimizelyUserContext2 = new OptimizelyUserContext(optlyObject, GenericUserId,
+                new UserAttributes
+                {
+                    { "browser_type", "chrome" },
+                }, ErrorHandlerMock.Object, LoggerMock.Object);
+            actualDecision =
+                decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext2,
+                    ProjectConfig);
 
             // Returned variation id should be '177771' because of audience 'Chrome users'.
-            expectedDecision = new FeatureDecision(expWithAudienceChromeUsers, varWithAudienceChromeUsers, FeatureDecision.DECISION_SOURCE_ROLLOUT);
+            expectedDecision = new FeatureDecision(expWithAudienceChromeUsers,
+                varWithAudienceChromeUsers, FeatureDecision.DECISION_SOURCE_ROLLOUT);
             Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision.ResultObject));
 
             // Calling with no audience.
             mockBucketer.Setup(bm => bm.GenerateBucketValue(It.IsAny<string>())).Returns(8000);
-            var optimizelyUserContext3 = new OptimizelyUserContext(optlyObject, GenericUserId, new UserAttributes(), ErrorHandlerMock.Object, LoggerMock.Object);
-            actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext3, ProjectConfig);
+            var optimizelyUserContext3 = new OptimizelyUserContext(optlyObject, GenericUserId,
+                new UserAttributes(), ErrorHandlerMock.Object, LoggerMock.Object);
+            actualDecision =
+                decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext3,
+                    ProjectConfig);
 
             // Returned variation id should be of everyone else rule because of no audience.
-            expectedDecision = new FeatureDecision(expWithNoAudience, varWithNoAudience, FeatureDecision.DECISION_SOURCE_ROLLOUT);
+            expectedDecision = new FeatureDecision(expWithNoAudience, varWithNoAudience,
+                FeatureDecision.DECISION_SOURCE_ROLLOUT);
             Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision.ResultObject));
 
             // Calling with audience 'Chrome users' and traffice allocation '9500'.
             mockBucketer.Setup(bm => bm.GenerateBucketValue(It.IsAny<string>())).Returns(9500);
-            var optimizelyUserContext4 = new OptimizelyUserContext(optlyObject, GenericUserId, new UserAttributes
-            {
-                { "browser_type", "chrome" }
-            }, ErrorHandlerMock.Object, LoggerMock.Object);
-            actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext4, ProjectConfig);
+            var optimizelyUserContext4 = new OptimizelyUserContext(optlyObject, GenericUserId,
+                new UserAttributes
+                {
+                    { "browser_type", "chrome" },
+                }, ErrorHandlerMock.Object, LoggerMock.Object);
+            actualDecision =
+                decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext4,
+                    ProjectConfig);
 
             // Returned decision entity should be null because bucket value exceeds traffic allocation of everyone else rule.
             Assert.Null(actualDecision.ResultObject?.Variation?.Key);
@@ -869,41 +1108,77 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetVariationForFeatureRolloutCheckAudienceInEveryoneElseRule()
         {
-            var featureFlag = ProjectConfig.GetFeatureFlagFromKey("boolean_single_variable_feature");
+            var featureFlag =
+                ProjectConfig.GetFeatureFlagFromKey("boolean_single_variable_feature");
             var rolloutId = featureFlag.RolloutId;
             var rollout = ProjectConfig.GetRolloutFromId(rolloutId);
             var everyoneElseRule = rollout.Experiments[2];
-            var variation = Result<Variation>.NewResult(everyoneElseRule.Variations[0], DecisionReasons);
-            var expectedDecision = new FeatureDecision(everyoneElseRule, variation.ResultObject, FeatureDecision.DECISION_SOURCE_ROLLOUT);
+            var variation =
+                Result<Variation>.NewResult(everyoneElseRule.Variations[0], DecisionReasons);
+            var expectedDecision = new FeatureDecision(everyoneElseRule, variation.ResultObject,
+                FeatureDecision.DECISION_SOURCE_ROLLOUT);
 
-            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), everyoneElseRule, It.IsAny<string>(), WhitelistedUserId)).Returns(variation);
-            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), everyoneElseRule, It.IsAny<string>(), GenericUserId)).Returns(Result<Variation>.NullResult(DecisionReasons));
+            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), everyoneElseRule,
+                    It.IsAny<string>(), WhitelistedUserId)).
+                Returns(variation);
+            BucketerMock.
+                Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), everyoneElseRule,
+                    It.IsAny<string>(), GenericUserId)).
+                Returns(Result<Variation>.NullResult(DecisionReasons));
 
-            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object, null, LoggerMock.Object);
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
+            var decisionService = new DecisionService(BucketerMock.Object, ErrorHandlerMock.Object,
+                null, LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
 
             // Returned variation id should be of everyone else rule as it passes audience Id checking.
-            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, WhitelistedUserId, null, ErrorHandlerMock.Object, LoggerMock.Object);
-            var actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext, ProjectConfig);
+            var optimizelyUserContext = new OptimizelyUserContext(optlyObject, WhitelistedUserId,
+                null, ErrorHandlerMock.Object, LoggerMock.Object);
+            var actualDecision =
+                decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext,
+                    ProjectConfig);
             Assert.True(TestData.CompareObjects(expectedDecision, actualDecision.ResultObject));
 
             // Returned variation id should be null.
-            var optimizelyUserContext2 = new OptimizelyUserContext(optlyObject, GenericUserId, null, ErrorHandlerMock.Object, LoggerMock.Object);
-            actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext2, ProjectConfig);
+            var optimizelyUserContext2 = new OptimizelyUserContext(optlyObject, GenericUserId, null,
+                ErrorHandlerMock.Object, LoggerMock.Object);
+            actualDecision =
+                decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext2,
+                    ProjectConfig);
             Assert.Null(actualDecision.ResultObject);
 
             // Returned variation id should be null as it fails audience Id checking.
             everyoneElseRule.AudienceIds = new string[] { ProjectConfig.Audiences[0].Id };
 
-            BucketerMock.Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(), It.IsAny<string>(), GenericUserId)).Returns(Result<Variation>.NullResult(DecisionReasons));
-            actualDecision = decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext2, ProjectConfig) ?? Result<FeatureDecision>.NullResult(DecisionReasons);
+            BucketerMock.
+                Setup(bm => bm.Bucket(It.IsAny<ProjectConfig>(), It.IsAny<Experiment>(),
+                    It.IsAny<string>(), GenericUserId)).
+                Returns(Result<Variation>.NullResult(DecisionReasons));
+            actualDecision =
+                decisionService.GetVariationForFeatureRollout(featureFlag, optimizelyUserContext2,
+                    ProjectConfig) ?? Result<FeatureDecision>.NullResult(DecisionReasons);
             Assert.Null(actualDecision.ResultObject);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "User \"testUser1\" does not meet the conditions for targeting rule \"1\"."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "User \"testUser1\" does not meet the conditions for targeting rule \"2\"."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "User \"genericUserId\" does not meet the conditions for targeting rule \"1\"."), Times.Exactly(2));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "User \"genericUserId\" does not meet the conditions for targeting rule \"2\"."), Times.Exactly(2));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "User \"genericUserId\" does not meet the conditions for targeting rule \"3\"."), Times.Exactly(1));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    "User \"testUser1\" does not meet the conditions for targeting rule \"1\"."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    "User \"testUser1\" does not meet the conditions for targeting rule \"2\"."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    "User \"genericUserId\" does not meet the conditions for targeting rule \"1\"."),
+                Times.Exactly(2));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    "User \"genericUserId\" does not meet the conditions for targeting rule \"2\"."),
+                Times.Exactly(2));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    "User \"genericUserId\" does not meet the conditions for targeting rule \"3\"."),
+                Times.Exactly(1));
         }
 
         #endregion GetVariationForFeatureRollout Tests
@@ -918,61 +1193,94 @@ namespace OptimizelySDK.Tests
             var expectedExperimentId = featureFlag.ExperimentIds[0];
             var expectedExperiment = ProjectConfig.GetExperimentFromId(expectedExperimentId);
             var variation = expectedExperiment.Variations[0];
-            var expectedDecision = Result<FeatureDecision>.NewResult(new FeatureDecision(expectedExperiment, variation, FeatureDecision.DECISION_SOURCE_FEATURE_TEST), DecisionReasons);
+            var expectedDecision = Result<FeatureDecision>.NewResult(
+                new FeatureDecision(expectedExperiment, variation,
+                    FeatureDecision.DECISION_SOURCE_FEATURE_TEST), DecisionReasons);
 
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureExperiment(It.IsAny<FeatureFlag>(), It.IsAny<OptimizelyUserContext>(),
-                It.IsAny<UserAttributes>(), ProjectConfig, It.IsAny<OptimizelyDecideOption[]>())).Returns(expectedDecision);
+            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureExperiment(
+                    It.IsAny<FeatureFlag>(), It.IsAny<OptimizelyUserContext>(),
+                    It.IsAny<UserAttributes>(), ProjectConfig,
+                    It.IsAny<OptimizelyDecideOption[]>())).
+                Returns(expectedDecision);
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns("user1");
 
-            var actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, OptimizelyUserContextMock.Object, ProjectConfig);
+            var actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag,
+                OptimizelyUserContextMock.Object, ProjectConfig);
             Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision));
         }
 
         // Should return the bucketed variation when the user is not bucketed in the feature flag experiment,
         // but is bucketed into a variation of the feature flag's rollout.
         [Test]
-        public void TestGetVariationForFeatureWhenTheUserIsNotBucketedIntoFeatureExperimentAndBucketedToFeatureRollout()
+        public void
+            TestGetVariationForFeatureWhenTheUserIsNotBucketedIntoFeatureExperimentAndBucketedToFeatureRollout()
         {
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("string_single_variable_feature");
             var rolloutId = featureFlag.RolloutId;
             var rollout = ProjectConfig.GetRolloutFromId(rolloutId);
             var expectedExperiment = rollout.Experiments[0];
             var variation = expectedExperiment.Variations[0];
-            var expectedDecision = Result<FeatureDecision>.NewResult(new FeatureDecision(expectedExperiment, variation, FeatureDecision.DECISION_SOURCE_ROLLOUT), DecisionReasons);
+            var expectedDecision = Result<FeatureDecision>.NewResult(
+                new FeatureDecision(expectedExperiment, variation,
+                    FeatureDecision.DECISION_SOURCE_ROLLOUT), DecisionReasons);
 
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureExperiment(It.IsAny<FeatureFlag>(), It.IsAny<OptimizelyUserContext>(),
-                It.IsAny<UserAttributes>(), ProjectConfig, It.IsAny<OptimizelyDecideOption[]>())).Returns(Result<FeatureDecision>.NullResult(null));
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureRollout(It.IsAny<FeatureFlag>(), It.IsAny<OptimizelyUserContext>(),
-                ProjectConfig)).Returns(expectedDecision);
+            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureExperiment(
+                    It.IsAny<FeatureFlag>(), It.IsAny<OptimizelyUserContext>(),
+                    It.IsAny<UserAttributes>(), ProjectConfig,
+                    It.IsAny<OptimizelyDecideOption[]>())).
+                Returns(Result<FeatureDecision>.NullResult(null));
+            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureRollout(
+                    It.IsAny<FeatureFlag>(), It.IsAny<OptimizelyUserContext>(),
+                    ProjectConfig)).
+                Returns(expectedDecision);
 
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
-            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject, WhitelistedUserId, new UserAttributes(), ErrorHandlerMock.Object, LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
+            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject,
+                WhitelistedUserId, new UserAttributes(), ErrorHandlerMock.Object,
+                LoggerMock.Object);
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns(UserProfileId);
 
-            var actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, OptimizelyUserContextMock.Object, ProjectConfig);
+            var actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag,
+                OptimizelyUserContextMock.Object, ProjectConfig);
 
             Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision));
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"userProfileId\" is bucketed into a rollout for feature flag \"string_single_variable_feature\"."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "The user \"userProfileId\" is bucketed into a rollout for feature flag \"string_single_variable_feature\"."));
         }
 
         // Should return null when the user neither gets bucketed into feature experiment nor in feature rollout.
         [Test]
-        public void TestGetVariationForFeatureWhenTheUserIsNeitherBucketedIntoFeatureExperimentNorToFeatureRollout()
+        public void
+            TestGetVariationForFeatureWhenTheUserIsNeitherBucketedIntoFeatureExperimentNorToFeatureRollout()
         {
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("string_single_variable_feature");
 
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureExperiment(It.IsAny<FeatureFlag>(), It.IsAny<OptimizelyUserContext>(), It.IsAny<UserAttributes>(), ProjectConfig, new OptimizelyDecideOption[] { })).Returns(Result<FeatureDecision>.NullResult(null));
-            DecisionServiceMock.Setup(ds => ds.GetVariationForFeatureRollout(It.IsAny<FeatureFlag>(), It.IsAny<OptimizelyUserContext>(), ProjectConfig)).Returns(Result<FeatureDecision>.NullResult(null));
+            DecisionServiceMock.Setup(ds =>
+                    ds.GetVariationForFeatureExperiment(It.IsAny<FeatureFlag>(),
+                        It.IsAny<OptimizelyUserContext>(), It.IsAny<UserAttributes>(),
+                        ProjectConfig,
+                        new OptimizelyDecideOption[] { })).
+                Returns(Result<FeatureDecision>.NullResult(null));
+            DecisionServiceMock.
+                Setup(ds => ds.GetVariationForFeatureRollout(It.IsAny<FeatureFlag>(),
+                    It.IsAny<OptimizelyUserContext>(), ProjectConfig)).
+                Returns(Result<FeatureDecision>.NullResult(null));
 
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
-            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject, WhitelistedUserId, new UserAttributes(), ErrorHandlerMock.Object, LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
+            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject,
+                WhitelistedUserId, new UserAttributes(), ErrorHandlerMock.Object,
+                LoggerMock.Object);
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns(UserProfileId);
 
-            var actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, OptimizelyUserContextMock.Object, ProjectConfig);
+            var actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag,
+                OptimizelyUserContextMock.Object, ProjectConfig);
             Assert.IsNull(actualDecision.ResultObject.Variation);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The user \"userProfileId\" is not bucketed into a rollout for feature flag \"string_single_variable_feature\"."));
+            LoggerMock.Verify(l => l.Log(LogLevel.INFO,
+                "The user \"userProfileId\" is not bucketed into a rollout for feature flag \"string_single_variable_feature\"."));
         }
 
         // Verify that the user is bucketed into the experiment's variation when the user satisfies bucketing and traffic allocation
@@ -981,37 +1289,58 @@ namespace OptimizelySDK.Tests
         public void TestGetVariationForFeatureWhenTheUserIsBuckedtedInBothExperimentAndRollout()
         {
             var featureFlag = ProjectConfig.GetFeatureFlagFromKey("string_single_variable_feature");
-            var experiment = ProjectConfig.GetExperimentFromKey("test_experiment_with_feature_rollout");
-            var variation = Result<Variation>.NewResult(ProjectConfig.GetVariationFromId("test_experiment_with_feature_rollout", "122236"), DecisionReasons);
-            var expectedDecision = new FeatureDecision(experiment, variation.ResultObject, FeatureDecision.DECISION_SOURCE_FEATURE_TEST);
-            var userAttributes = new UserAttributes {
-                { "browser_type", "chrome" }
+            var experiment =
+                ProjectConfig.GetExperimentFromKey("test_experiment_with_feature_rollout");
+            var variation = Result<Variation>.NewResult(
+                ProjectConfig.GetVariationFromId("test_experiment_with_feature_rollout", "122236"),
+                DecisionReasons);
+            var expectedDecision = new FeatureDecision(experiment, variation.ResultObject,
+                FeatureDecision.DECISION_SOURCE_FEATURE_TEST);
+            var userAttributes = new UserAttributes
+            {
+                { "browser_type", "chrome" },
             };
 
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
 
-            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject, WhitelistedUserId, userAttributes, ErrorHandlerMock.Object, LoggerMock.Object);
+            OptimizelyUserContextMock = new Mock<OptimizelyUserContext>(optlyObject,
+                WhitelistedUserId, userAttributes, ErrorHandlerMock.Object, LoggerMock.Object);
             OptimizelyUserContextMock.Setup(ouc => ouc.GetUserId()).Returns(UserProfileId);
 
-            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment, OptimizelyUserContextMock.Object, ProjectConfig, It.IsAny<OptimizelyDecideOption[]>())).Returns(variation);
-            var actualDecision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(featureFlag, OptimizelyUserContextMock.Object, userAttributes, ProjectConfig, new OptimizelyDecideOption[] { });
+            DecisionServiceMock.Setup(ds => ds.GetVariation(experiment,
+                    OptimizelyUserContextMock.Object, ProjectConfig,
+                    It.IsAny<OptimizelyDecideOption[]>())).
+                Returns(variation);
+            var actualDecision = DecisionServiceMock.Object.GetVariationForFeatureExperiment(
+                featureFlag, OptimizelyUserContextMock.Object, userAttributes, ProjectConfig,
+                new OptimizelyDecideOption[] { });
 
             // The user is bucketed into feature experiment's variation.
             Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision.ResultObject));
 
             var rollout = ProjectConfig.GetRolloutFromId(featureFlag.RolloutId);
             var rolloutExperiment = rollout.Experiments[0];
-            var rolloutVariation = Result<Variation>.NewResult(rolloutExperiment.Variations[0], DecisionReasons);
-            var expectedRolloutDecision = new FeatureDecision(rolloutExperiment, rolloutVariation.ResultObject, FeatureDecision.DECISION_SOURCE_ROLLOUT);
+            var rolloutVariation =
+                Result<Variation>.NewResult(rolloutExperiment.Variations[0], DecisionReasons);
+            var expectedRolloutDecision = new FeatureDecision(rolloutExperiment,
+                rolloutVariation.ResultObject, FeatureDecision.DECISION_SOURCE_ROLLOUT);
 
-            BucketerMock.Setup(bm => bm.Bucket(ProjectConfig, rolloutExperiment, It.IsAny<string>(), It.IsAny<string>())).Returns(rolloutVariation);
-            var actualRolloutDecision = DecisionServiceMock.Object.GetVariationForFeatureRollout(featureFlag, OptimizelyUserContextMock.Object, ProjectConfig);
+            BucketerMock.
+                Setup(bm => bm.Bucket(ProjectConfig, rolloutExperiment, It.IsAny<string>(),
+                    It.IsAny<string>())).
+                Returns(rolloutVariation);
+            var actualRolloutDecision =
+                DecisionServiceMock.Object.GetVariationForFeatureRollout(featureFlag,
+                    OptimizelyUserContextMock.Object, ProjectConfig);
 
             // The user is bucketed into feature rollout's variation.
 
-            Assert.IsTrue(TestData.CompareObjects(expectedRolloutDecision, actualRolloutDecision.ResultObject));
+            Assert.IsTrue(TestData.CompareObjects(expectedRolloutDecision,
+                actualRolloutDecision.ResultObject));
 
-            actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag, OptimizelyUserContextMock.Object, ProjectConfig);
+            actualDecision = DecisionServiceMock.Object.GetVariationForFeature(featureFlag,
+                OptimizelyUserContextMock.Object, ProjectConfig);
 
             // The user is bucketed into feature experiment's variation and not the rollout's variation.
             Assert.IsTrue(TestData.CompareObjects(expectedDecision, actualDecision.ResultObject));
@@ -1035,45 +1364,58 @@ namespace OptimizelySDK.Tests
 
             var userAttributes = new UserAttributes
             {
-                {"device_type", "iPhone" },
-                {"location", "San Francisco" }
+                { "device_type", "iPhone" },
+                { "location", "San Francisco" },
             };
 
-            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(), LoggerMock.Object);
+            var optlyObject = new Optimizely(TestData.Datafile, new ValidEventDispatcher(),
+                LoggerMock.Object);
             optlyObject.Activate("test_experiment", "test_user", userAttributes);
 
             // invalid experiment key should return a null variation
-            Assert.False(DecisionService.SetForcedVariation(invalidExperimentKey, userId, expectedVariationKey, Config));
-            Assert.Null(DecisionService.GetForcedVariation(invalidExperimentKey, userId, Config).ResultObject);
+            Assert.False(DecisionService.SetForcedVariation(invalidExperimentKey, userId,
+                expectedVariationKey, Config));
+            Assert.Null(DecisionService.GetForcedVariation(invalidExperimentKey, userId, Config).
+                ResultObject);
 
             // setting a null variation should return a null variation
             Assert.True(DecisionService.SetForcedVariation(experimentKey, userId, null, Config));
-            Assert.Null(DecisionService.GetForcedVariation(experimentKey, userId, Config).ResultObject);
+            Assert.Null(DecisionService.GetForcedVariation(experimentKey, userId, Config).
+                ResultObject);
 
             // setting an invalid variation should return a null variation
-            Assert.False(DecisionService.SetForcedVariation(experimentKey, userId, invalidVariationKey, Config));
-            Assert.Null(DecisionService.GetForcedVariation(experimentKey, userId, Config).ResultObject);
+            Assert.False(DecisionService.SetForcedVariation(experimentKey, userId,
+                invalidVariationKey, Config));
+            Assert.Null(DecisionService.GetForcedVariation(experimentKey, userId, Config).
+                ResultObject);
 
             // confirm the forced variation is returned after a set
-            Assert.True(DecisionService.SetForcedVariation(experimentKey, userId, expectedVariationKey, Config));
-            var actualForcedVariation = DecisionService.GetForcedVariation(experimentKey, userId, Config);
+            Assert.True(DecisionService.SetForcedVariation(experimentKey, userId,
+                expectedVariationKey, Config));
+            var actualForcedVariation =
+                DecisionService.GetForcedVariation(experimentKey, userId, Config);
             Assert.AreEqual(expectedVariationKey, actualForcedVariation.ResultObject.Key);
 
             // check multiple sets
-            Assert.True(DecisionService.SetForcedVariation(experimentKey2, userId, expectedVariationKey2, Config));
-            var actualForcedVariation2 = DecisionService.GetForcedVariation(experimentKey2, userId, Config);
+            Assert.True(DecisionService.SetForcedVariation(experimentKey2, userId,
+                expectedVariationKey2, Config));
+            var actualForcedVariation2 =
+                DecisionService.GetForcedVariation(experimentKey2, userId, Config);
             Assert.AreEqual(expectedVariationKey2, actualForcedVariation2.ResultObject.Key);
             // make sure the second set does not overwrite the first set
-            actualForcedVariation = DecisionService.GetForcedVariation(experimentKey, userId, Config);
+            actualForcedVariation =
+                DecisionService.GetForcedVariation(experimentKey, userId, Config);
             Assert.AreEqual(expectedVariationKey, actualForcedVariation.ResultObject.Key);
             // make sure unsetting the second experiment-to-variation mapping does not unset the
             // first experiment-to-variation mapping
             Assert.True(DecisionService.SetForcedVariation(experimentKey2, userId, null, Config));
-            actualForcedVariation = DecisionService.GetForcedVariation(experimentKey, userId, Config);
+            actualForcedVariation =
+                DecisionService.GetForcedVariation(experimentKey, userId, Config);
             Assert.AreEqual(expectedVariationKey, actualForcedVariation.ResultObject.Key);
 
             // an invalid user ID should return a null variation
-            Assert.Null(DecisionService.GetForcedVariation(experimentKey, invalidUserId, Config).ResultObject);
+            Assert.Null(DecisionService.GetForcedVariation(experimentKey, invalidUserId, Config).
+                ResultObject);
         }
 
         // test that all the logs in setForcedVariation are getting called
@@ -1093,11 +1435,23 @@ namespace OptimizelySDK.Tests
             DecisionService.SetForcedVariation(experimentKey, userId, invalidVariationKey, Config);
             DecisionService.SetForcedVariation(experimentKey, userId, variationKey, Config);
 
-            LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(4));
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, string.Format(@"Experiment key ""{0}"" is not in datafile.", invalidExperimentKey)));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, string.Format(@"Variation mapped to experiment ""{0}"" has been removed for user ""{1}"".", experimentKey, userId)));
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, string.Format(@"No variation key ""{0}"" defined in datafile for experiment ""{1}"".", invalidVariationKey, experimentKey)));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, string.Format(@"Set variation ""{0}"" for experiment ""{1}"" and user ""{2}"" in the forced variation map.", variationId, experimentId, userId)));
+            LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()),
+                Times.Exactly(4));
+            LoggerMock.Verify(l => l.Log(LogLevel.ERROR,
+                string.Format(@"Experiment key ""{0}"" is not in datafile.",
+                    invalidExperimentKey)));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                string.Format(
+                    @"Variation mapped to experiment ""{0}"" has been removed for user ""{1}"".",
+                    experimentKey, userId)));
+            LoggerMock.Verify(l => l.Log(LogLevel.ERROR,
+                string.Format(
+                    @"No variation key ""{0}"" defined in datafile for experiment ""{1}"".",
+                    invalidVariationKey, experimentKey)));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                string.Format(
+                    @"Set variation ""{0}"" for experiment ""{1}"" and user ""{2}"" in the forced variation map.",
+                    variationId, experimentId, userId)));
         }
 
         // test that all the logs in getForcedVariation are getting called
@@ -1119,39 +1473,71 @@ namespace OptimizelySDK.Tests
             DecisionService.GetForcedVariation(pausedExperimentKey, userId, Config);
             DecisionService.GetForcedVariation(experimentKey, userId, Config);
 
-            LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Exactly(5));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, string.Format(@"Set variation ""{0}"" for experiment ""{1}"" and user ""{2}"" in the forced variation map.", variationId, experimentId, userId)));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, string.Format(@"User ""{0}"" is not in the forced variation map.", invalidUserId)));
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, string.Format(@"Experiment key ""{0}"" is not in datafile.", invalidExperimentKey)));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, string.Format(@"No experiment ""{0}"" mapped to user ""{1}"" in the forced variation map.", pausedExperimentKey, userId)));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, string.Format(@"Variation ""{0}"" is mapped to experiment ""{1}"" and user ""{2}"" in the forced variation map", variationKey, experimentKey, userId)));
+            LoggerMock.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()),
+                Times.Exactly(5));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                string.Format(
+                    @"Set variation ""{0}"" for experiment ""{1}"" and user ""{2}"" in the forced variation map.",
+                    variationId, experimentId, userId)));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                string.Format(@"User ""{0}"" is not in the forced variation map.", invalidUserId)));
+            LoggerMock.Verify(l => l.Log(LogLevel.ERROR,
+                string.Format(@"Experiment key ""{0}"" is not in datafile.",
+                    invalidExperimentKey)));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                string.Format(
+                    @"No experiment ""{0}"" mapped to user ""{1}"" in the forced variation map.",
+                    pausedExperimentKey, userId)));
+            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG,
+                string.Format(
+                    @"Variation ""{0}"" is mapped to experiment ""{1}"" and user ""{2}"" in the forced variation map",
+                    variationKey, experimentKey, userId)));
         }
 
         [Test]
         public void TestSetForcedVariationMultipleSets()
         {
-            Assert.True(DecisionService.SetForcedVariation("test_experiment", "test_user_1", "variation", Config));
-            Assert.AreEqual(DecisionService.GetForcedVariation("test_experiment", "test_user_1", Config).ResultObject.Key, "variation");
+            Assert.True(DecisionService.SetForcedVariation("test_experiment", "test_user_1",
+                "variation", Config));
+            Assert.AreEqual(
+                DecisionService.GetForcedVariation("test_experiment", "test_user_1", Config).
+                    ResultObject.Key, "variation");
 
             // same user, same experiment, different variation
-            Assert.True(DecisionService.SetForcedVariation("test_experiment", "test_user_1", "control", Config));
-            Assert.AreEqual(DecisionService.GetForcedVariation("test_experiment", "test_user_1", Config).ResultObject.Key, "control");
+            Assert.True(DecisionService.SetForcedVariation("test_experiment", "test_user_1",
+                "control", Config));
+            Assert.AreEqual(
+                DecisionService.GetForcedVariation("test_experiment", "test_user_1", Config).
+                    ResultObject.Key, "control");
 
             // same user, different experiment
-            Assert.True(DecisionService.SetForcedVariation("group_experiment_1", "test_user_1", "group_exp_1_var_1", Config));
-            Assert.AreEqual(DecisionService.GetForcedVariation("group_experiment_1", "test_user_1", Config).ResultObject.Key, "group_exp_1_var_1");
+            Assert.True(DecisionService.SetForcedVariation("group_experiment_1", "test_user_1",
+                "group_exp_1_var_1", Config));
+            Assert.AreEqual(
+                DecisionService.GetForcedVariation("group_experiment_1", "test_user_1", Config).
+                    ResultObject.Key, "group_exp_1_var_1");
 
             // different user
-            Assert.True(DecisionService.SetForcedVariation("test_experiment", "test_user_2", "variation", Config));
-            Assert.AreEqual(DecisionService.GetForcedVariation("test_experiment", "test_user_2", Config).ResultObject.Key, "variation");
+            Assert.True(DecisionService.SetForcedVariation("test_experiment", "test_user_2",
+                "variation", Config));
+            Assert.AreEqual(
+                DecisionService.GetForcedVariation("test_experiment", "test_user_2", Config).
+                    ResultObject.Key, "variation");
 
             // different user, different experiment
-            Assert.True(DecisionService.SetForcedVariation("group_experiment_1", "test_user_2", "group_exp_1_var_1", Config));
-            Assert.AreEqual(DecisionService.GetForcedVariation("group_experiment_1", "test_user_2", Config).ResultObject.Key, "group_exp_1_var_1");
+            Assert.True(DecisionService.SetForcedVariation("group_experiment_1", "test_user_2",
+                "group_exp_1_var_1", Config));
+            Assert.AreEqual(
+                DecisionService.GetForcedVariation("group_experiment_1", "test_user_2", Config).
+                    ResultObject.Key, "group_exp_1_var_1");
 
             // make sure the first user forced variations are still valid
-            Assert.AreEqual(DecisionService.GetForcedVariation("test_experiment", "test_user_1", Config).ResultObject.Key, "control");
-            Assert.AreEqual(DecisionService.GetForcedVariation("group_experiment_1", "test_user_1", Config).ResultObject.Key, "group_exp_1_var_1");
+            Assert.AreEqual(
+                DecisionService.GetForcedVariation("test_experiment", "test_user_1", Config).
+                    ResultObject.Key, "control");
+            Assert.AreEqual(
+                DecisionService.GetForcedVariation("group_experiment_1", "test_user_1", Config).
+                    ResultObject.Key, "group_exp_1_var_1");
         }
 
         #endregion Forced variation Tests

--- a/OptimizelySDK.Tests/DefaultErrorHandlerTest.cs
+++ b/OptimizelySDK.Tests/DefaultErrorHandlerTest.cs
@@ -14,6 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
+
 using System;
 using System.Collections.Generic;
 using Moq;
@@ -41,12 +42,12 @@ namespace OptimizelySDK.Tests
         public void TestErrorHandlerMessage()
         {
             DefaultErrorHandler = new DefaultErrorHandler(LoggerMock.Object, false);
-            string testingException = "Testing exception";
+            var testingException = "Testing exception";
             try
             {
                 throw new OptimizelyException("Testing exception");
             }
-            catch(OptimizelyException ex)
+            catch (OptimizelyException ex)
             {
                 DefaultErrorHandler.HandleError(ex);
             }
@@ -54,12 +55,11 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(log => log.Log(LogLevel.ERROR, testingException), Times.Once);
         }
 
-        [Test]
-        [ExpectedException]
+        [Test, ExpectedException]
         public void TestErrorHandlerMessageWithThrowException()
         {
             DefaultErrorHandler = new DefaultErrorHandler(LoggerMock.Object, true);
-            string testingException = "Testing and throwing exception";
+            var testingException = "Testing and throwing exception";
             try
             {
                 throw new OptimizelyException("Testing exception");
@@ -72,6 +72,5 @@ namespace OptimizelySDK.Tests
 
             LoggerMock.Verify(log => log.Log(LogLevel.ERROR, testingException), Times.Once);
         }
-
     }
 }

--- a/OptimizelySDK.Tests/DefaultErrorHandlerTest.cs
+++ b/OptimizelySDK.Tests/DefaultErrorHandlerTest.cs
@@ -18,12 +18,12 @@
 using System;
 using System.Collections.Generic;
 using Moq;
-using OptimizelySDK.Logger;
-using OptimizelySDK.ErrorHandler;
-using OptimizelySDK.Entity;
 using NUnit.Framework;
 using OptimizelySDK.Bucketing;
+using OptimizelySDK.Entity;
+using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Exceptions;
+using OptimizelySDK.Logger;
 
 namespace OptimizelySDK.Tests
 {

--- a/OptimizelySDK.Tests/EntityTests/FeatureVariableTest.cs
+++ b/OptimizelySDK.Tests/EntityTests/FeatureVariableTest.cs
@@ -1,4 +1,4 @@
-/* 
+﻿/* 
  * Copyright 2019-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/OptimizelySDK.Tests/EntityTests/FeatureVariableTest.cs
+++ b/OptimizelySDK.Tests/EntityTests/FeatureVariableTest.cs
@@ -26,11 +26,18 @@ namespace OptimizelySDK.Tests.EntityTests
         [Test]
         public void TestFeatureVariableTypeName()
         {
-            Assert.AreEqual(FeatureVariable.GetFeatureVariableTypeName(FeatureVariable.BOOLEAN_TYPE), "GetFeatureVariableBoolean");
-            Assert.AreEqual(FeatureVariable.GetFeatureVariableTypeName(FeatureVariable.DOUBLE_TYPE), "GetFeatureVariableDouble");
-            Assert.AreEqual(FeatureVariable.GetFeatureVariableTypeName(FeatureVariable.INTEGER_TYPE), "GetFeatureVariableInteger");
-            Assert.AreEqual(FeatureVariable.GetFeatureVariableTypeName(FeatureVariable.STRING_TYPE), "GetFeatureVariableString");
-            Assert.AreEqual(FeatureVariable.GetFeatureVariableTypeName(FeatureVariable.JSON_TYPE), "GetFeatureVariableJSON");
+            Assert.AreEqual(
+                FeatureVariable.GetFeatureVariableTypeName(FeatureVariable.BOOLEAN_TYPE),
+                "GetFeatureVariableBoolean");
+            Assert.AreEqual(FeatureVariable.GetFeatureVariableTypeName(FeatureVariable.DOUBLE_TYPE),
+                "GetFeatureVariableDouble");
+            Assert.AreEqual(
+                FeatureVariable.GetFeatureVariableTypeName(FeatureVariable.INTEGER_TYPE),
+                "GetFeatureVariableInteger");
+            Assert.AreEqual(FeatureVariable.GetFeatureVariableTypeName(FeatureVariable.STRING_TYPE),
+                "GetFeatureVariableString");
+            Assert.AreEqual(FeatureVariable.GetFeatureVariableTypeName(FeatureVariable.JSON_TYPE),
+                "GetFeatureVariableJSON");
         }
 
         [Test]

--- a/OptimizelySDK.Tests/EventTests/BatchEventProcessorTest.cs
+++ b/OptimizelySDK.Tests/EventTests/BatchEventProcessorTest.cs
@@ -1,4 +1,7 @@
-﻿using Moq;
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using Moq;
 using NUnit.Framework;
 using OptimizelySDK.Config;
 using OptimizelySDK.Entity;
@@ -9,9 +12,6 @@ using OptimizelySDK.Event.Entity;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Notifications;
 using OptimizelySDK.Tests.NotificationTests;
-using System;
-using System.Collections.Concurrent;
-using System.Threading;
 
 namespace OptimizelySDK.Tests.EventTests
 {
@@ -98,7 +98,7 @@ namespace OptimizelySDK.Tests.EventTests
         {
             var countdownEvent = new CountdownEvent(1);
             var eventDispatcher = new TestEventDispatcher(countdownEvent)
-                { Logger = LoggerMock.Object };
+            { Logger = LoggerMock.Object };
             SetEventProcessor(eventDispatcher);
 
             for (var i = 0; i < MAX_BATCH_SIZE; i++)

--- a/OptimizelySDK.Tests/EventTests/BatchEventProcessorTest.cs
+++ b/OptimizelySDK.Tests/EventTests/BatchEventProcessorTest.cs
@@ -16,7 +16,7 @@ using System.Threading;
 namespace OptimizelySDK.Tests.EventTests
 {
     [TestFixture]
-    class BatchEventProcessorTest
+    internal class BatchEventProcessorTest
     {
         private static string TestUserId = "testUserId";
         private const string EventName = "purchase";
@@ -24,12 +24,12 @@ namespace OptimizelySDK.Tests.EventTests
         public const int MAX_BATCH_SIZE = 10;
         public const int MAX_DURATION_MS = 1000;
         public const int TIMEOUT_INTERVAL_MS = 5000;
-        
+
         private ProjectConfig Config;
         private Mock<ILogger> LoggerMock;
         private BlockingCollection<object> eventQueue;
         private BatchEventProcessor EventProcessor;
-        private Mock<IEventDispatcher> EventDispatcherMock;        
+        private Mock<IEventDispatcher> EventDispatcherMock;
         private NotificationCenter NotificationCenter = new NotificationCenter();
         private Mock<TestNotificationCallbacks> NotificationCallbackMock;
 
@@ -39,8 +39,9 @@ namespace OptimizelySDK.Tests.EventTests
             LoggerMock = new Mock<ILogger>();
             LoggerMock.Setup(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()));
 
-            Config = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object, new ErrorHandler.NoOpErrorHandler());
-            
+            Config = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object,
+                new NoOpErrorHandler());
+
             eventQueue = new BlockingCollection<object>(100);
             EventDispatcherMock = new Mock<IEventDispatcher>();
 
@@ -56,7 +57,7 @@ namespace OptimizelySDK.Tests.EventTests
         {
             EventProcessor.Stop();
         }
-        
+
         [Test]
         public void TestDrainOnClose()
         {
@@ -68,7 +69,7 @@ namespace OptimizelySDK.Tests.EventTests
             eventDispatcher.ExpectConversion(EventName, TestUserId);
 
             Thread.Sleep(1500);
-            
+
             Assert.True(eventDispatcher.CompareEvents());
             Assert.AreEqual(0, EventProcessor.EventQueue.Count);
         }
@@ -87,7 +88,8 @@ namespace OptimizelySDK.Tests.EventTests
             Thread.Sleep(1500);
 
             Assert.True(eventDispatcher.CompareEvents());
-            Assert.True(countdownEvent.Wait(TimeSpan.FromMilliseconds(MAX_DURATION_MS * 3)), "Exceeded timeout waiting for notification.");
+            Assert.True(countdownEvent.Wait(TimeSpan.FromMilliseconds(MAX_DURATION_MS * 3)),
+                "Exceeded timeout waiting for notification.");
             Assert.AreEqual(0, EventProcessor.EventQueue.Count);
         }
 
@@ -95,10 +97,11 @@ namespace OptimizelySDK.Tests.EventTests
         public void TestFlushMaxBatchSize()
         {
             var countdownEvent = new CountdownEvent(1);
-            var eventDispatcher = new TestEventDispatcher(countdownEvent) { Logger = LoggerMock.Object };
+            var eventDispatcher = new TestEventDispatcher(countdownEvent)
+                { Logger = LoggerMock.Object };
             SetEventProcessor(eventDispatcher);
 
-            for (int i = 0; i < MAX_BATCH_SIZE; i++)
+            for (var i = 0; i < MAX_BATCH_SIZE; i++)
             {
                 UserEvent userEvent = BuildConversionEvent(EventName);
                 EventProcessor.Process(userEvent);
@@ -133,7 +136,8 @@ namespace OptimizelySDK.Tests.EventTests
             Thread.Sleep(1500);
 
             Assert.True(eventDispatcher.CompareEvents());
-            Assert.True(countdownEvent.Wait(TimeSpan.FromMilliseconds(MAX_DURATION_MS / 2)), "Exceeded timeout waiting for notification.");
+            Assert.True(countdownEvent.Wait(TimeSpan.FromMilliseconds(MAX_DURATION_MS / 2)),
+                "Exceeded timeout waiting for notification.");
             Assert.AreEqual(0, EventProcessor.EventQueue.Count);
         }
 
@@ -150,7 +154,7 @@ namespace OptimizelySDK.Tests.EventTests
         {
             EventProcessor = new BatchEventProcessor.Builder().Build();
 
-            Assert.True(EventProcessor.Logger is OptimizelySDK.Logger.NoOpLogger);
+            Assert.True(EventProcessor.Logger is NoOpLogger);
         }
 
         [Test]
@@ -182,7 +186,8 @@ namespace OptimizelySDK.Tests.EventTests
             Thread.Sleep(1500);
 
             Assert.True(eventDispatcher.CompareEvents());
-            Assert.True(countdownEvent.Wait(TimeSpan.FromMilliseconds(MAX_DURATION_MS * 3)), "Exceeded timeout waiting for notification.");
+            Assert.True(countdownEvent.Wait(TimeSpan.FromMilliseconds(MAX_DURATION_MS * 3)),
+                "Exceeded timeout waiting for notification.");
         }
 
         [Test]
@@ -207,7 +212,8 @@ namespace OptimizelySDK.Tests.EventTests
             Thread.Sleep(1500);
 
             Assert.True(eventDispatcher.CompareEvents());
-            Assert.True(countdownEvent.Wait(TimeSpan.FromMilliseconds(MAX_DURATION_MS * 3)), "Exceeded timeout waiting for notification.");
+            Assert.True(countdownEvent.Wait(TimeSpan.FromMilliseconds(MAX_DURATION_MS * 3)),
+                "Exceeded timeout waiting for notification.");
             Assert.AreEqual(0, EventProcessor.EventQueue.Count);
         }
 
@@ -231,7 +237,8 @@ namespace OptimizelySDK.Tests.EventTests
             EventProcessor.Start();
             EventProcessor.Stop();
 
-            Assert.True(countdownEvent.Wait(TimeSpan.FromMilliseconds(MAX_DURATION_MS * 3)), "Exceeded timeout waiting for notification.");
+            Assert.True(countdownEvent.Wait(TimeSpan.FromMilliseconds(MAX_DURATION_MS * 3)),
+                "Exceeded timeout waiting for notification.");
         }
 
         [Test]
@@ -277,21 +284,22 @@ namespace OptimizelySDK.Tests.EventTests
 
             // Need to make sure, after dispose, process shouldn't raise exception
             EventProcessor.Process(userEvent);
-
         }
 
         [Test]
         public void TestNotificationCenter()
         {
             var countdownEvent = new CountdownEvent(1);
-            NotificationCenter.AddNotification(NotificationCenter.NotificationType.LogEvent, logEvent => countdownEvent.Signal());
+            NotificationCenter.AddNotification(NotificationCenter.NotificationType.LogEvent,
+                logEvent => countdownEvent.Signal());
             SetEventProcessor(EventDispatcherMock.Object);
 
             UserEvent userEvent = BuildConversionEvent(EventName);
             EventProcessor.Process(userEvent);
-            
+
             EventProcessor.Stop();
-            Assert.True(countdownEvent.Wait(TimeSpan.FromMilliseconds(MAX_DURATION_MS * 3)), "Exceeded timeout waiting for notification.");
+            Assert.True(countdownEvent.Wait(TimeSpan.FromMilliseconds(MAX_DURATION_MS * 3)),
+                "Exceeded timeout waiting for notification.");
         }
 
         [Test]
@@ -310,15 +318,14 @@ namespace OptimizelySDK.Tests.EventTests
 
         private void SetEventProcessor(IEventDispatcher eventDispatcher)
         {
-            EventProcessor = new BatchEventProcessor.Builder()
-                .WithEventQueue(eventQueue)
-                .WithEventDispatcher(eventDispatcher)
-                .WithMaxBatchSize(MAX_BATCH_SIZE)
-                .WithFlushInterval(TimeSpan.FromMilliseconds(MAX_DURATION_MS))
-                .WithTimeoutInterval(TimeSpan.FromMilliseconds(TIMEOUT_INTERVAL_MS))
-                .WithLogger(LoggerMock.Object)
-                .WithNotificationCenter(NotificationCenter)
-                .Build();
+            EventProcessor = new BatchEventProcessor.Builder().WithEventQueue(eventQueue).
+                WithEventDispatcher(eventDispatcher).
+                WithMaxBatchSize(MAX_BATCH_SIZE).
+                WithFlushInterval(TimeSpan.FromMilliseconds(MAX_DURATION_MS)).
+                WithTimeoutInterval(TimeSpan.FromMilliseconds(TIMEOUT_INTERVAL_MS)).
+                WithLogger(LoggerMock.Object).
+                WithNotificationCenter(NotificationCenter).
+                Build();
         }
 
         private ConversionEvent BuildConversionEvent(string eventName)
@@ -326,17 +333,24 @@ namespace OptimizelySDK.Tests.EventTests
             return BuildConversionEvent(eventName, Config);
         }
 
-        private static ConversionEvent BuildConversionEvent(string eventName, ProjectConfig projectConfig)
+        private static ConversionEvent BuildConversionEvent(string eventName,
+            ProjectConfig projectConfig
+        )
         {
             return UserEventFactory.CreateConversionEvent(projectConfig, eventName, TestUserId,
                 new UserAttributes(), new EventTags());
         }
     }
 
-    class CountdownEventDispatcher : IEventDispatcher
+    internal class CountdownEventDispatcher : IEventDispatcher
     {
         public ILogger Logger { get; set; }
         public CountdownEvent CountdownEvent { get; set; }
-        public void DispatchEvent(LogEvent logEvent) => Assert.False(!CountdownEvent.Wait(TimeSpan.FromMilliseconds(BatchEventProcessorTest.TIMEOUT_INTERVAL_MS * 2)));
+
+        public void DispatchEvent(LogEvent logEvent)
+        {
+            Assert.False(!CountdownEvent.Wait(
+                TimeSpan.FromMilliseconds(BatchEventProcessorTest.TIMEOUT_INTERVAL_MS * 2)));
+        }
     }
 }

--- a/OptimizelySDK.Tests/EventTests/CanonicalEvent.cs
+++ b/OptimizelySDK.Tests/EventTests/CanonicalEvent.cs
@@ -1,7 +1,7 @@
-﻿using OptimizelySDK.Entity;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using OptimizelySDK.Entity;
 
 namespace OptimizelySDK.Tests.EventTests
 {

--- a/OptimizelySDK.Tests/EventTests/CanonicalEvent.cs
+++ b/OptimizelySDK.Tests/EventTests/CanonicalEvent.cs
@@ -14,7 +14,9 @@ namespace OptimizelySDK.Tests.EventTests
         private UserAttributes Attributes;
         private EventTags Tags;
 
-        public CanonicalEvent(string experimentId, string variationId, string eventName, string visitorId, UserAttributes attributes, EventTags tags)
+        public CanonicalEvent(string experimentId, string variationId, string eventName,
+            string visitorId, UserAttributes attributes, EventTags tags
+        )
         {
             ExperimentId = experimentId;
             VariationId = variationId;
@@ -24,29 +26,39 @@ namespace OptimizelySDK.Tests.EventTests
             Attributes = attributes ?? new UserAttributes();
             Tags = tags ?? new EventTags();
         }
-        
+
         public override bool Equals(object obj)
         {
             if (obj == null)
+            {
                 return false;
+            }
 
-            CanonicalEvent canonicalEvent = obj as CanonicalEvent;
+            var canonicalEvent = obj as CanonicalEvent;
             if (canonicalEvent == null)
+            {
                 return false;
+            }
 
             if (ExperimentId != canonicalEvent.ExperimentId ||
                 VariationId != canonicalEvent.VariationId ||
                 EventName != canonicalEvent.EventName ||
                 VisitorId != canonicalEvent.VisitorId)
+            {
                 return false;
+            }
 
-            if (!Attributes.OrderBy(pair => pair.Key)
-                .SequenceEqual(canonicalEvent.Attributes.OrderBy(pair => pair.Key)))
+            if (!Attributes.OrderBy(pair => pair.Key).
+                    SequenceEqual(canonicalEvent.Attributes.OrderBy(pair => pair.Key)))
+            {
                 return false;
+            }
 
-            if (!Tags.OrderBy(pair => pair.Key)
-                .SequenceEqual(canonicalEvent.Tags.OrderBy(pair => pair.Key)))
+            if (!Tags.OrderBy(pair => pair.Key).
+                    SequenceEqual(canonicalEvent.Tags.OrderBy(pair => pair.Key)))
+            {
                 return false;
+            }
 
             return true;
         }
@@ -54,21 +66,29 @@ namespace OptimizelySDK.Tests.EventTests
         public override int GetHashCode()
         {
             var hashCode = -907746114;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(ExperimentId);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(VariationId);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventName);
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(VisitorId);
-            hashCode = hashCode * -1521134295 + EqualityComparer<Dictionary<string, object>>.Default.GetHashCode(Attributes);
-            hashCode = hashCode * -1521134295 + EqualityComparer<EventTags>.Default.GetHashCode(Tags);
+            hashCode = (hashCode * -1521134295) +
+                       EqualityComparer<string>.Default.GetHashCode(ExperimentId);
+            hashCode = (hashCode * -1521134295) +
+                       EqualityComparer<string>.Default.GetHashCode(VariationId);
+            hashCode = (hashCode * -1521134295) +
+                       EqualityComparer<string>.Default.GetHashCode(EventName);
+            hashCode = (hashCode * -1521134295) +
+                       EqualityComparer<string>.Default.GetHashCode(VisitorId);
+            hashCode = (hashCode * -1521134295) +
+                       EqualityComparer<Dictionary<string, object>>.Default.GetHashCode(Attributes);
+            hashCode = (hashCode * -1521134295) +
+                       EqualityComparer<EventTags>.Default.GetHashCode(Tags);
             return hashCode;
         }
 
         public static bool operator ==(CanonicalEvent lhs, CanonicalEvent rhs)
         {
-            if (Object.ReferenceEquals(lhs, null))
+            if (ReferenceEquals(lhs, null))
             {
-                if (Object.ReferenceEquals(rhs, null))
+                if (ReferenceEquals(rhs, null))
+                {
                     return true;
+                }
 
                 return false;
             }

--- a/OptimizelySDK.Tests/EventTests/DefaultEventDispatcherTest.cs
+++ b/OptimizelySDK.Tests/EventTests/DefaultEventDispatcherTest.cs
@@ -20,22 +20,22 @@ namespace OptimizelySDK.Tests.EventTests
             var logEvent = new LogEvent("",
                 new Dictionary<string, object>
                 {
-                    {"accountId", "1234" },
-                    {"projectId", "9876" },
-                    {"visitorId", "testUser" }
+                    { "accountId", "1234" },
+                    { "projectId", "9876" },
+                    { "visitorId", "testUser" },
                 },
                 "POST",
                 new Dictionary<string, string>
                 {
-                    {"Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
 
             var expectionedOptions = new Dictionary<string, object>
             {
-                {"headers", logEvent.Headers },
-                {"json", logEvent.Params },
-                {"timeout", 10 },
-                {"connect_timeout", 10 }
+                { "headers", logEvent.Headers },
+                { "json", logEvent.Params },
+                { "timeout", 10 },
+                { "connect_timeout", 10 },
             };
 
             //TODO: Have to mock http calls. Will discuss with Randall.

--- a/OptimizelySDK.Tests/EventTests/DefaultEventDispatcherTest.cs
+++ b/OptimizelySDK.Tests/EventTests/DefaultEventDispatcherTest.cs
@@ -1,13 +1,13 @@
-﻿using OptimizelySDK.Entity;
-using OptimizelySDK.Logger;
-using Moq;
-using OptimizelySDK.Event.Builder;
-using OptimizelySDK.Event;
+﻿using System;
 using System.Collections.Generic;
+using Moq;
 using Newtonsoft.Json.Linq;
-using System;
-using OptimizelySDK.Event.Dispatcher;
 using NUnit.Framework;
+using OptimizelySDK.Entity;
+using OptimizelySDK.Event;
+using OptimizelySDK.Event.Builder;
+using OptimizelySDK.Event.Dispatcher;
+using OptimizelySDK.Logger;
 
 namespace OptimizelySDK.Tests.EventTests
 {

--- a/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
@@ -1,4 +1,4 @@
-/* 
+﻿/* 
  * Copyright 2017-2019, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Entity;
-using OptimizelySDK.Logger;
-using OptimizelySDK.Event.Builder;
-using OptimizelySDK.Event;
-using System.Collections.Generic;
 using System;
+using System.Collections.Generic;
 using NUnit.Framework;
 using OptimizelySDK.Bucketing;
-using OptimizelySDK.Utils;
 using OptimizelySDK.Config;
+using OptimizelySDK.Entity;
+using OptimizelySDK.Event;
+using OptimizelySDK.Event.Builder;
+using OptimizelySDK.Logger;
+using OptimizelySDK.Utils;
 
 namespace OptimizelySDK.Tests.EventTests
 {
@@ -32,10 +32,11 @@ namespace OptimizelySDK.Tests.EventTests
     {
         private string TestUserId = string.Empty;
         private ProjectConfig Config;
-
+        [Obsolete]
         private EventBuilder EventBuilder;
 
         [TestFixtureSetUp]
+        [Obsolete]
         public void Setup()
         {
             TestUserId = "testUserId";

--- a/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventBuilderTest.cs
@@ -40,7 +40,8 @@ namespace OptimizelySDK.Tests.EventTests
         {
             TestUserId = "testUserId";
             var logger = new NoOpLogger();
-            Config = DatafileProjectConfig.Create(TestData.Datafile, logger, new ErrorHandler.NoOpErrorHandler());
+            Config = DatafileProjectConfig.Create(TestData.Datafile, logger,
+                new ErrorHandler.NoOpErrorHandler());
             EventBuilder = new EventBuilder(new Bucketer(logger));
         }
 
@@ -52,60 +53,65 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "77210100090" }
-                                                }
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "77210100090" },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            {"visitor_id", TestUserId}
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -113,15 +119,15 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
 
-            var logEvent = EventBuilder.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "77210100090", TestUserId, null);
+            var logEvent = EventBuilder.CreateImpressionEvent(Config,
+                Config.GetExperimentFromKey("test_experiment"), "77210100090", TestUserId, null);
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
-
         }
 
         [Test]
@@ -132,67 +138,72 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "77210100090" }
-                                                }
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "77210100090" },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -200,17 +211,18 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
-
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
                 { "device_type", "iPhone" },
-                { "company", "Optimizely" }
+                { "company", "Optimizely" },
             };
 
-            var logEvent = EventBuilder.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "77210100090", TestUserId, userAttributes);
+            var logEvent = EventBuilder.CreateImpressionEvent(Config,
+                Config.GetExperimentFromKey("test_experiment"), "77210100090", TestUserId,
+                userAttributes);
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
@@ -225,88 +237,93 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" }
-                                                }
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "7722370027" },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "323434545" },
-                                        {"key", "boolean_key" },
-                                        {"type", "custom" },
-                                        {"value", true}
+                                        { "entity_id", "323434545" },
+                                        { "key", "boolean_key" },
+                                        { "type", "custom" },
+                                        { "value", true },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "616727838" },
-                                        {"key", "integer_key" },
-                                        {"type", "custom" },
-                                        {"value", 15}
+                                        { "entity_id", "616727838" },
+                                        { "key", "integer_key" },
+                                        { "type", "custom" },
+                                        { "value", 15 },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "808797686" },
-                                        {"key", "double_key" },
-                                        {"type", "custom" },
-                                        {"value", 3.14}
+                                        { "entity_id", "808797686" },
+                                        { "key", "double_key" },
+                                        { "type", "custom" },
+                                        { "value", 3.14 },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -314,18 +331,20 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
-                {"device_type", "iPhone" },
-                {"boolean_key", true },
-                {"integer_key", 15 },
-                {"double_key", 3.14 }
+                { "device_type", "iPhone" },
+                { "boolean_key", true },
+                { "integer_key", 15 },
+                { "double_key", 3.14 },
             };
 
-            var logEvent = EventBuilder.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, userAttributes);
+            var logEvent = EventBuilder.CreateImpressionEvent(Config,
+                Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId,
+                userAttributes);
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
@@ -339,81 +358,86 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" }
-                                                }
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "7722370027" },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "323434545" },
-                                        {"key", "boolean_key" },
-                                        {"type", "custom" },
-                                        {"value", true}
+                                        { "entity_id", "323434545" },
+                                        { "key", "boolean_key" },
+                                        { "type", "custom" },
+                                        { "value", true },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "808797686" },
-                                        {"key", "double_key" },
-                                        {"type", "custom" },
-                                        {"value", 3.14}
+                                        { "entity_id", "808797686" },
+                                        { "key", "double_key" },
+                                        { "type", "custom" },
+                                        { "value", 3.14 },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -421,7 +445,7 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
@@ -439,7 +463,9 @@ namespace OptimizelySDK.Tests.EventTests
                 { "invalid_num_value", Math.Pow(2, 53) + 2 },
             };
 
-            var logEvent = EventBuilder.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, userAttributes);
+            var logEvent = EventBuilder.CreateImpressionEvent(Config,
+                Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId,
+                userAttributes);
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
@@ -453,50 +479,54 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                {"visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>
                         {
-                            {"snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063"},
-                                                    {"timestamp", timeStamp},
-                                                    {"uuid", guid},
-                                                    {"key", "purchase"},
-                                                }
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"visitor_id", TestUserId },
-                            {"attributes", new object[]
+                            { "visitor_id", TestUserId },
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
-                            }
-                        }
+                            },
+                        },
                     }
                 },
-                {"project_id", "7720880029"},
-                {"enrich_decisions", true} ,
-                {"account_id", "1592310167"},
-                {"client_name", "csharp-sdk"},
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -505,14 +535,15 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
-            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, null, null);
+            var logEvent =
+                EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, null, null);
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
@@ -527,57 +558,61 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                {"visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>
                         {
-                            {"snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063"},
-                                                    {"timestamp", timeStamp},
-                                                    {"uuid", guid},
-                                                    {"key", "purchase"},
-                                                }
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"visitor_id", TestUserId },
-                            {"attributes", new object[]
+                            { "visitor_id", TestUserId },
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
-                            }
-                        }
+                            },
+                        },
                     }
                 },
-                {"project_id", "7720880029"},
-                {"account_id", "1592310167"},
-                {"enrich_decisions", true},
-                {"client_name", "csharp-sdk"},
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -586,19 +621,20 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
                 { "device_type", "iPhone" },
-                { "company", "Optimizely" }
+                { "company", "Optimizely" },
             };
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
-            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, userAttributes, null);
+            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId,
+                userAttributes, null);
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
@@ -613,57 +649,62 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 42 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 42 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", 42 }
+                                                            { "revenue", 42 },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            { "attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true},
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -672,20 +713,20 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
 
             var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, null,
                 new EventTags
-            {
-                    {"revenue", 42 }
-            });
+                {
+                    { "revenue", 42 },
+                });
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
@@ -700,65 +741,70 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 42 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 42 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", 42},
-                                                            {"non-revenue", "definitely"}
+                                                            { "revenue", 42 },
+                                                            { "non-revenue", "definitely" },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -767,25 +813,26 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
-                { "device_type", "iPhone"},
-                {"company", "Optimizely" }
+                { "device_type", "iPhone" },
+                { "company", "Optimizely" },
             };
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
-            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, userAttributes,
+            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId,
+                userAttributes,
                 new EventTags
                 {
-                    {"revenue", 42 },
-                    {"non-revenue", "definitely" }
+                    { "revenue", 42 },
+                    { "non-revenue", "definitely" },
                 });
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
@@ -801,58 +848,63 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 42 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 42 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", "42" },
-                                                            {"non-revenue", "definitely"}
+                                                            { "revenue", "42" },
+                                                            { "non-revenue", "definitely" },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
                             { "visitor_id", TestUserId },
-                            { "attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
-                            }
-                        }
+                            },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -861,19 +913,19 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
             var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, null,
                 new EventTags
                 {
-                    {"revenue", "42" },
-                    {"non-revenue", "definitely" }
+                    { "revenue", "42" },
+                    { "non-revenue", "definitely" },
                 });
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
@@ -889,59 +941,64 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 42 },
-                                                    {"value", 400.0 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 42 },
+                                                    { "value", 400.0 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", 42 },
-                                                            {"value", 400 }
+                                                            { "revenue", 42 },
+                                                            { "value", 400 },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            { "attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -950,20 +1007,20 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
             var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, null,
                 new EventTags
-            {
-                    {"revenue", 42 },
-                    {"value", 400 }
-            });
+                {
+                    { "revenue", 42 },
+                    { "value", 400 },
+                });
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
@@ -977,59 +1034,64 @@ namespace OptimizelySDK.Tests.EventTests
             var timeStamp = TestData.SecondsSince1970();
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 0 },
-                                                    {"value", 0.0 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 0 },
+                                                    { "value", 0.0 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", 0 },
-                                                            {"value", 0.0 }
+                                                            { "revenue", 0 },
+                                                            { "value", 0.0 },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            { "attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -1038,20 +1100,20 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
             var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, null,
                 new EventTags
-            {
-                    {"revenue", 0 },
-                    {"value", 0.0 }
-            });
+                {
+                    { "revenue", 0 },
+                    { "value", 0.0 },
+                });
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
@@ -1065,59 +1127,64 @@ namespace OptimizelySDK.Tests.EventTests
             var timeStamp = TestData.SecondsSince1970();
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 10 },
-                                                    {"value", 1.0 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 10 },
+                                                    { "value", 1.0 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", 10 },
-                                                            {"value", 1.0 }
+                                                            { "revenue", 10 },
+                                                            { "value", 1.0 },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            { "attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -1126,25 +1193,26 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
             var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, null,
                 new EventTags
-            {
-                    {"revenue", 10 },
-                    {"value", 1.0 }
-            });
+                {
+                    { "revenue", 10 },
+                    { "value", 1.0 },
+                });
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
+
         [Test]
         public void TestConversionEventWithRevenueValue1()
         {
@@ -1152,59 +1220,64 @@ namespace OptimizelySDK.Tests.EventTests
             var timeStamp = TestData.SecondsSince1970();
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 1 },
-                                                    {"value", 10.0 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 1 },
+                                                    { "value", 10.0 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", 1 },
-                                                            {"value", 10.0 }
+                                                            { "revenue", 1 },
+                                                            { "value", 10.0 },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            { "attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -1213,20 +1286,20 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
             var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, null,
                 new EventTags
-            {
-                    {"revenue", 1 },
-                    {"value", 10.0 }
-            });
+                {
+                    { "revenue", 1 },
+                    { "value", 10.0 },
+                });
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
@@ -1242,83 +1315,88 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                }
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
-                                        {"key", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
-                                        {"type", "custom" },
-                                        {"value", "variation"}
+                                        { "entity_id", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
+                                        { "key", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", "variation" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
-            "https://logx.optimizely.com/v1/events",
-            payloadParams,
-            "POST",
-            new Dictionary<string, string>
-            {
-                { "Content-Type", "application/json"}
-            });
+                "https://logx.optimizely.com/v1/events",
+                payloadParams,
+                "POST",
+                new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" },
+                });
 
             var userAttributes = new UserAttributes
             {
-                { "device_type", "iPhone"},
-                {"company", "Optimizely" },
-                {ControlAttributes.BUCKETING_ID_ATTRIBUTE, "variation" }
+                { "device_type", "iPhone" },
+                { "company", "Optimizely" },
+                { ControlAttributes.BUCKETING_ID_ATTRIBUTE, "variation" },
             };
 
-            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, userAttributes, null);
+            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId,
+                userAttributes, null);
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
@@ -1333,74 +1411,79 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" }
-                                                }
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "7722370027" },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
-                                        {"key", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
-                                        {"type", "custom" },
-                                        {"value", "variation"}
+                                        { "entity_id", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
+                                        { "key", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", "variation" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -1408,17 +1491,19 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
                 { "device_type", "iPhone" },
                 { "company", "Optimizely" },
-                {ControlAttributes.BUCKETING_ID_ATTRIBUTE, "variation" }
+                { ControlAttributes.BUCKETING_ID_ATTRIBUTE, "variation" },
             };
 
-            var logEvent = EventBuilder.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, userAttributes);
+            var logEvent = EventBuilder.CreateImpressionEvent(Config,
+                Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId,
+                userAttributes);
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
@@ -1433,67 +1518,72 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" }
-                                                }
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "7722370027" },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"key", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"type", "custom" },
-                                        {"value", "chrome"}
+                                        { "entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "key", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", "chrome" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -1501,19 +1591,20 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
-                {ControlAttributes.USER_AGENT_ATTRIBUTE, "chrome" }
+                { ControlAttributes.USER_AGENT_ATTRIBUTE, "chrome" },
             };
 
             var botFilteringEnabledConfig = Config;
             botFilteringEnabledConfig.BotFiltering = true;
             var experiment = botFilteringEnabledConfig.GetExperimentFromKey("test_experiment");
 
-            var logEvent = EventBuilder.CreateImpressionEvent(botFilteringEnabledConfig, experiment, "7722370027", TestUserId, userAttributes);
+            var logEvent = EventBuilder.CreateImpressionEvent(botFilteringEnabledConfig, experiment,
+                "7722370027", TestUserId, userAttributes);
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
@@ -1527,60 +1618,65 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" }
-                                                }
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "7722370027" },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"key", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"type", "custom" },
-                                        {"value", "chrome"}
-                                    }
+                                        { "entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "key", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", "chrome" },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -1588,19 +1684,20 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
-                {ControlAttributes.USER_AGENT_ATTRIBUTE, "chrome" }
+                { ControlAttributes.USER_AGENT_ATTRIBUTE, "chrome" },
             };
 
             var botFilteringDisabledConfig = Config;
             botFilteringDisabledConfig.BotFiltering = null;
             var experiment = botFilteringDisabledConfig.GetExperimentFromKey("test_experiment");
 
-            var logEvent = EventBuilder.CreateImpressionEvent(botFilteringDisabledConfig, experiment, "7722370027", TestUserId, userAttributes);
+            var logEvent = EventBuilder.CreateImpressionEvent(botFilteringDisabledConfig,
+                experiment, "7722370027", TestUserId, userAttributes);
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
@@ -1614,57 +1711,61 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                {"visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>
                         {
-                            {"snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063"},
-                                                    {"timestamp", timeStamp},
-                                                    {"uuid", guid},
-                                                    {"key", "purchase"},
-                                                }
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"visitor_id", TestUserId },
-                            {"attributes", new object[]
+                            { "visitor_id", TestUserId },
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"key", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"type", "custom" },
-                                        {"value", "safari"}
+                                        { "entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "key", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", "safari" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
-                            }
-                        }
+                            },
+                        },
                     }
                 },
-                {"project_id", "7720880029"},
-                {"account_id", "1592310167"},
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk"},
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -1673,21 +1774,22 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
-                {ControlAttributes.USER_AGENT_ATTRIBUTE, "safari" }
+                { ControlAttributes.USER_AGENT_ATTRIBUTE, "safari" },
             };
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
             var botFilteringEnabledConfig = Config;
             botFilteringEnabledConfig.BotFiltering = true;
-            var logEvent = EventBuilder.CreateConversionEvent(botFilteringEnabledConfig, "purchase", TestUserId, userAttributes, null);
+            var logEvent = EventBuilder.CreateConversionEvent(botFilteringEnabledConfig, "purchase",
+                TestUserId, userAttributes, null);
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
@@ -1702,50 +1804,54 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                {"visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>
                         {
-                            {"snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063"},
-                                                    {"timestamp", timeStamp},
-                                                    {"uuid", guid},
-                                                    {"key", "purchase"},
-                                                }
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"visitor_id", TestUserId },
-                            {"attributes", new object[]
+                            { "visitor_id", TestUserId },
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"key", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"type", "custom" },
-                                        {"value", "safari"}
-                                    }
+                                        { "entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "key", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", "safari" },
+                                    },
                                 }
-                            }
-                        }
+                            },
+                        },
                     }
                 },
-                {"project_id", "7720880029"},
-                {"enrich_decisions", true},
-                {"account_id", "1592310167"},
-                {"client_name", "csharp-sdk"},
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -1754,21 +1860,22 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
-                {ControlAttributes.USER_AGENT_ATTRIBUTE, "safari" }
+                { ControlAttributes.USER_AGENT_ATTRIBUTE, "safari" },
             };
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
             var botFilteringDisabledConfig = Config;
             botFilteringDisabledConfig.BotFiltering = null;
-            var logEvent = EventBuilder.CreateConversionEvent(botFilteringDisabledConfig, "purchase", TestUserId, userAttributes, null);
+            var logEvent = EventBuilder.CreateConversionEvent(botFilteringDisabledConfig,
+                "purchase", TestUserId, userAttributes, null);
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
 
@@ -1780,39 +1887,45 @@ namespace OptimizelySDK.Tests.EventTests
         {
             var guid = Guid.NewGuid();
             var timeStamp = TestData.SecondsSince1970();
-            
-            var eventInMultiExperimentConfig = DatafileProjectConfig.Create(TestData.SimpleABExperimentsDatafile, new NoOpLogger(), new ErrorHandler.NoOpErrorHandler());
+
+            var eventInMultiExperimentConfig = DatafileProjectConfig.Create(
+                TestData.SimpleABExperimentsDatafile, new NoOpLogger(),
+                new ErrorHandler.NoOpErrorHandler());
 
             var experimentIdVariationMap = new Dictionary<string, Variation>
             {
                 {
-                    "111127", new Variation{Id="111129", Key="variation"}
+                    "111127", new Variation { Id = "111129", Key = "variation" }
                 },
                 {
-                    "111130", new Variation{Id="111131", Key="variation"}
-                }
+                    "111130", new Variation { Id = "111131", Key = "variation" }
+                },
             };
 
-            var logEvent = EventBuilder.CreateConversionEvent(eventInMultiExperimentConfig, "event_with_multiple_running_experiments", "test_user",
-                                                              new UserAttributes {
-                                                                {"test_attribute", "test_value"}
-                                                              },
-                                                              new EventTags {
-                                                                {"revenue", 4200},
-                                                                {"value", 1.234},
-                                                                {"non-revenue", "abc"}
-                                                             });
-                    
-            var payloadParams = new Dictionary<string, object>
+            var logEvent = EventBuilder.CreateConversionEvent(eventInMultiExperimentConfig,
+                "event_with_multiple_running_experiments", "test_user",
+                new UserAttributes
                 {
-                {"client_version", Optimizely.SDK_VERSION},
-                {"project_id", "111001"},
-                {"enrich_decisions", true},
-                {"account_id", "12001"},
-                {"client_name", "csharp-sdk"},
-                {"anonymize_ip", false},
-                {"revision", eventInMultiExperimentConfig.Revision},
-                {"visitors", new object[]
+                    { "test_attribute", "test_value" },
+                },
+                new EventTags
+                {
+                    { "revenue", 4200 },
+                    { "value", 1.234 },
+                    { "non-revenue", "abc" },
+                });
+
+            var payloadParams = new Dictionary<string, object>
+            {
+                { "client_version", Optimizely.SDK_VERSION },
+                { "project_id", "111001" },
+                { "enrich_decisions", true },
+                { "account_id", "12001" },
+                { "client_name", "csharp-sdk" },
+                { "anonymize_ip", false },
+                { "revision", eventInMultiExperimentConfig.Revision },
+                {
+                    "visitors", new object[]
                     {
                         //visitors[0]
                         new Dictionary<string, object>
@@ -1823,17 +1936,18 @@ namespace OptimizelySDK.Tests.EventTests
                                 {
                                     new Dictionary<string, string>
                                     {
-                                        {"entity_id", "111094"},
-                                        {"type", "custom"},
-                                        {"value", "test_value"},
-                                        {"key", "test_attribute"}
-                                    }
+                                        { "entity_id", "111094" },
+                                        { "type", "custom" },
+                                        { "value", "test_value" },
+                                        { "key", "test_attribute" },
+                                    },
                                 }
                             },
                             //visitors[0].visitor_id
-                            {"visitor_id", "test_user"},
+                            { "visitor_id", "test_user" },
                             //visitors[0].snapshots
-                            {"snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     //snapshots[0]
                                     new Dictionary<string, object>
@@ -1844,34 +1958,32 @@ namespace OptimizelySDK.Tests.EventTests
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"uuid", guid},
-                                                    {"timestamp", timeStamp},
-                                                    {"revenue", 4200},
-                                                    {"value", 1.234},
-                                                    {"key", "event_with_multiple_running_experiments"},
-                                                    {"entity_id", "111095"},
+                                                    { "uuid", guid },
+                                                    { "timestamp", timeStamp },
+                                                    { "revenue", 4200 },
+                                                    { "value", 1.234 },
+                                                    {
+                                                        "key",
+                                                        "event_with_multiple_running_experiments"
+                                                    },
+                                                    { "entity_id", "111095" },
                                                     {
                                                         "tags", new Dictionary<string, object>
                                                         {
-                                                            {"non-revenue", "abc"},
-                                                            {"revenue", 4200},
-                                                            {"value", 1.234},
+                                                            { "non-revenue", "abc" },
+                                                            { "revenue", 4200 },
+                                                            { "value", 1.234 },
                                                         }
-                                                    }
-
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-
-                                    }
-
+                                        },
+                                    },
                                 }
-                            }
-
-                        }
+                            },
+                        },
                     }
-
-                }
+                },
             };
 
 
@@ -1881,7 +1993,7 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
@@ -1897,71 +2009,75 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                {"visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>
                         {
-                            {"snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063"},
-                                                    {"timestamp", timeStamp},
-                                                    {"uuid", guid},
-                                                    {"key", "purchase"},
-                                                }
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"visitor_id", TestUserId },
-                            {"attributes", new object[]
+                            { "visitor_id", TestUserId },
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "323434545" },
-                                        {"key", "boolean_key" },
-                                        {"type", "custom" },
-                                        {"value", true}
+                                        { "entity_id", "323434545" },
+                                        { "key", "boolean_key" },
+                                        { "type", "custom" },
+                                        { "value", true },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "808797686" },
-                                        {"key", "double_key" },
-                                        {"type", "custom" },
-                                        {"value", 3.14}
+                                        { "entity_id", "808797686" },
+                                        { "key", "double_key" },
+                                        { "type", "custom" },
+                                        { "value", 3.14 },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
-                            }
-                        }
+                            },
+                        },
                     }
                 },
-                {"project_id", "7720880029"},
-                {"account_id", "1592310167"},
-                {"enrich_decisions", true},
-                {"client_name", "csharp-sdk"},
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -1970,7 +2086,7 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
@@ -1990,10 +2106,11 @@ namespace OptimizelySDK.Tests.EventTests
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
-            
-            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId, userAttributes, null);
+
+            var logEvent = EventBuilder.CreateConversionEvent(Config, "purchase", TestUserId,
+                userAttributes, null);
 
             TestData.ChangeGUIDAndTimeStamp(logEvent.Params, timeStamp, guid);
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));

--- a/OptimizelySDK.Tests/EventTests/EventEntitiesTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventEntitiesTest.cs
@@ -39,104 +39,114 @@ namespace OptimizelySDK.Tests.EventTests
 
             var expectedPayload = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "77210100090" }
-                                                }
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "77210100090" },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", userId }
-                        }
+                            { "visitor_id", userId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
-            EventBatch.Builder builder = new EventBatch.Builder();
-            builder.WithAccountId("1592310167")
-                .WithProjectID("7720880029")
-                .WithClientVersion(Optimizely.SDK_VERSION)
-                .WithRevision("15")
-                .WithClientName("csharp-sdk")
-                .WithAnonymizeIP(false)
-                .WithEnrichDecisions(true);
+            var builder = new EventBatch.Builder();
+            builder.WithAccountId("1592310167").
+                WithProjectID("7720880029").
+                WithClientVersion(Optimizely.SDK_VERSION).
+                WithRevision("15").
+                WithClientName("csharp-sdk").
+                WithAnonymizeIP(false).
+                WithEnrichDecisions(true);
 
-            var visitorAttribute1 = new VisitorAttribute(entityId: "7723280020", type: "custom", value: "iPhone", key: "device_type");
-            var visitorAttribute2 = new VisitorAttribute(entityId: ControlAttributes.BOT_FILTERING_ATTRIBUTE, type: "custom", value: true, key: ControlAttributes.BOT_FILTERING_ATTRIBUTE);
-            var snapshotEvent = new SnapshotEvent.Builder()
-                .WithUUID(guid.ToString())
-                .WithEntityId("7719770039")
-                .WithKey("campaign_activated")
-                .WithValue(null)
-                .WithRevenue(null)
-                .WithTimeStamp(timeStamp)
-                .WithEventTags(null)
-                .Build();
+            var visitorAttribute1 = new VisitorAttribute("7723280020", type: "custom",
+                value: "iPhone", key: "device_type");
+            var visitorAttribute2 = new VisitorAttribute(ControlAttributes.BOT_FILTERING_ATTRIBUTE,
+                type: "custom", value: true, key: ControlAttributes.BOT_FILTERING_ATTRIBUTE);
+            var snapshotEvent = new SnapshotEvent.Builder().WithUUID(guid.ToString()).
+                WithEntityId("7719770039").
+                WithKey("campaign_activated").
+                WithValue(null).
+                WithRevenue(null).
+                WithTimeStamp(timeStamp).
+                WithEventTags(null).
+                Build();
             var metadata = new DecisionMetadata("experiment", "experiment_key", "7716830082");
             var decision = new Decision("7719770039", "7716830082", "77210100090");
-            var snapshot = new Snapshot(events: new SnapshotEvent[] { snapshotEvent }, decisions: new Decision[] { decision });
+            var snapshot = new Snapshot(new SnapshotEvent[] { snapshotEvent },
+                new Decision[] { decision });
 
             var visitor = new Visitor(
-                snapshots: new Snapshot[] {
-                    snapshot
+                new Snapshot[]
+                {
+                    snapshot,
                 },
-                attributes: new VisitorAttribute[]{
-                    visitorAttribute1, visitorAttribute2},
-                visitorId: "test_user");
+                new VisitorAttribute[]
+                {
+                    visitorAttribute1, visitorAttribute2,
+                },
+                "test_user");
 
             builder.WithVisitors(new Visitor[] { visitor });
 
-            EventBatch eventBatch = builder.Build();
+            var eventBatch = builder.Build();
             // Single Conversion Event
             TestData.CompareObjects(expectedPayload, eventBatch);
         }
@@ -144,20 +154,20 @@ namespace OptimizelySDK.Tests.EventTests
         [Test]
         public void TestConversionEventEqualsSerializedPayload()
         {
-
             var guid = Guid.NewGuid();
             var timeStamp = TestData.SecondsSince1970();
 
             var expectdPayload = new Dictionary<string, object>
+            {
+                { "client_version", Optimizely.SDK_VERSION },
+                { "project_id", "111001" },
+                { "enrich_decisions", true },
+                { "account_id", "12001" },
+                { "client_name", "csharp-sdk" },
+                { "anonymize_ip", false },
+                { "revision", "2" },
                 {
-                {"client_version", Optimizely.SDK_VERSION},
-                {"project_id", "111001"},
-                {"enrich_decisions", true},
-                {"account_id", "12001"},
-                {"client_name", "csharp-sdk"},
-                {"anonymize_ip", false},
-                {"revision", "2"},
-                {"visitors", new object[]
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>
                         {
@@ -167,17 +177,18 @@ namespace OptimizelySDK.Tests.EventTests
                                 {
                                     new Dictionary<string, string>
                                     {
-                                        {"entity_id", "111094"},
-                                        {"type", "custom"},
-                                        {"value", "test_value"},
-                                        {"key", "test_attribute"}
-                                    }
+                                        { "entity_id", "111094" },
+                                        { "type", "custom" },
+                                        { "value", "test_value" },
+                                        { "key", "test_attribute" },
+                                    },
                                 }
                             },
                             //visitors[0].visitor_id
-                            {"visitor_id", "test_user"},
+                            { "visitor_id", "test_user" },
                             //visitors[0].snapshots
-                            {"snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     //snapshots[0]
                                     new Dictionary<string, object>
@@ -188,79 +199,78 @@ namespace OptimizelySDK.Tests.EventTests
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"uuid", guid},
-                                                    {"timestamp", timeStamp},
-                                                    {"revenue", 4200},
-                                                    {"value", 1.234},
-                                                    {"key", "event_with_multiple_running_experiments"},
-                                                    {"entity_id", "111095"},
+                                                    { "uuid", guid },
+                                                    { "timestamp", timeStamp },
+                                                    { "revenue", 4200 },
+                                                    { "value", 1.234 },
+                                                    {
+                                                        "key",
+                                                        "event_with_multiple_running_experiments"
+                                                    },
+                                                    { "entity_id", "111095" },
                                                     {
                                                         "tags", new Dictionary<string, object>
                                                         {
-                                                            {"non-revenue", "abc"},
-                                                            {"revenue", 4200},
-                                                            {"value", 1.234},
+                                                            { "non-revenue", "abc" },
+                                                            { "revenue", 4200 },
+                                                            { "value", 1.234 },
                                                         }
-                                                    }
-
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-
-                                    }
-
+                                        },
+                                    },
                                 }
-                            }
-
-                        }
+                            },
+                        },
                     }
-
-                }
+                },
             };
 
-            EventBatch.Builder builder = new EventBatch.Builder();
-            builder.WithAccountId("12001")
-                .WithProjectID("111001")
-                .WithClientVersion(Optimizely.SDK_VERSION)
-                .WithRevision("2")
-                .WithClientName("csharp-sdk")
-                .WithAnonymizeIP(false)
-                .WithEnrichDecisions(true);
-            
-            var visitorAttribute = new VisitorAttribute(entityId: "111094", type: "custom", value: "test_value", key: "test_attribute");
+            var builder = new EventBatch.Builder();
+            builder.WithAccountId("12001").
+                WithProjectID("111001").
+                WithClientVersion(Optimizely.SDK_VERSION).
+                WithRevision("2").
+                WithClientName("csharp-sdk").
+                WithAnonymizeIP(false).
+                WithEnrichDecisions(true);
 
-            var snapshotEvent = new SnapshotEvent.Builder()
-                .WithUUID(guid.ToString())
-                .WithEntityId("111095")
-                .WithKey("event_with_multiple_running_experiments")
-                .WithValue((long?)1.234)
-                .WithRevenue(4200)
-                .WithTimeStamp(timeStamp)
-                .WithEventTags(new EventTags
+            var visitorAttribute = new VisitorAttribute("111094", type: "custom",
+                value: "test_value", key: "test_attribute");
+
+            var snapshotEvent = new SnapshotEvent.Builder().WithUUID(guid.ToString()).
+                WithEntityId("111095").
+                WithKey("event_with_multiple_running_experiments").
+                WithValue((long?)1.234).
+                WithRevenue(4200).
+                WithTimeStamp(timeStamp).
+                WithEventTags(new EventTags
                 {
-                    {"non-revenue", "abc"},
-                    {"revenue", 4200},
-                    {"value", 1.234}
-                })
-                .Build();
+                    { "non-revenue", "abc" },
+                    { "revenue", 4200 },
+                    { "value", 1.234 },
+                }).
+                Build();
 
-            var snapshot = new Snapshot(events: new SnapshotEvent[] { snapshotEvent });
+            var snapshot = new Snapshot(new SnapshotEvent[] { snapshotEvent });
 
             var visitor = new Visitor(
-                snapshots: new Snapshot[] {
-                    snapshot
+                new Snapshot[]
+                {
+                    snapshot,
                 },
-                attributes: new VisitorAttribute[]{
-                    visitorAttribute},
-                visitorId: "test_user");
+                new VisitorAttribute[]
+                {
+                    visitorAttribute,
+                },
+                "test_user");
 
             builder.WithVisitors(new Visitor[] { visitor });
 
-            EventBatch eventBatch = builder.Build();
+            var eventBatch = builder.Build();
             // Single Conversion Event
             TestData.CompareObjects(expectdPayload, eventBatch);
         }
-
-
     }
 }

--- a/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
+++ b/OptimizelySDK.Tests/EventTests/EventFactoryTest.cs
@@ -31,7 +31,6 @@ namespace OptimizelySDK.Tests.EventTests
     [TestFixture]
     public class EventFactoryTest
     {
-
         private string TestUserId = string.Empty;
         private ProjectConfig Config;
         private ILogger Logger;
@@ -41,7 +40,8 @@ namespace OptimizelySDK.Tests.EventTests
         {
             TestUserId = "testUserId";
             var logger = new NoOpLogger();
-            Config = DatafileProjectConfig.Create(TestData.Datafile, logger, new ErrorHandler.NoOpErrorHandler());
+            Config = DatafileProjectConfig.Create(TestData.Datafile, logger,
+                new NoOpErrorHandler());
         }
 
         [Test]
@@ -49,17 +49,20 @@ namespace OptimizelySDK.Tests.EventTests
         {
             Config.SendFlagDecisions = false;
             var impressionEvent = UserEventFactory.CreateImpressionEvent(
-                Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, null, "test_feature", "rollout");
+                Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId,
+                null, "test_feature", "rollout");
             Assert.IsNull(impressionEvent);
         }
 
         [Test]
-        public void TestCreateImpressionEventReturnsNullWhenSendFlagDecisionsIsFalseAndVariationIsNull()
+        public void
+            TestCreateImpressionEventReturnsNullWhenSendFlagDecisionsIsFalseAndVariationIsNull()
         {
             Config.SendFlagDecisions = false;
             Variation variation = null;
             var impressionEvent = UserEventFactory.CreateImpressionEvent(
-                Config, Config.GetExperimentFromKey("test_experiment"), variation, TestUserId, null, "test_experiment", "experiment");
+                Config, Config.GetExperimentFromKey("test_experiment"), variation, TestUserId, null,
+                "test_experiment", "experiment");
             Assert.IsNull(impressionEvent);
         }
 
@@ -69,79 +72,95 @@ namespace OptimizelySDK.Tests.EventTests
             var guid = Guid.NewGuid();
             var timeStamp = TestData.SecondsSince1970();
 
-            var payloadParams = new Dictionary<string, object> {
+            var payloadParams = new Dictionary<string, object>
+            {
                 {
-                        "visitors", new object[] {
-                            new Dictionary<string, object>() {
+                    "visitors", new object[]
+                    {
+                        new Dictionary<string, object>()
+                        {
+                            {
+                                "snapshots", new object[]
                                 {
-                                    "snapshots", new object[] {
-                                        new Dictionary<string, object> {
+                                    new Dictionary<string, object>
+                                    {
+                                        {
+                                            "decisions", new object[]
                                             {
-                                                "decisions", new object[] {
-                                                    new Dictionary<string, object> {
-                                                        { "campaign_id", "7719770039" },
-                                                        { "experiment_id", "7716830082" },
-                                                        { "variation_id", "7722370027" },
-                                                        { "metadata",
-                                                            new Dictionary<string, object> {
+                                                new Dictionary<string, object>
+                                                {
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "7722370027" },
+                                                    {
+                                                        "metadata",
+                                                        new Dictionary<string, object>
+                                                        {
                                                             { "rule_type", "experiment" },
                                                             { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
                                                             { "variation_key", "control" },
-                                                            { "enabled", false }
-                                                        } }
-                                                    }
-                                                }
-                                            },
-                                            {
-                                                "events", new object[] {
-                                                    new Dictionary<string, object> {
-                                                        {"entity_id", "7719770039" },
-                                                        {"timestamp", timeStamp },
-                                                        {"uuid", guid },
-                                                        {"key", "campaign_activated" }
-                                                    }
-                                                }
+                                                            { "enabled", false },
+                                                        }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
-                                },
+                                        },
+                                        {
+                                            "events", new object[]
+                                            {
+                                                new Dictionary<string, object>
+                                                {
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
+                                            }
+                                        },
+                                    },
+                                }
+                            },
+                            {
+                                "attributes", new object[]
                                 {
-                                    "attributes", new object[] {
-                                        new Dictionary<string, object> {
-                                            {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                            {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                            {"type", "custom" },
-                                            {"value", true }
-                                        }
-                                    }
-                                },
-                                {"visitor_id", TestUserId}
-                            }
-                        }
-                    },
-                    {"project_id", "7720880029" },
-                    {"account_id", "1592310167" },
-                    {"enrich_decisions", true} ,
-                    {"client_name", "csharp-sdk" },
-                    {"client_version", Optimizely.SDK_VERSION },
-                    {"revision", "15" },
-                    {"anonymize_ip", false}
-                };
+                                    new Dictionary<string, object>
+                                    {
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
+                                }
+                            },
+                            { "visitor_id", TestUserId },
+                        },
+                    }
+                },
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
+            };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
                 payloadParams,
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
             var impressionEvent = UserEventFactory.CreateImpressionEvent(
-                Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, null, "test_experiment", "experiment");
+                Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId,
+                null, "test_experiment", "experiment");
 
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp,
+                Guid.Parse(impressionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
         }
@@ -152,73 +171,84 @@ namespace OptimizelySDK.Tests.EventTests
             var guid = Guid.NewGuid();
             var timeStamp = TestData.SecondsSince1970();
             var variationId = "7722370027";
-            var payloadParams = new Dictionary<string, object> {
+            var payloadParams = new Dictionary<string, object>
+            {
                 {
-                    "visitors", new object[] {
-                        new Dictionary<string, object>() {
+                    "visitors", new object[]
+                    {
+                        new Dictionary<string, object>()
+                        {
                             {
-                                "snapshots", new object[] {
-                                    new Dictionary<string, object> {
+                                "snapshots", new object[]
+                                {
+                                    new Dictionary<string, object>
+                                    {
                                         {
-                                            "decisions", new object[] {
-                                                new Dictionary<string, object> {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" },
-                                                    { "metadata", new Dictionary<string, object> {
+                                            "decisions", new object[]
+                                            {
+                                                new Dictionary<string, object>
+                                                {
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "7722370027" },
+                                                    {
+                                                        "metadata", new Dictionary<string, object>
+                                                        {
                                                             { "rule_type", "experiment" },
                                                             { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
                                                             { "variation_key", "control" },
-                                                            {"enabled", false }
-
+                                                            { "enabled", false },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
                                         },
                                         {
-                                            "events", new object[] {
-                                                new Dictionary<string, object> {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                            "events", new object[]
+                                            {
+                                                new Dictionary<string, object>
+                                                {
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
                             {
-                                "attributes", new object[] {
+                                "attributes", new object[]
+                                {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -226,20 +256,22 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
-
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
                 { "device_type", "iPhone" },
-                { "company", "Optimizely" }
+                { "company", "Optimizely" },
             };
             //
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), variationId, TestUserId, userAttributes, "test_experiment", "experiment");
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config,
+                Config.GetExperimentFromKey("test_experiment"), variationId, TestUserId,
+                userAttributes, "test_experiment", "experiment");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp,
+                Guid.Parse(impressionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
         }
@@ -252,96 +284,103 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" },
-                                                    { "metadata", new Dictionary<string, object> {
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "7722370027" },
+                                                    {
+                                                        "metadata", new Dictionary<string, object>
+                                                        {
                                                             { "rule_type", "experiment" },
                                                             { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
                                                             { "variation_key", "control" },
-                                                            {"enabled", false }
+                                                            { "enabled", false },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "323434545" },
-                                        {"key", "boolean_key" },
-                                        {"type", "custom" },
-                                        {"value", true}
+                                        { "entity_id", "323434545" },
+                                        { "key", "boolean_key" },
+                                        { "type", "custom" },
+                                        { "value", true },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "616727838" },
-                                        {"key", "integer_key" },
-                                        {"type", "custom" },
-                                        {"value", 15}
+                                        { "entity_id", "616727838" },
+                                        { "key", "integer_key" },
+                                        { "type", "custom" },
+                                        { "value", 15 },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "808797686" },
-                                        {"key", "double_key" },
-                                        {"type", "custom" },
-                                        {"value", 3.14}
+                                        { "entity_id", "808797686" },
+                                        { "key", "double_key" },
+                                        { "type", "custom" },
+                                        { "value", 3.14 },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -349,20 +388,23 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
-                {"device_type", "iPhone" },
-                {"boolean_key", true },
-                {"integer_key", 15 },
-                {"double_key", 3.14 }
+                { "device_type", "iPhone" },
+                { "boolean_key", true },
+                { "integer_key", 15 },
+                { "double_key", 3.14 },
             };
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, userAttributes, "test_experiment", "experiment");
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config,
+                Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId,
+                userAttributes, "test_experiment", "experiment");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp,
+                Guid.Parse(impressionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
         }
@@ -375,89 +417,96 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" },
-                                                    { "metadata", new Dictionary<string, object> {
-                                                           { "rule_type", "experiment" },
-                                                           { "rule_key", "test_experiment" },
-                                                           { "flag_key", "test_experiment" },
-                                                           { "variation_key", "control" },
-                                                           {"enabled", false }
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "7722370027" },
+                                                    {
+                                                        "metadata", new Dictionary<string, object>
+                                                        {
+                                                            { "rule_type", "experiment" },
+                                                            { "rule_key", "test_experiment" },
+                                                            { "flag_key", "test_experiment" },
+                                                            { "variation_key", "control" },
+                                                            { "enabled", false },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "323434545" },
-                                        {"key", "boolean_key" },
-                                        {"type", "custom" },
-                                        {"value", true}
+                                        { "entity_id", "323434545" },
+                                        { "key", "boolean_key" },
+                                        { "type", "custom" },
+                                        { "value", true },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "808797686" },
-                                        {"key", "double_key" },
-                                        {"type", "custom" },
-                                        {"value", 3.14}
+                                        { "entity_id", "808797686" },
+                                        { "key", "double_key" },
+                                        { "type", "custom" },
+                                        { "value", 3.14 },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -465,7 +514,7 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
@@ -482,10 +531,13 @@ namespace OptimizelySDK.Tests.EventTests
                 { "nan", double.NaN },
                 { "invalid_num_value", Math.Pow(2, 53) + 2 },
             };
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, userAttributes, "test_experiment", "experiment");
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config,
+                Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId,
+                userAttributes, "test_experiment", "experiment");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp,
+                Guid.Parse(impressionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
         }
@@ -498,89 +550,96 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", null },
-                                                    {"experiment_id", string.Empty },
-                                                    {"variation_id", null },
-                                                    { "metadata", new Dictionary<string, object> {
+                                                    { "campaign_id", null },
+                                                    { "experiment_id", string.Empty },
+                                                    { "variation_id", null },
+                                                    {
+                                                        "metadata", new Dictionary<string, object>
+                                                        {
                                                             { "rule_type", "rollout" },
                                                             { "rule_key", string.Empty },
                                                             { "flag_key", "test_feature" },
                                                             { "variation_key", string.Empty },
-                                                            { "enabled", false }
+                                                            { "enabled", false },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", null },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", null },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "323434545" },
-                                        {"key", "boolean_key" },
-                                        {"type", "custom" },
-                                        {"value", true}
+                                        { "entity_id", "323434545" },
+                                        { "key", "boolean_key" },
+                                        { "type", "custom" },
+                                        { "value", true },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "808797686" },
-                                        {"key", "double_key" },
-                                        {"type", "custom" },
-                                        {"value", 3.14}
+                                        { "entity_id", "808797686" },
+                                        { "key", "double_key" },
+                                        { "type", "custom" },
+                                        { "value", 3.14 },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -588,7 +647,7 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
@@ -607,10 +666,12 @@ namespace OptimizelySDK.Tests.EventTests
             };
             Variation variation = null;
 
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, null, variation, TestUserId, userAttributes, "test_feature", "rollout");
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, null, variation,
+                TestUserId, userAttributes, "test_feature", "rollout");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp,
+                Guid.Parse(impressionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
         }
@@ -623,50 +684,54 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                {"visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>
                         {
-                            {"snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063"},
-                                                    {"timestamp", timeStamp},
-                                                    {"uuid", guid},
-                                                    {"key", "purchase"},
-                                                }
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"visitor_id", TestUserId },
-                            {"attributes", new object[]
+                            { "visitor_id", TestUserId },
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
-                            }
-                        }
+                            },
+                        },
                     }
                 },
-                {"project_id", "7720880029"},
-                {"enrich_decisions", true} ,
-                {"account_id", "1592310167"},
-                {"client_name", "csharp-sdk"},
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -675,17 +740,19 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
-            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase", TestUserId, null, null);
+            var conversionEvent =
+                UserEventFactory.CreateConversionEvent(Config, "purchase", TestUserId, null, null);
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
@@ -698,57 +765,61 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                {"visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>
                         {
-                            {"snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063"},
-                                                    {"timestamp", timeStamp},
-                                                    {"uuid", guid},
-                                                    {"key", "purchase"},
-                                                }
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"visitor_id", TestUserId },
-                            {"attributes", new object[]
+                            { "visitor_id", TestUserId },
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
-                            }
-                        }
+                            },
+                        },
                     }
                 },
-                {"project_id", "7720880029"},
-                {"account_id", "1592310167"},
-                {"enrich_decisions", true},
-                {"client_name", "csharp-sdk"},
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -757,22 +828,25 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
                 { "device_type", "iPhone" },
-                { "company", "Optimizely" }
+                { "company", "Optimizely" },
             };
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
-            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase", TestUserId, userAttributes, null);
+            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase",
+                TestUserId, userAttributes, null);
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID)); ;
+            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
+            ;
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
@@ -785,57 +859,62 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 42 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 42 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", 42 }
+                                                            { "revenue", 42 },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            { "attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true},
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -844,22 +923,24 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
-            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase", TestUserId, null,
+            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase",
+                TestUserId, null,
                 new EventTags
-            {
-                    {"revenue", 42 }
-            });
+                {
+                    { "revenue", 42 },
+                });
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
@@ -872,65 +953,70 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 42 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 42 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", 42},
-                                                            {"non-revenue", "definitely"}
+                                                            { "revenue", 42 },
+                                                            { "non-revenue", "definitely" },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -939,29 +1025,31 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
-                { "device_type", "iPhone"},
-                {"company", "Optimizely" }
+                { "device_type", "iPhone" },
+                { "company", "Optimizely" },
             };
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
-            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase", TestUserId, userAttributes,
+            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase",
+                TestUserId, userAttributes,
                 new EventTags
                 {
-                    {"revenue", 42 },
-                    {"non-revenue", "definitely" }
+                    { "revenue", 42 },
+                    { "non-revenue", "definitely" },
                 });
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
@@ -974,58 +1062,63 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 42 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 42 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", "42" },
-                                                            {"non-revenue", "definitely"}
+                                                            { "revenue", "42" },
+                                                            { "non-revenue", "definitely" },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
                             { "visitor_id", TestUserId },
-                            { "attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
-                            }
-                        }
+                            },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -1034,22 +1127,24 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
-            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase", TestUserId, null,
+            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase",
+                TestUserId, null,
                 new EventTags
                 {
-                    {"revenue", "42" },
-                    {"non-revenue", "definitely" }
+                    { "revenue", "42" },
+                    { "non-revenue", "definitely" },
                 });
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
-            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
@@ -1062,59 +1157,64 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 42 },
-                                                    {"value", 400.0 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 42 },
+                                                    { "value", 400.0 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", 42 },
-                                                            {"value", 400 }
+                                                            { "revenue", 42 },
+                                                            { "value", 400 },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            { "attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -1123,25 +1223,27 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
-            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase", TestUserId, null,
+            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase",
+                TestUserId, null,
                 new EventTags
-            {
-                    {"revenue", 42 },
-                    {"value", 400 }
-            });
+                {
+                    { "revenue", 42 },
+                    { "value", 400 },
+                });
 
 
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
@@ -1153,59 +1255,64 @@ namespace OptimizelySDK.Tests.EventTests
             var timeStamp = TestData.SecondsSince1970();
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 0 },
-                                                    {"value", 0.0 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 0 },
+                                                    { "value", 0.0 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", 0 },
-                                                            {"value", 0.0 }
+                                                            { "revenue", 0 },
+                                                            { "value", 0.0 },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            { "attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -1214,23 +1321,25 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
-            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase", TestUserId, null,
+            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase",
+                TestUserId, null,
                 new EventTags
-            {
-                    {"revenue", 0 },
-                    {"value", 0.0 }
-            });
+                {
+                    { "revenue", 0 },
+                    { "value", 0.0 },
+                });
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
@@ -1242,59 +1351,64 @@ namespace OptimizelySDK.Tests.EventTests
             var timeStamp = TestData.SecondsSince1970();
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 10 },
-                                                    {"value", 1.0 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 10 },
+                                                    { "value", 1.0 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", 10 },
-                                                            {"value", 1.0 }
+                                                            { "revenue", 10 },
+                                                            { "value", 1.0 },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            { "attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -1303,22 +1417,24 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
-            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase", TestUserId, null,
+            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase",
+                TestUserId, null,
                 new EventTags
-            {
-                    {"revenue", 10 },
-                    {"value", 1.0 }
-            });
+                {
+                    { "revenue", 10 },
+                    { "value", 1.0 },
+                });
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
@@ -1330,59 +1446,64 @@ namespace OptimizelySDK.Tests.EventTests
             var timeStamp = TestData.SecondsSince1970();
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                    {"revenue", 1 },
-                                                    {"value", 10.0 },
-                                                    {"tags",
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                    { "revenue", 1 },
+                                                    { "value", 10.0 },
+                                                    {
+                                                        "tags",
                                                         new Dictionary<string, object>
                                                         {
-                                                            {"revenue", 1 },
-                                                            {"value", 10.0 }
+                                                            { "revenue", 1 },
+                                                            { "value", 10.0 },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            { "attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -1391,23 +1512,25 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
-            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase", TestUserId, null,
+            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase",
+                TestUserId, null,
                 new EventTags
-            {
-                    {"revenue", 1 },
-                    {"value", 10.0 }
-            });
+                {
+                    { "revenue", 1 },
+                    { "value", 10.0 },
+                });
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
@@ -1421,86 +1544,92 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "purchase" },
-                                                }
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
-                                        {"key", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
-                                        {"type", "custom" },
-                                        {"value", "variation"}
+                                        { "entity_id", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
+                                        { "key", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", "variation" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
-            "https://logx.optimizely.com/v1/events",
-            payloadParams,
-            "POST",
-            new Dictionary<string, string>
-            {
-                { "Content-Type", "application/json"}
-            });
+                "https://logx.optimizely.com/v1/events",
+                payloadParams,
+                "POST",
+                new Dictionary<string, string>
+                {
+                    { "Content-Type", "application/json" },
+                });
 
             var userAttributes = new UserAttributes
             {
-                { "device_type", "iPhone"},
-                {"company", "Optimizely" },
-                {ControlAttributes.BUCKETING_ID_ATTRIBUTE, "variation" }
+                { "device_type", "iPhone" },
+                { "company", "Optimizely" },
+                { ControlAttributes.BUCKETING_ID_ATTRIBUTE, "variation" },
             };
 
-            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase", TestUserId, userAttributes, null);
+            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase",
+                TestUserId, userAttributes, null);
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
@@ -1513,82 +1642,89 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" },
-                                                    { "metadata", new Dictionary<string, object> {
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "7722370027" },
+                                                    {
+                                                        "metadata", new Dictionary<string, object>
+                                                        {
                                                             { "rule_type", "experiment" },
                                                             { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
                                                             { "variation_key", "control" },
-                                                            {"enabled", false }
+                                                            { "enabled", false },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
-                                        {"key", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
-                                        {"type", "custom" },
-                                        {"value", "variation"}
+                                        { "entity_id", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
+                                        { "key", ControlAttributes.BUCKETING_ID_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", "variation" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"enrich_decisions", true},
-                {"account_id", "1592310167" },
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -1596,19 +1732,22 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
                 { "device_type", "iPhone" },
                 { "company", "Optimizely" },
-                {ControlAttributes.BUCKETING_ID_ATTRIBUTE, "variation" }
+                { ControlAttributes.BUCKETING_ID_ATTRIBUTE, "variation" },
             };
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config, Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId, userAttributes, "test_experiment", "experiment");
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(Config,
+                Config.GetExperimentFromKey("test_experiment"), "7722370027", TestUserId,
+                userAttributes, "test_experiment", "experiment");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp,
+                Guid.Parse(impressionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
         }
@@ -1621,75 +1760,82 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" },
-                                                    { "metadata", new Dictionary<string, object> {
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "7722370027" },
+                                                    {
+                                                        "metadata", new Dictionary<string, object>
+                                                        {
                                                             { "rule_type", "experiment" },
                                                             { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
                                                             { "variation_key", "control" },
-                                                            {"enabled", false }
+                                                            { "enabled", false },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"key", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"type", "custom" },
-                                        {"value", "chrome"}
+                                        { "entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "key", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", "chrome" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -1697,22 +1843,25 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
-                {ControlAttributes.USER_AGENT_ATTRIBUTE, "chrome" }
+                { ControlAttributes.USER_AGENT_ATTRIBUTE, "chrome" },
             };
 
             var botFilteringEnabledConfig = Config;
             botFilteringEnabledConfig.BotFiltering = true;
             var experiment = botFilteringEnabledConfig.GetExperimentFromKey("test_experiment");
 
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(botFilteringEnabledConfig, experiment, "7722370027", TestUserId, userAttributes, "test_experiment", "experiment");
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(botFilteringEnabledConfig,
+                experiment, "7722370027", TestUserId, userAttributes, "test_experiment",
+                "experiment");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp,
+                Guid.Parse(impressionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
         }
@@ -1725,68 +1874,75 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                { "visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>()
                         {
-                            { "snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        { "decisions", new object[]
+                                        {
+                                            "decisions", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"campaign_id", "7719770039" },
-                                                    {"experiment_id", "7716830082" },
-                                                    {"variation_id", "7722370027" },
-                                                    { "metadata", new Dictionary<string, object> {
+                                                    { "campaign_id", "7719770039" },
+                                                    { "experiment_id", "7716830082" },
+                                                    { "variation_id", "7722370027" },
+                                                    {
+                                                        "metadata", new Dictionary<string, object>
+                                                        {
                                                             { "rule_type", "experiment" },
                                                             { "rule_key", "test_experiment" },
                                                             { "flag_key", "test_experiment" },
                                                             { "variation_key", "control" },
-                                                            {"enabled", false }
+                                                            { "enabled", false },
                                                         }
-                                                    }
-                                                }
+                                                    },
+                                                },
                                             }
                                         },
-                                        { "events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7719770039" },
-                                                    {"timestamp", timeStamp },
-                                                    {"uuid", guid },
-                                                    {"key", "campaign_activated" }
-                                                }
+                                                    { "entity_id", "7719770039" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "campaign_activated" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"attributes", new object[]
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"key", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"type", "custom" },
-                                        {"value", "chrome"}
-                                    }
+                                        { "entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "key", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", "chrome" },
+                                    },
                                 }
                             },
-                            { "visitor_id", TestUserId }
-                        }
+                            { "visitor_id", TestUserId },
+                        },
                     }
                 },
-                {"project_id", "7720880029" },
-                {"account_id", "1592310167" },
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk" },
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedLogEvent = new LogEvent("https://logx.optimizely.com/v1/events",
@@ -1794,22 +1950,25 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json" }
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
-                {ControlAttributes.USER_AGENT_ATTRIBUTE, "chrome" }
+                { ControlAttributes.USER_AGENT_ATTRIBUTE, "chrome" },
             };
 
             var botFilteringDisabledConfig = Config;
             botFilteringDisabledConfig.BotFiltering = null;
             var experiment = botFilteringDisabledConfig.GetExperimentFromKey("test_experiment");
 
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(botFilteringDisabledConfig, experiment, "7722370027", TestUserId, userAttributes, "test_experiment", "experiment");
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(botFilteringDisabledConfig,
+                experiment, "7722370027", TestUserId, userAttributes, "test_experiment",
+                "experiment");
             var logEvent = EventFactory.CreateLogEvent(impressionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp, Guid.Parse(impressionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, impressionEvent.Timestamp,
+                Guid.Parse(impressionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
         }
@@ -1822,57 +1981,61 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                {"visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>
                         {
-                            {"snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063"},
-                                                    {"timestamp", timeStamp},
-                                                    {"uuid", guid},
-                                                    {"key", "purchase"},
-                                                }
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"visitor_id", TestUserId },
-                            {"attributes", new object[]
+                            { "visitor_id", TestUserId },
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"key", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"type", "custom" },
-                                        {"value", "safari"}
+                                        { "entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "key", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", "safari" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
-                            }
-                        }
+                            },
+                        },
                     }
                 },
-                {"project_id", "7720880029"},
-                {"account_id", "1592310167"},
-                {"enrich_decisions", true} ,
-                {"client_name", "csharp-sdk"},
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -1881,25 +2044,27 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
-                {ControlAttributes.USER_AGENT_ATTRIBUTE, "safari" }
+                { ControlAttributes.USER_AGENT_ATTRIBUTE, "safari" },
             };
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
             var botFilteringEnabledConfig = Config;
             botFilteringEnabledConfig.BotFiltering = true;
 
-            var conversionEvent = UserEventFactory.CreateConversionEvent(botFilteringEnabledConfig, "purchase", TestUserId, userAttributes, null);
+            var conversionEvent = UserEventFactory.CreateConversionEvent(botFilteringEnabledConfig,
+                "purchase", TestUserId, userAttributes, null);
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
@@ -1912,50 +2077,54 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                {"visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>
                         {
-                            {"snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063"},
-                                                    {"timestamp", timeStamp},
-                                                    {"uuid", guid},
-                                                    {"key", "purchase"},
-                                                }
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"visitor_id", TestUserId },
-                            {"attributes", new object[]
+                            { "visitor_id", TestUserId },
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"key", ControlAttributes.USER_AGENT_ATTRIBUTE },
-                                        {"type", "custom" },
-                                        {"value", "safari"}
-                                    }
+                                        { "entity_id", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "key", ControlAttributes.USER_AGENT_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", "safari" },
+                                    },
                                 }
-                            }
-                        }
+                            },
+                        },
                     }
                 },
-                {"project_id", "7720880029"},
-                {"enrich_decisions", true},
-                {"account_id", "1592310167"},
-                {"client_name", "csharp-sdk"},
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "enrich_decisions", true },
+                { "account_id", "1592310167" },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -1964,25 +2133,27 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
             {
-                {ControlAttributes.USER_AGENT_ATTRIBUTE, "safari" }
+                { ControlAttributes.USER_AGENT_ATTRIBUTE, "safari" },
             };
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
 
             var botFilteringDisabledConfig = Config;
             botFilteringDisabledConfig.BotFiltering = null;
 
-            var conversionEvent = UserEventFactory.CreateConversionEvent(botFilteringDisabledConfig, "purchase", TestUserId, userAttributes, null);
+            var conversionEvent = UserEventFactory.CreateConversionEvent(botFilteringDisabledConfig,
+                "purchase", TestUserId, userAttributes, null);
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
@@ -1993,28 +2164,30 @@ namespace OptimizelySDK.Tests.EventTests
             var guid = Guid.NewGuid();
             var timeStamp = TestData.SecondsSince1970();
 
-            var eventInMultiExperimentConfig = DatafileProjectConfig.Create(TestData.SimpleABExperimentsDatafile, new NoOpLogger(), new ErrorHandler.NoOpErrorHandler());
+            var eventInMultiExperimentConfig = DatafileProjectConfig.Create(
+                TestData.SimpleABExperimentsDatafile, new NoOpLogger(), new NoOpErrorHandler());
 
             var experimentIdVariationMap = new Dictionary<string, Variation>
             {
                 {
-                    "111127", new Variation{Id="111129", Key="variation"}
+                    "111127", new Variation { Id = "111129", Key = "variation" }
                 },
                 {
-                    "111130", new Variation{Id="111131", Key="variation"}
-                }
+                    "111130", new Variation { Id = "111131", Key = "variation" }
+                },
             };
 
             var payloadParams = new Dictionary<string, object>
+            {
+                { "client_version", Optimizely.SDK_VERSION },
+                { "project_id", "111001" },
+                { "enrich_decisions", true },
+                { "account_id", "12001" },
+                { "client_name", "csharp-sdk" },
+                { "anonymize_ip", false },
+                { "revision", eventInMultiExperimentConfig.Revision },
                 {
-                {"client_version", Optimizely.SDK_VERSION},
-                {"project_id", "111001"},
-                {"enrich_decisions", true},
-                {"account_id", "12001"},
-                {"client_name", "csharp-sdk"},
-                {"anonymize_ip", false},
-                {"revision", eventInMultiExperimentConfig.Revision},
-                {"visitors", new object[]
+                    "visitors", new object[]
                     {
                         //visitors[0]
                         new Dictionary<string, object>
@@ -2025,17 +2198,18 @@ namespace OptimizelySDK.Tests.EventTests
                                 {
                                     new Dictionary<string, string>
                                     {
-                                        {"entity_id", "111094"},
-                                        {"type", "custom"},
-                                        {"value", "test_value"},
-                                        {"key", "test_attribute"}
-                                    }
+                                        { "entity_id", "111094" },
+                                        { "type", "custom" },
+                                        { "value", "test_value" },
+                                        { "key", "test_attribute" },
+                                    },
                                 }
                             },
                             //visitors[0].visitor_id
-                            {"visitor_id", "test_user"},
+                            { "visitor_id", "test_user" },
                             //visitors[0].snapshots
-                            {"snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     //snapshots[0]
                                     new Dictionary<string, object>
@@ -2046,34 +2220,32 @@ namespace OptimizelySDK.Tests.EventTests
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"uuid", guid},
-                                                    {"timestamp", timeStamp},
-                                                    {"revenue", 4200},
-                                                    {"value", 1.234},
-                                                    {"key", "event_with_multiple_running_experiments"},
-                                                    {"entity_id", "111095"},
+                                                    { "uuid", guid },
+                                                    { "timestamp", timeStamp },
+                                                    { "revenue", 4200 },
+                                                    { "value", 1.234 },
+                                                    {
+                                                        "key",
+                                                        "event_with_multiple_running_experiments"
+                                                    },
+                                                    { "entity_id", "111095" },
                                                     {
                                                         "tags", new Dictionary<string, object>
                                                         {
-                                                            {"non-revenue", "abc"},
-                                                            {"revenue", 4200},
-                                                            {"value", 1.234},
+                                                            { "non-revenue", "abc" },
+                                                            { "revenue", 4200 },
+                                                            { "value", 1.234 },
                                                         }
-                                                    }
-
-                                                }
+                                                    },
+                                                },
                                             }
-                                        }
-
-                                    }
-
+                                        },
+                                    },
                                 }
-                            }
-
-                        }
+                            },
+                        },
                     }
-
-                }
+                },
             };
 
 
@@ -2083,20 +2255,25 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
-            var conversionEvent = UserEventFactory.CreateConversionEvent(eventInMultiExperimentConfig, "event_with_multiple_running_experiments", "test_user",
-                                                              new UserAttributes {
-                                                                {"test_attribute", "test_value"}
-                                                              },
-                                                              new EventTags {
-                                                                {"revenue", 4200},
-                                                                {"value", 1.234},
-                                                                {"non-revenue", "abc"}
-                                                             });
+            var conversionEvent = UserEventFactory.CreateConversionEvent(
+                eventInMultiExperimentConfig, "event_with_multiple_running_experiments",
+                "test_user",
+                new UserAttributes
+                {
+                    { "test_attribute", "test_value" },
+                },
+                new EventTags
+                {
+                    { "revenue", 4200 },
+                    { "value", 1.234 },
+                    { "non-revenue", "abc" },
+                });
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedLogEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
 
             Assert.IsTrue(TestData.CompareObjects(expectedLogEvent, logEvent));
         }
@@ -2109,71 +2286,75 @@ namespace OptimizelySDK.Tests.EventTests
 
             var payloadParams = new Dictionary<string, object>
             {
-                {"visitors", new object[]
+                {
+                    "visitors", new object[]
                     {
                         new Dictionary<string, object>
                         {
-                            {"snapshots", new object[]
+                            {
+                                "snapshots", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"events", new object[]
+                                        {
+                                            "events", new object[]
                                             {
                                                 new Dictionary<string, object>
                                                 {
-                                                    {"entity_id", "7718020063"},
-                                                    {"timestamp", timeStamp},
-                                                    {"uuid", guid},
-                                                    {"key", "purchase"},
-                                                }
+                                                    { "entity_id", "7718020063" },
+                                                    { "timestamp", timeStamp },
+                                                    { "uuid", guid },
+                                                    { "key", "purchase" },
+                                                },
                                             }
-                                        }
-                                    }
+                                        },
+                                    },
                                 }
                             },
-                            {"visitor_id", TestUserId },
-                            {"attributes", new object[]
+                            { "visitor_id", TestUserId },
+                            {
+                                "attributes", new object[]
                                 {
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "7723280020" },
-                                        {"key", "device_type" },
-                                        {"type", "custom" },
-                                        {"value", "iPhone"}
+                                        { "entity_id", "7723280020" },
+                                        { "key", "device_type" },
+                                        { "type", "custom" },
+                                        { "value", "iPhone" },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "323434545" },
-                                        {"key", "boolean_key" },
-                                        {"type", "custom" },
-                                        {"value", true}
+                                        { "entity_id", "323434545" },
+                                        { "key", "boolean_key" },
+                                        { "type", "custom" },
+                                        { "value", true },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", "808797686" },
-                                        {"key", "double_key" },
-                                        {"type", "custom" },
-                                        {"value", 3.14}
+                                        { "entity_id", "808797686" },
+                                        { "key", "double_key" },
+                                        { "type", "custom" },
+                                        { "value", 3.14 },
                                     },
                                     new Dictionary<string, object>
                                     {
-                                        {"entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"key", ControlAttributes.BOT_FILTERING_ATTRIBUTE},
-                                        {"type", "custom" },
-                                        {"value", true }
-                                    }
+                                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                                        { "type", "custom" },
+                                        { "value", true },
+                                    },
                                 }
-                            }
-                        }
+                            },
+                        },
                     }
                 },
-                {"project_id", "7720880029"},
-                {"account_id", "1592310167"},
-                {"enrich_decisions", true},
-                {"client_name", "csharp-sdk"},
-                {"client_version", Optimizely.SDK_VERSION },
-                {"revision", "15" },
-                {"anonymize_ip", false}
+                { "project_id", "7720880029" },
+                { "account_id", "1592310167" },
+                { "enrich_decisions", true },
+                { "client_name", "csharp-sdk" },
+                { "client_version", Optimizely.SDK_VERSION },
+                { "revision", "15" },
+                { "anonymize_ip", false },
             };
 
             var expectedEvent = new LogEvent(
@@ -2182,7 +2363,7 @@ namespace OptimizelySDK.Tests.EventTests
                 "POST",
                 new Dictionary<string, string>
                 {
-                    { "Content-Type", "application/json"}
+                    { "Content-Type", "application/json" },
                 });
 
             var userAttributes = new UserAttributes
@@ -2202,14 +2383,15 @@ namespace OptimizelySDK.Tests.EventTests
 
             var experimentToVariationMap = new Dictionary<string, Variation>
             {
-                {"7716830082", new Variation{Id="7722370027", Key="control"} }
+                { "7716830082", new Variation { Id = "7722370027", Key = "control" } },
             };
-            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase", TestUserId, userAttributes, null);
+            var conversionEvent = UserEventFactory.CreateConversionEvent(Config, "purchase",
+                TestUserId, userAttributes, null);
             var logEvent = EventFactory.CreateLogEvent(conversionEvent, Logger);
 
-            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp, Guid.Parse(conversionEvent.UUID));
+            TestData.ChangeGUIDAndTimeStamp(expectedEvent.Params, conversionEvent.Timestamp,
+                Guid.Parse(conversionEvent.UUID));
             Assert.IsTrue(TestData.CompareObjects(expectedEvent, logEvent));
         }
     }
 }
-

--- a/OptimizelySDK.Tests/EventTests/EventProcessorProps.cs
+++ b/OptimizelySDK.Tests/EventTests/EventProcessorProps.cs
@@ -33,23 +33,28 @@ namespace OptimizelySDK.Tests.EventTest
         public EventProcessorProps(BatchEventProcessor eventProcessor)
         {
             var fieldsInfo = Reflection.GetAllFields(eventProcessor.GetType());
-            BatchSize = Reflection.GetFieldValue<int, BatchEventProcessor>(eventProcessor, "BatchSize", fieldsInfo);
-            FlushInterval = Reflection.GetFieldValue<TimeSpan, BatchEventProcessor>(eventProcessor, "FlushInterval", fieldsInfo);
-            TimeoutInterval = Reflection.GetFieldValue<TimeSpan, BatchEventProcessor>(eventProcessor, "TimeoutInterval", fieldsInfo);
+            BatchSize =
+                Reflection.GetFieldValue<int, BatchEventProcessor>(eventProcessor, "BatchSize",
+                    fieldsInfo);
+            FlushInterval =
+                Reflection.GetFieldValue<TimeSpan, BatchEventProcessor>(eventProcessor,
+                    "FlushInterval", fieldsInfo);
+            TimeoutInterval =
+                Reflection.GetFieldValue<TimeSpan, BatchEventProcessor>(eventProcessor,
+                    "TimeoutInterval", fieldsInfo);
         }
 
         /// <summary>
         /// To create default instance of expected values.
         /// </summary>
-        public EventProcessorProps()
-        {
-
-        }
+        public EventProcessorProps() { }
 
         public override bool Equals(object obj)
         {
             if (obj == null)
+            {
                 return false;
+            }
 
             var eventProcessor = obj as EventProcessorProps;
             if (eventProcessor == null)
@@ -59,7 +64,8 @@ namespace OptimizelySDK.Tests.EventTest
 
             if (BatchSize != eventProcessor.BatchSize ||
                 FlushInterval.TotalMilliseconds != eventProcessor.FlushInterval.TotalMilliseconds ||
-                TimeoutInterval.TotalMilliseconds != eventProcessor.TimeoutInterval.TotalMilliseconds)
+                TimeoutInterval.TotalMilliseconds !=
+                eventProcessor.TimeoutInterval.TotalMilliseconds)
             {
                 return false;
             }

--- a/OptimizelySDK.Tests/EventTests/ForwardingEventProcessorTest.cs
+++ b/OptimizelySDK.Tests/EventTests/ForwardingEventProcessorTest.cs
@@ -12,7 +12,7 @@ using OptimizelySDK.Notifications;
 namespace OptimizelySDK.Tests.EventTests
 {
     [TestFixture]
-    class ForwardingEventProcessorTest
+    internal class ForwardingEventProcessorTest
     {
         private const string UserId = "userId";
         private const string EventName = "purchase";
@@ -21,10 +21,10 @@ namespace OptimizelySDK.Tests.EventTests
         private TestForwardingEventDispatcher EventDispatcher;
         private NotificationCenter NotificationCenter = new NotificationCenter();
 
-        Mock<ILogger> LoggerMock;
-        Mock<IErrorHandler> ErrorHandlerMock;
+        private Mock<ILogger> LoggerMock;
+        private Mock<IErrorHandler> ErrorHandlerMock;
 
-        ProjectConfig ProjectConfig;
+        private ProjectConfig ProjectConfig;
 
         [SetUp]
         public void Setup()
@@ -35,17 +35,19 @@ namespace OptimizelySDK.Tests.EventTests
             ErrorHandlerMock = new Mock<IErrorHandler>();
             ErrorHandlerMock.Setup(e => e.HandleError(It.IsAny<Exception>()));
 
-            ProjectConfig = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object, new NoOpErrorHandler());
+            ProjectConfig = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object,
+                new NoOpErrorHandler());
 
             EventDispatcher = new TestForwardingEventDispatcher { IsUpdated = false };
-            EventProcessor = new ForwardingEventProcessor(EventDispatcher, NotificationCenter, LoggerMock.Object, ErrorHandlerMock.Object);
+            EventProcessor = new ForwardingEventProcessor(EventDispatcher, NotificationCenter,
+                LoggerMock.Object, ErrorHandlerMock.Object);
         }
 
         [Test]
         public void TestEventHandlerWithConversionEvent()
         {
             var userEvent = CreateConversionEvent(EventName);
-            EventProcessor.Process(userEvent);            
+            EventProcessor.Process(userEvent);
 
             Assert.True(EventDispatcher.IsUpdated);
         }
@@ -54,19 +56,22 @@ namespace OptimizelySDK.Tests.EventTests
         [Test]
         public void TestExceptionWhileDispatching()
         {
-            var eventProcessor = new ForwardingEventProcessor(new InvalidEventDispatcher(), NotificationCenter, LoggerMock.Object, ErrorHandlerMock.Object);
+            var eventProcessor = new ForwardingEventProcessor(new InvalidEventDispatcher(),
+                NotificationCenter, LoggerMock.Object, ErrorHandlerMock.Object);
             var userEvent = CreateConversionEvent(EventName);
 
             eventProcessor.Process(userEvent);
-            
-            ErrorHandlerMock.Verify(errorHandler => errorHandler.HandleError(It.IsAny<Exception>()), Times.Once );            
+
+            ErrorHandlerMock.Verify(errorHandler => errorHandler.HandleError(It.IsAny<Exception>()),
+                Times.Once);
         }
 
         [Test]
         public void TestNotifications()
         {
-            bool notificationTriggered = false;
-            NotificationCenter.AddNotification(NotificationCenter.NotificationType.LogEvent, logEvent => notificationTriggered = true);
+            var notificationTriggered = false;
+            NotificationCenter.AddNotification(NotificationCenter.NotificationType.LogEvent,
+                logEvent => notificationTriggered = true);
             var userEvent = CreateConversionEvent(EventName);
 
             EventProcessor.Process(userEvent);
@@ -77,7 +82,8 @@ namespace OptimizelySDK.Tests.EventTests
 
         private ConversionEvent CreateConversionEvent(string eventName)
         {
-            return UserEventFactory.CreateConversionEvent(ProjectConfig, eventName, UserId, new UserAttributes(), new EventTags());
+            return UserEventFactory.CreateConversionEvent(ProjectConfig, eventName, UserId,
+                new UserAttributes(), new EventTags());
         }
     }
 }

--- a/OptimizelySDK.Tests/EventTests/LogEventTest.cs
+++ b/OptimizelySDK.Tests/EventTests/LogEventTest.cs
@@ -1,5 +1,4 @@
-﻿
-using Newtonsoft.Json.Linq;
+﻿using Newtonsoft.Json.Linq;
 using NUnit.Framework;
 using OptimizelySDK.Event;
 using System;
@@ -17,7 +16,6 @@ namespace OptimizelySDK.Tests.EventTests
 
         public static bool CompareObjects(object o1, object o2)
         {
-
             var str1 = Newtonsoft.Json.JsonConvert.SerializeObject(o1);
             var str2 = Newtonsoft.Json.JsonConvert.SerializeObject(o2);
             var jtoken1 = JToken.Parse(Newtonsoft.Json.JsonConvert.SerializeObject(o1));
@@ -30,17 +28,17 @@ namespace OptimizelySDK.Tests.EventTests
         public void Setup()
         {
             LogEvent = new LogEvent(
-                url: "https://logx.optimizely.com", 
-                parameters: new Dictionary<string, object>
+                "https://logx.optimizely.com",
+                new Dictionary<string, object>
                 {
                     { "accountId", "1234" },
                     { "projectId", "9876" },
-                    { "visitorId", "testUser" }
+                    { "visitorId", "testUser" },
                 },
-                httpVerb: "POST", 
-                headers: new Dictionary<string, string>
+                "POST",
+                new Dictionary<string, string>
                 {
-                    { "Content-type", "application/json" }
+                    { "Content-type", "application/json" },
                 });
         }
 
@@ -57,7 +55,7 @@ namespace OptimizelySDK.Tests.EventTests
             {
                 { "accountId", "1234" },
                 { "projectId", "9876" },
-                { "visitorId", "testUser" }
+                { "visitorId", "testUser" },
             };
             Assert.IsTrue(CompareObjects(testParams, LogEvent.Params));
         }
@@ -73,7 +71,7 @@ namespace OptimizelySDK.Tests.EventTests
         {
             var headers = new Dictionary<string, string>
             {
-                { "Content-type", "application/json" }
+                { "Content-type", "application/json" },
             };
             Assert.IsTrue(CompareObjects(headers, LogEvent.Headers));
         }

--- a/OptimizelySDK.Tests/EventTests/LogEventTest.cs
+++ b/OptimizelySDK.Tests/EventTests/LogEventTest.cs
@@ -1,11 +1,11 @@
-﻿using Newtonsoft.Json.Linq;
-using NUnit.Framework;
-using OptimizelySDK.Event;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using OptimizelySDK.Event;
 
 namespace OptimizelySDK.Tests.EventTests
 {

--- a/OptimizelySDK.Tests/EventTests/TestEventDispatcher.cs
+++ b/OptimizelySDK.Tests/EventTests/TestEventDispatcher.cs
@@ -30,16 +30,20 @@ namespace OptimizelySDK.Tests.EventTests
         public bool CompareEvents()
         {
             if (ExpectedEvents.Count != ActualEvents.Count)
+            {
                 return false;
+            }
 
 
-            for (int count = 0; count < ExpectedEvents.Count; ++count)
+            for (var count = 0; count < ExpectedEvents.Count; ++count)
             {
                 var expectedEvent = ExpectedEvents[count];
                 var actualEvent = ActualEvents[count];
 
                 if (expectedEvent != actualEvent)
+                {
                     return false;
+                }
             }
 
             return true;
@@ -50,12 +54,14 @@ namespace OptimizelySDK.Tests.EventTests
             Visitor[] visitors = null;
             if (actualLogEvent.Params.ContainsKey("visitors"))
             {
-                JArray jArray = (JArray)actualLogEvent.Params["visitors"];
+                var jArray = (JArray)actualLogEvent.Params["visitors"];
                 visitors = jArray.ToObject<Visitor[]>();
             }
 
             if (visitors == null)
+            {
                 return;
+            }
 
             foreach (var visitor in visitors)
             {
@@ -67,11 +73,15 @@ namespace OptimizelySDK.Tests.EventTests
                         foreach (var @event in snapshot.Events)
                         {
                             var userAttributes = new UserAttributes();
-                            foreach (var attribute in visitor.Attributes.Where(attr => !attr.Key.StartsWith(DatafileProjectConfig.RESERVED_ATTRIBUTE_PREFIX))) {
+                            foreach (var attribute in visitor.Attributes.Where(attr =>
+                                         !attr.Key.StartsWith(DatafileProjectConfig.
+                                             RESERVED_ATTRIBUTE_PREFIX)))
+                            {
                                 userAttributes.Add(attribute.Key, attribute.Value);
                             }
 
-                            ActualEvents.Add(new CanonicalEvent(decision.ExperimentId, decision.VariationId, @event.Key,
+                            ActualEvents.Add(new CanonicalEvent(decision.ExperimentId,
+                                decision.VariationId, @event.Key,
                                 visitor.VisitorId, userAttributes, @event.EventTags));
                         }
                     }
@@ -84,7 +94,8 @@ namespace OptimizelySDK.Tests.EventTests
             }
             catch (ObjectDisposedException)
             {
-                Logger.Log(LogLevel.ERROR, "The CountdownEvent instance has already been disposed.");
+                Logger.Log(LogLevel.ERROR,
+                    "The CountdownEvent instance has already been disposed.");
             }
             catch (InvalidOperationException)
             {
@@ -92,19 +103,26 @@ namespace OptimizelySDK.Tests.EventTests
             }
         }
 
-        public void ExpectImpression(string experimentId, string variationId, string userId, UserAttributes attributes = null)
+        public void ExpectImpression(string experimentId, string variationId, string userId,
+            UserAttributes attributes = null
+        )
         {
             Expect(experimentId, variationId, IMPRESSION_EVENT_NAME, userId, attributes, null);
         }
 
-        public void ExpectConversion(string eventName, string userId, UserAttributes attributes = null, EventTags tags = null)
+        public void ExpectConversion(string eventName, string userId,
+            UserAttributes attributes = null, EventTags tags = null
+        )
         {
             Expect(null, null, eventName, userId, attributes, tags);
         }
 
-        private void Expect(string experimentId, string variationId, string eventName, string visitorId, UserAttributes attributes, EventTags tags)
+        private void Expect(string experimentId, string variationId, string eventName,
+            string visitorId, UserAttributes attributes, EventTags tags
+        )
         {
-            var expectedEvent = new CanonicalEvent(experimentId, variationId, eventName, visitorId, attributes, tags);
+            var expectedEvent = new CanonicalEvent(experimentId, variationId, eventName, visitorId,
+                attributes, tags);
             ExpectedEvents.Add(expectedEvent);
         }
     }

--- a/OptimizelySDK.Tests/EventTests/TestEventDispatcher.cs
+++ b/OptimizelySDK.Tests/EventTests/TestEventDispatcher.cs
@@ -1,4 +1,8 @@
-﻿using Newtonsoft.Json;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OptimizelySDK.Config;
 using OptimizelySDK.Entity;
@@ -6,10 +10,6 @@ using OptimizelySDK.Event;
 using OptimizelySDK.Event.Dispatcher;
 using OptimizelySDK.Event.Entity;
 using OptimizelySDK.Logger;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
 
 namespace OptimizelySDK.Tests.EventTests
 {

--- a/OptimizelySDK.Tests/EventTests/TestForwardingEventDispatcher.cs
+++ b/OptimizelySDK.Tests/EventTests/TestForwardingEventDispatcher.cs
@@ -1,12 +1,12 @@
-﻿using NUnit.Framework;
-using OptimizelySDK.Event;
-using OptimizelySDK.Event.Dispatcher;
-using OptimizelySDK.Logger;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using NUnit.Framework;
+using OptimizelySDK.Event;
+using OptimizelySDK.Event.Dispatcher;
+using OptimizelySDK.Logger;
 
 namespace OptimizelySDK.Tests.EventTests
 {

--- a/OptimizelySDK.Tests/EventTests/UserEventFactoryTest.cs
+++ b/OptimizelySDK.Tests/EventTests/UserEventFactoryTest.cs
@@ -38,7 +38,8 @@ namespace OptimizelySDK.Tests.EventTests
             LoggerMock = new Mock<ILogger>();
             ErrorHandlerMock = new Mock<IErrorHandler>();
 
-            Config = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object, ErrorHandlerMock.Object);
+            Config = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object,
+                ErrorHandlerMock.Object);
         }
 
         [Test]
@@ -49,7 +50,8 @@ namespace OptimizelySDK.Tests.EventTests
             var variation = Config.GetVariationFromId(experiment.Key, "77210100090");
             var userId = TestUserId;
 
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(projectConfig, experiment, variation, userId, null, "test_experiment", "experiment");
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(projectConfig, experiment,
+                variation, userId, null, "test_experiment", "experiment");
 
             Assert.AreEqual(Config.ProjectId, impressionEvent.Context.ProjectId);
             Assert.AreEqual(Config.Revision, impressionEvent.Context.Revision);
@@ -70,12 +72,14 @@ namespace OptimizelySDK.Tests.EventTests
             var variation = Config.GetVariationFromId(experiment.Key, "77210100090");
             var userId = TestUserId;
 
-            var userAttributes = new UserAttributes {
+            var userAttributes = new UserAttributes
+            {
                 { "device_type", "iPhone" },
-                { "company", "Optimizely" }
+                { "company", "Optimizely" },
             };
 
-            var impressionEvent = UserEventFactory.CreateImpressionEvent(projectConfig, experiment, variation, userId, userAttributes, "test_experiment", "experiment");
+            var impressionEvent = UserEventFactory.CreateImpressionEvent(projectConfig, experiment,
+                variation, userId, userAttributes, "test_experiment", "experiment");
 
             Assert.AreEqual(Config.ProjectId, impressionEvent.Context.ProjectId);
             Assert.AreEqual(Config.Revision, impressionEvent.Context.Revision);
@@ -87,7 +91,8 @@ namespace OptimizelySDK.Tests.EventTests
             Assert.AreEqual(userId, impressionEvent.UserId);
             Assert.AreEqual(Config.BotFiltering, impressionEvent.BotFiltering);
 
-            var expectedVisitorAttributes = EventFactory.BuildAttributeList(userAttributes, projectConfig);
+            var expectedVisitorAttributes =
+                EventFactory.BuildAttributeList(userAttributes, projectConfig);
             TestData.CompareObjects(expectedVisitorAttributes, impressionEvent.VisitorAttributes);
         }
 
@@ -99,12 +104,14 @@ namespace OptimizelySDK.Tests.EventTests
             var variation = Config.GetVariationFromId(experiment.Key, "77210100090");
             var userId = TestUserId;
             var eventKey = "purchase";
-            var userAttributes = new UserAttributes {
+            var userAttributes = new UserAttributes
+            {
                 { "device_type", "iPhone" },
-                { "company", "Optimizely" }
+                { "company", "Optimizely" },
             };
 
-            var conversionEvent = UserEventFactory.CreateConversionEvent(projectConfig, eventKey, userId, userAttributes, null);
+            var conversionEvent = UserEventFactory.CreateConversionEvent(projectConfig, eventKey,
+                userId, userAttributes, null);
 
             Assert.AreEqual(Config.ProjectId, conversionEvent.Context.ProjectId);
             Assert.AreEqual(Config.Revision, conversionEvent.Context.Revision);
@@ -115,7 +122,8 @@ namespace OptimizelySDK.Tests.EventTests
             Assert.AreEqual(userId, conversionEvent.UserId);
             Assert.AreEqual(Config.BotFiltering, conversionEvent.BotFiltering);
 
-            var expectedVisitorAttributes = EventFactory.BuildAttributeList(userAttributes, projectConfig);
+            var expectedVisitorAttributes =
+                EventFactory.BuildAttributeList(userAttributes, projectConfig);
             TestData.CompareObjects(expectedVisitorAttributes, conversionEvent.VisitorAttributes);
         }
 
@@ -128,17 +136,20 @@ namespace OptimizelySDK.Tests.EventTests
             var userId = TestUserId;
             var eventKey = "purchase";
 
-            var eventTags = new EventTags {
+            var eventTags = new EventTags
+            {
                 { "revenue", 4200 },
                 { "value", 1.234 },
-                { "non-revenue", "abc" }
+                { "non-revenue", "abc" },
             };
-            var userAttributes = new UserAttributes {
+            var userAttributes = new UserAttributes
+            {
                 { "device_type", "iPhone" },
-                { "company", "Optimizely" }
+                { "company", "Optimizely" },
             };
 
-            var conversionEvent = UserEventFactory.CreateConversionEvent(projectConfig, eventKey, userId, userAttributes, eventTags);
+            var conversionEvent = UserEventFactory.CreateConversionEvent(projectConfig, eventKey,
+                userId, userAttributes, eventTags);
 
             Assert.AreEqual(Config.ProjectId, conversionEvent.Context.ProjectId);
             Assert.AreEqual(Config.Revision, conversionEvent.Context.Revision);
@@ -150,7 +161,8 @@ namespace OptimizelySDK.Tests.EventTests
             Assert.AreEqual(Config.BotFiltering, conversionEvent.BotFiltering);
             Assert.AreEqual(eventTags, conversionEvent.EventTags);
 
-            var expectedVisitorAttributes = EventFactory.BuildAttributeList(userAttributes, projectConfig);
+            var expectedVisitorAttributes =
+                EventFactory.BuildAttributeList(userAttributes, projectConfig);
             TestData.CompareObjects(expectedVisitorAttributes, conversionEvent.VisitorAttributes);
         }
     }

--- a/OptimizelySDK.Tests/ForcedDecisionsStoreTest.cs
+++ b/OptimizelySDK.Tests/ForcedDecisionsStoreTest.cs
@@ -34,8 +34,10 @@ namespace OptimizelySDK.Tests
             forcedDecisionStore[context2] = expectedForcedDecision2;
 
             Assert.AreEqual(forcedDecisionStore.Count, 2);
-            Assert.AreEqual(forcedDecisionStore[context1].VariationKey, expectedForcedDecision1.VariationKey);
-            Assert.AreEqual(forcedDecisionStore[context2].VariationKey, expectedForcedDecision2.VariationKey);
+            Assert.AreEqual(forcedDecisionStore[context1].VariationKey,
+                expectedForcedDecision1.VariationKey);
+            Assert.AreEqual(forcedDecisionStore[context2].VariationKey,
+                expectedForcedDecision2.VariationKey);
         }
 
         [Test]
@@ -70,7 +72,8 @@ namespace OptimizelySDK.Tests
             forcedDecisionStore[context1] = expectedForcedDecision1;
 
             Assert.AreEqual(forcedDecisionStore.Count, 1);
-            Assert.AreEqual(forcedDecisionStore[context1].VariationKey, expectedForcedDecision1.VariationKey);
+            Assert.AreEqual(forcedDecisionStore[context1].VariationKey,
+                expectedForcedDecision1.VariationKey);
             Assert.IsNull(forcedDecisionStore[NullFlagKeyContext]);
         }
 
@@ -88,7 +91,8 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(forcedDecisionStore.Count, 2);
             Assert.IsTrue(forcedDecisionStore.Remove(context2));
             Assert.AreEqual(forcedDecisionStore.Count, 1);
-            Assert.AreEqual(forcedDecisionStore[context1].VariationKey, expectedForcedDecision1.VariationKey);
+            Assert.AreEqual(forcedDecisionStore[context1].VariationKey,
+                expectedForcedDecision1.VariationKey);
             Assert.IsNull(forcedDecisionStore[context2]);
         }
 
@@ -118,6 +122,5 @@ namespace OptimizelySDK.Tests
             forcedDecisionStore.RemoveAll();
             Assert.AreEqual(forcedDecisionStore.Count, 0);
         }
-
     }
 }

--- a/OptimizelySDK.Tests/IntegrationOdpDatafile.json
+++ b/OptimizelySDK.Tests/IntegrationOdpDatafile.json
@@ -1,318 +1,442 @@
 {
-	"version": "4",
-	"rollouts": [{
-			"experiments": [{
-				"status": "Running",
-				"key": "feat_no_vars_rule",
-				"layerId": "11551226731",
-				"trafficAllocation": [{
-					"entityId": "11557362669",
-					"endOfRange": 10000
-				}],
-				"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
-				"variations": [{
-					"variables": [],
-					"id": "11557362669",
-					"key": "11557362669",
-					"featureEnabled": true
-				}],
-				"forcedVariations": {},
-				"id": "11488548027"
-			}],
-			"id": "11551226731"
-		},
-		{
-			"experiments": [{
-				"status": "Paused",
-				"key": "feat_with_var_rule",
-				"layerId": "11638870867",
-				"trafficAllocation": [{
-					"entityId": "11475708558",
-					"endOfRange": 0
-				}],
-				"audienceIds": [],
-				"variations": [{
-					"variables": [],
-					"id": "11475708558",
-					"key": "11475708558",
-					"featureEnabled": false
-				}],
-				"forcedVariations": {},
-				"id": "11630490911"
-			}],
-			"id": "11638870867"
-		},
-		{
-			"experiments": [{
-				"status": "Running",
-				"key": "11488548028",
-				"layerId": "11551226732",
-				"trafficAllocation": [{
-					"entityId": "11557362670",
-					"endOfRange": 10000
-				}],
-				"audienceIds": ["0"],
-				"audienceConditions": ["and", ["or", "3468206642", "3988293898"],
-					["or", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"]
-				],
-				"variations": [{
-					"variables": [],
-					"id": "11557362670",
-					"key": "11557362670",
-					"featureEnabled": true
-				}],
-				"forcedVariations": {},
-				"id": "11488548028"
-			}],
-			"id": "11551226732"
-		},
-		{
-			"experiments": [{
-				"status": "Paused",
-				"key": "11630490912",
-				"layerId": "11638870868",
-				"trafficAllocation": [{
-					"entityId": "11475708559",
-					"endOfRange": 0
-				}],
-				"audienceIds": [],
-				"variations": [{
-					"variables": [],
-					"id": "11475708559",
-					"key": "11475708559",
-					"featureEnabled": false
-				}],
-				"forcedVariations": {},
-				"id": "11630490912"
-			}],
-			"id": "11638870868"
-		}
-	],
-	"anonymizeIP": false,
-	"projectId": "11624721371",
-	"variables": [],
-	"featureFlags": [{
-			"experimentIds": [],
-			"rolloutId": "11551226731",
-			"variables": [],
-			"id": "11477755619",
-			"key": "feat_no_vars"
-		},
-		{
-			"experimentIds": [
-				"11564051718"
-			],
-			"rolloutId": "11638870867",
-			"variables": [{
-				"defaultValue": "x",
-				"type": "string",
-				"id": "11535264366",
-				"key": "x"
-			}],
-			"id": "11567102051",
-			"key": "feat_with_var"
-		},
-		{
-			"experimentIds": [],
-			"rolloutId": "11551226732",
-			"variables": [],
-			"id": "11567102052",
-			"key": "feat2"
-		},
-		{
-			"experimentIds": ["1323241599"],
-			"rolloutId": "11638870868",
-			"variables": [{
-				"defaultValue": "10",
-				"type": "integer",
-				"id": "11535264367",
-				"key": "z"
-			}],
-			"id": "11567102053",
-			"key": "feat2_with_var"
-		}
-	],
-	"experiments": [{
-			"status": "Running",
-			"key": "feat_with_var_test",
-			"layerId": "11504144555",
-			"trafficAllocation": [{
-				"entityId": "11617170975",
-				"endOfRange": 10000
-			}],
-			"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
-			"variations": [{
-				"variables": [{
-					"id": "11535264366",
-					"value": "xyz"
-				}],
-				"id": "11617170975",
-				"key": "variation_2",
-				"featureEnabled": true
-			}],
-			"forcedVariations": {},
-			"id": "11564051718"
-		},
-		{
-			"id": "1323241597",
-			"key": "typed_audience_experiment",
-			"layerId": "1630555627",
-			"status": "Running",
-			"variations": [{
-				"id": "1423767503",
-				"key": "A",
-				"variables": []
-			}],
-			"trafficAllocation": [{
-				"entityId": "1423767503",
-				"endOfRange": 10000
-			}],
-			"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
-			"forcedVariations": {}
-		},
-		{
-			"id": "1323241598",
-			"key": "audience_combinations_experiment",
-			"layerId": "1323241598",
-			"status": "Running",
-			"variations": [{
-				"id": "1423767504",
-				"key": "A",
-				"variables": []
-			}],
-			"trafficAllocation": [{
-				"entityId": "1423767504",
-				"endOfRange": 10000
-			}],
-			"audienceIds": ["0"],
-			"audienceConditions": ["and", ["or", "3468206642", "3988293898"],
-				["or", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"]
-			],
-			"forcedVariations": {}
-		},
-		{
-			"id": "1323241599",
-			"key": "feat2_with_var_test",
-			"layerId": "1323241600",
-			"status": "Running",
-			"variations": [{
-				"variables": [{
-					"id": "11535264367",
-					"value": "150"
-				}],
-				"id": "1423767505",
-				"key": "variation_2",
-				"featureEnabled": true
-			}],
-			"trafficAllocation": [{
-				"entityId": "1423767505",
-				"endOfRange": 10000
-			}],
-			"audienceIds": ["0"],
-			"audienceConditions": ["and", ["or", "3468206642", "3988293898"],
-				["or", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"]
-			],
-			"forcedVariations": {}
-		}
-	],
-	"audiences": [
-		{
-			"id": "3468206642",
-			"name": "exactString",
-			"conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"house\", \"type\": \"custom_attribute\", \"value\": \"Gryffindor\"}]]]"
-		},
-		{
-			"id": "3468206645",
-			"name": "notChrome",
-			"conditions": "[\"and\", [\"or\", [\"not\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\":\"Chrome\"}]]]]"
-		},
-		{
-			"id": "3988293898",
-			"name": "$$dummySubstringString",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3988293899",
-			"name": "$$dummyExists",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3468206646",
-			"name": "$$dummyExactNumber",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3468206647",
-			"name": "$$dummyGtNumber",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3468206644",
-			"name": "$$dummyLtNumber",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3468206643",
-			"name": "$$dummyExactBoolean",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "0",
-			"name": "$$dummy",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "$opt_dummy_audience",
-			"name": "dummy_audience",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		}
-	],
-	"typedAudiences": [],
-	"groups": [],
-	"integrations": [
-		{
-			"key": "odp",
-			"host": "https://api.zaius.com",
-			"publicKey": "fake-public-key"
-		}
-	],
-	"attributes": [{
-			"key": "house",
-			"id": "594015"
-		},
-		{
-			"key": "lasers",
-			"id": "594016"
-		},
-		{
-			"key": "should_do_it",
-			"id": "594017"
-		},
-		{
-			"key": "favorite_ice_cream",
-			"id": "594018"
-		}
-	],
-	"botFiltering": false,
-	"accountId": "4879520872",
-	"events": [{
-			"key": "item_bought",
-			"id": "594089",
-			"experimentIds": [
-				"11564051718",
-				"1323241597"
-			]
-		},
-		{
-			"key": "user_signed_up",
-			"id": "594090",
-			"experimentIds": [
-				"1323241598",
-				"1323241599"
-			]
-		}
-	],
-	"revision": "3",
-	"sdkKey": "typedAudienceDatafile",
-	"environmentKey": "Production"
+  "version": "4",
+  "rollouts": [
+    {
+      "experiments": [
+        {
+          "status": "Running",
+          "key": "feat_no_vars_rule",
+          "layerId": "11551226731",
+          "trafficAllocation": [
+            {
+              "entityId": "11557362669",
+              "endOfRange": 10000
+            }
+          ],
+          "audienceIds": [
+            "3468206642",
+            "3988293898",
+            "3988293899",
+            "3468206646",
+            "3468206647",
+            "3468206644",
+            "3468206643"
+          ],
+          "variations": [
+            {
+              "variables": [],
+              "id": "11557362669",
+              "key": "11557362669",
+              "featureEnabled": true
+            }
+          ],
+          "forcedVariations": {},
+          "id": "11488548027"
+        }
+      ],
+      "id": "11551226731"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Paused",
+          "key": "feat_with_var_rule",
+          "layerId": "11638870867",
+          "trafficAllocation": [
+            {
+              "entityId": "11475708558",
+              "endOfRange": 0
+            }
+          ],
+          "audienceIds": [],
+          "variations": [
+            {
+              "variables": [],
+              "id": "11475708558",
+              "key": "11475708558",
+              "featureEnabled": false
+            }
+          ],
+          "forcedVariations": {},
+          "id": "11630490911"
+        }
+      ],
+      "id": "11638870867"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Running",
+          "key": "11488548028",
+          "layerId": "11551226732",
+          "trafficAllocation": [
+            {
+              "entityId": "11557362670",
+              "endOfRange": 10000
+            }
+          ],
+          "audienceIds": [
+            "0"
+          ],
+          "audienceConditions": [
+            "and",
+            [
+              "or",
+              "3468206642",
+              "3988293898"
+            ],
+            [
+              "or",
+              "3988293899",
+              "3468206646",
+              "3468206647",
+              "3468206644",
+              "3468206643"
+            ]
+          ],
+          "variations": [
+            {
+              "variables": [],
+              "id": "11557362670",
+              "key": "11557362670",
+              "featureEnabled": true
+            }
+          ],
+          "forcedVariations": {},
+          "id": "11488548028"
+        }
+      ],
+      "id": "11551226732"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Paused",
+          "key": "11630490912",
+          "layerId": "11638870868",
+          "trafficAllocation": [
+            {
+              "entityId": "11475708559",
+              "endOfRange": 0
+            }
+          ],
+          "audienceIds": [],
+          "variations": [
+            {
+              "variables": [],
+              "id": "11475708559",
+              "key": "11475708559",
+              "featureEnabled": false
+            }
+          ],
+          "forcedVariations": {},
+          "id": "11630490912"
+        }
+      ],
+      "id": "11638870868"
+    }
+  ],
+  "anonymizeIP": false,
+  "projectId": "11624721371",
+  "variables": [],
+  "featureFlags": [
+    {
+      "experimentIds": [],
+      "rolloutId": "11551226731",
+      "variables": [],
+      "id": "11477755619",
+      "key": "feat_no_vars"
+    },
+    {
+      "experimentIds": [
+        "11564051718"
+      ],
+      "rolloutId": "11638870867",
+      "variables": [
+        {
+          "defaultValue": "x",
+          "type": "string",
+          "id": "11535264366",
+          "key": "x"
+        }
+      ],
+      "id": "11567102051",
+      "key": "feat_with_var"
+    },
+    {
+      "experimentIds": [],
+      "rolloutId": "11551226732",
+      "variables": [],
+      "id": "11567102052",
+      "key": "feat2"
+    },
+    {
+      "experimentIds": [
+        "1323241599"
+      ],
+      "rolloutId": "11638870868",
+      "variables": [
+        {
+          "defaultValue": "10",
+          "type": "integer",
+          "id": "11535264367",
+          "key": "z"
+        }
+      ],
+      "id": "11567102053",
+      "key": "feat2_with_var"
+    }
+  ],
+  "experiments": [
+    {
+      "status": "Running",
+      "key": "feat_with_var_test",
+      "layerId": "11504144555",
+      "trafficAllocation": [
+        {
+          "entityId": "11617170975",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [
+        "3468206642",
+        "3988293898",
+        "3988293899",
+        "3468206646",
+        "3468206647",
+        "3468206644",
+        "3468206643"
+      ],
+      "variations": [
+        {
+          "variables": [
+            {
+              "id": "11535264366",
+              "value": "xyz"
+            }
+          ],
+          "id": "11617170975",
+          "key": "variation_2",
+          "featureEnabled": true
+        }
+      ],
+      "forcedVariations": {},
+      "id": "11564051718"
+    },
+    {
+      "id": "1323241597",
+      "key": "typed_audience_experiment",
+      "layerId": "1630555627",
+      "status": "Running",
+      "variations": [
+        {
+          "id": "1423767503",
+          "key": "A",
+          "variables": []
+        }
+      ],
+      "trafficAllocation": [
+        {
+          "entityId": "1423767503",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [
+        "3468206642",
+        "3988293898",
+        "3988293899",
+        "3468206646",
+        "3468206647",
+        "3468206644",
+        "3468206643"
+      ],
+      "forcedVariations": {}
+    },
+    {
+      "id": "1323241598",
+      "key": "audience_combinations_experiment",
+      "layerId": "1323241598",
+      "status": "Running",
+      "variations": [
+        {
+          "id": "1423767504",
+          "key": "A",
+          "variables": []
+        }
+      ],
+      "trafficAllocation": [
+        {
+          "entityId": "1423767504",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [
+        "0"
+      ],
+      "audienceConditions": [
+        "and",
+        [
+          "or",
+          "3468206642",
+          "3988293898"
+        ],
+        [
+          "or",
+          "3988293899",
+          "3468206646",
+          "3468206647",
+          "3468206644",
+          "3468206643"
+        ]
+      ],
+      "forcedVariations": {}
+    },
+    {
+      "id": "1323241599",
+      "key": "feat2_with_var_test",
+      "layerId": "1323241600",
+      "status": "Running",
+      "variations": [
+        {
+          "variables": [
+            {
+              "id": "11535264367",
+              "value": "150"
+            }
+          ],
+          "id": "1423767505",
+          "key": "variation_2",
+          "featureEnabled": true
+        }
+      ],
+      "trafficAllocation": [
+        {
+          "entityId": "1423767505",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [
+        "0"
+      ],
+      "audienceConditions": [
+        "and",
+        [
+          "or",
+          "3468206642",
+          "3988293898"
+        ],
+        [
+          "or",
+          "3988293899",
+          "3468206646",
+          "3468206647",
+          "3468206644",
+          "3468206643"
+        ]
+      ],
+      "forcedVariations": {}
+    }
+  ],
+  "audiences": [
+    {
+      "id": "3468206642",
+      "name": "exactString",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"house\", \"type\": \"custom_attribute\", \"value\": \"Gryffindor\"}]]]"
+    },
+    {
+      "id": "3468206645",
+      "name": "notChrome",
+      "conditions": "[\"and\", [\"or\", [\"not\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\":\"Chrome\"}]]]]"
+    },
+    {
+      "id": "3988293898",
+      "name": "$$dummySubstringString",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3988293899",
+      "name": "$$dummyExists",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3468206646",
+      "name": "$$dummyExactNumber",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3468206647",
+      "name": "$$dummyGtNumber",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3468206644",
+      "name": "$$dummyLtNumber",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3468206643",
+      "name": "$$dummyExactBoolean",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "0",
+      "name": "$$dummy",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "$opt_dummy_audience",
+      "name": "dummy_audience",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    }
+  ],
+  "typedAudiences": [],
+  "groups": [],
+  "integrations": [
+    {
+      "key": "odp",
+      "host": "https://api.zaius.com",
+      "publicKey": "fake-public-key"
+    }
+  ],
+  "attributes": [
+    {
+      "key": "house",
+      "id": "594015"
+    },
+    {
+      "key": "lasers",
+      "id": "594016"
+    },
+    {
+      "key": "should_do_it",
+      "id": "594017"
+    },
+    {
+      "key": "favorite_ice_cream",
+      "id": "594018"
+    }
+  ],
+  "botFiltering": false,
+  "accountId": "4879520872",
+  "events": [
+    {
+      "key": "item_bought",
+      "id": "594089",
+      "experimentIds": [
+        "11564051718",
+        "1323241597"
+      ]
+    },
+    {
+      "key": "user_signed_up",
+      "id": "594090",
+      "experimentIds": [
+        "1323241598",
+        "1323241599"
+      ]
+    }
+  ],
+  "revision": "3",
+  "sdkKey": "typedAudienceDatafile",
+  "environmentKey": "Production"
 }

--- a/OptimizelySDK.Tests/IntegrationOdpWithOtherFieldsDatafile.json
+++ b/OptimizelySDK.Tests/IntegrationOdpWithOtherFieldsDatafile.json
@@ -1,321 +1,445 @@
 {
-	"version": "4",
-	"rollouts": [{
-			"experiments": [{
-				"status": "Running",
-				"key": "feat_no_vars_rule",
-				"layerId": "11551226731",
-				"trafficAllocation": [{
-					"entityId": "11557362669",
-					"endOfRange": 10000
-				}],
-				"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
-				"variations": [{
-					"variables": [],
-					"id": "11557362669",
-					"key": "11557362669",
-					"featureEnabled": true
-				}],
-				"forcedVariations": {},
-				"id": "11488548027"
-			}],
-			"id": "11551226731"
-		},
-		{
-			"experiments": [{
-				"status": "Paused",
-				"key": "feat_with_var_rule",
-				"layerId": "11638870867",
-				"trafficAllocation": [{
-					"entityId": "11475708558",
-					"endOfRange": 0
-				}],
-				"audienceIds": [],
-				"variations": [{
-					"variables": [],
-					"id": "11475708558",
-					"key": "11475708558",
-					"featureEnabled": false
-				}],
-				"forcedVariations": {},
-				"id": "11630490911"
-			}],
-			"id": "11638870867"
-		},
-		{
-			"experiments": [{
-				"status": "Running",
-				"key": "11488548028",
-				"layerId": "11551226732",
-				"trafficAllocation": [{
-					"entityId": "11557362670",
-					"endOfRange": 10000
-				}],
-				"audienceIds": ["0"],
-				"audienceConditions": ["and", ["or", "3468206642", "3988293898"],
-					["or", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"]
-				],
-				"variations": [{
-					"variables": [],
-					"id": "11557362670",
-					"key": "11557362670",
-					"featureEnabled": true
-				}],
-				"forcedVariations": {},
-				"id": "11488548028"
-			}],
-			"id": "11551226732"
-		},
-		{
-			"experiments": [{
-				"status": "Paused",
-				"key": "11630490912",
-				"layerId": "11638870868",
-				"trafficAllocation": [{
-					"entityId": "11475708559",
-					"endOfRange": 0
-				}],
-				"audienceIds": [],
-				"variations": [{
-					"variables": [],
-					"id": "11475708559",
-					"key": "11475708559",
-					"featureEnabled": false
-				}],
-				"forcedVariations": {},
-				"id": "11630490912"
-			}],
-			"id": "11638870868"
-		}
-	],
-	"anonymizeIP": false,
-	"projectId": "11624721371",
-	"variables": [],
-	"featureFlags": [{
-			"experimentIds": [],
-			"rolloutId": "11551226731",
-			"variables": [],
-			"id": "11477755619",
-			"key": "feat_no_vars"
-		},
-		{
-			"experimentIds": [
-				"11564051718"
-			],
-			"rolloutId": "11638870867",
-			"variables": [{
-				"defaultValue": "x",
-				"type": "string",
-				"id": "11535264366",
-				"key": "x"
-			}],
-			"id": "11567102051",
-			"key": "feat_with_var"
-		},
-		{
-			"experimentIds": [],
-			"rolloutId": "11551226732",
-			"variables": [],
-			"id": "11567102052",
-			"key": "feat2"
-		},
-		{
-			"experimentIds": ["1323241599"],
-			"rolloutId": "11638870868",
-			"variables": [{
-				"defaultValue": "10",
-				"type": "integer",
-				"id": "11535264367",
-				"key": "z"
-			}],
-			"id": "11567102053",
-			"key": "feat2_with_var"
-		}
-	],
-	"experiments": [{
-			"status": "Running",
-			"key": "feat_with_var_test",
-			"layerId": "11504144555",
-			"trafficAllocation": [{
-				"entityId": "11617170975",
-				"endOfRange": 10000
-			}],
-			"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
-			"variations": [{
-				"variables": [{
-					"id": "11535264366",
-					"value": "xyz"
-				}],
-				"id": "11617170975",
-				"key": "variation_2",
-				"featureEnabled": true
-			}],
-			"forcedVariations": {},
-			"id": "11564051718"
-		},
-		{
-			"id": "1323241597",
-			"key": "typed_audience_experiment",
-			"layerId": "1630555627",
-			"status": "Running",
-			"variations": [{
-				"id": "1423767503",
-				"key": "A",
-				"variables": []
-			}],
-			"trafficAllocation": [{
-				"entityId": "1423767503",
-				"endOfRange": 10000
-			}],
-			"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
-			"forcedVariations": {}
-		},
-		{
-			"id": "1323241598",
-			"key": "audience_combinations_experiment",
-			"layerId": "1323241598",
-			"status": "Running",
-			"variations": [{
-				"id": "1423767504",
-				"key": "A",
-				"variables": []
-			}],
-			"trafficAllocation": [{
-				"entityId": "1423767504",
-				"endOfRange": 10000
-			}],
-			"audienceIds": ["0"],
-			"audienceConditions": ["and", ["or", "3468206642", "3988293898"],
-				["or", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"]
-			],
-			"forcedVariations": {}
-		},
-		{
-			"id": "1323241599",
-			"key": "feat2_with_var_test",
-			"layerId": "1323241600",
-			"status": "Running",
-			"variations": [{
-				"variables": [{
-					"id": "11535264367",
-					"value": "150"
-				}],
-				"id": "1423767505",
-				"key": "variation_2",
-				"featureEnabled": true
-			}],
-			"trafficAllocation": [{
-				"entityId": "1423767505",
-				"endOfRange": 10000
-			}],
-			"audienceIds": ["0"],
-			"audienceConditions": ["and", ["or", "3468206642", "3988293898"],
-				["or", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"]
-			],
-			"forcedVariations": {}
-		}
-	],
-	"audiences": [
-		{
-			"id": "3468206642",
-			"name": "exactString",
-			"conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"house\", \"type\": \"custom_attribute\", \"value\": \"Gryffindor\"}]]]"
-		},
-		{
-			"id": "3468206645",
-			"name": "notChrome",
-			"conditions": "[\"and\", [\"or\", [\"not\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\":\"Chrome\"}]]]]"
-		},
-		{
-			"id": "3988293898",
-			"name": "$$dummySubstringString",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3988293899",
-			"name": "$$dummyExists",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3468206646",
-			"name": "$$dummyExactNumber",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3468206647",
-			"name": "$$dummyGtNumber",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3468206644",
-			"name": "$$dummyLtNumber",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3468206643",
-			"name": "$$dummyExactBoolean",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "0",
-			"name": "$$dummy",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "$opt_dummy_audience",
-			"name": "dummy_audience",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		}
-	],
-	"typedAudiences": [],
-	"groups": [],
-	"integrations": [
-		{
-			"key": "odp",
-			"host": "https://api.zaius.com",
-			"publicKey": "fake-public-key",
-			"k1": 10, 
-			"k2": true, 
-			"k3": "any-value"
-		}
-	],
-	"attributes": [{
-			"key": "house",
-			"id": "594015"
-		},
-		{
-			"key": "lasers",
-			"id": "594016"
-		},
-		{
-			"key": "should_do_it",
-			"id": "594017"
-		},
-		{
-			"key": "favorite_ice_cream",
-			"id": "594018"
-		}
-	],
-	"botFiltering": false,
-	"accountId": "4879520872",
-	"events": [{
-			"key": "item_bought",
-			"id": "594089",
-			"experimentIds": [
-				"11564051718",
-				"1323241597"
-			]
-		},
-		{
-			"key": "user_signed_up",
-			"id": "594090",
-			"experimentIds": [
-				"1323241598",
-				"1323241599"
-			]
-		}
-	],
-	"revision": "3",
-	"sdkKey": "typedAudienceDatafile",
-	"environmentKey": "Production"
+  "version": "4",
+  "rollouts": [
+    {
+      "experiments": [
+        {
+          "status": "Running",
+          "key": "feat_no_vars_rule",
+          "layerId": "11551226731",
+          "trafficAllocation": [
+            {
+              "entityId": "11557362669",
+              "endOfRange": 10000
+            }
+          ],
+          "audienceIds": [
+            "3468206642",
+            "3988293898",
+            "3988293899",
+            "3468206646",
+            "3468206647",
+            "3468206644",
+            "3468206643"
+          ],
+          "variations": [
+            {
+              "variables": [],
+              "id": "11557362669",
+              "key": "11557362669",
+              "featureEnabled": true
+            }
+          ],
+          "forcedVariations": {},
+          "id": "11488548027"
+        }
+      ],
+      "id": "11551226731"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Paused",
+          "key": "feat_with_var_rule",
+          "layerId": "11638870867",
+          "trafficAllocation": [
+            {
+              "entityId": "11475708558",
+              "endOfRange": 0
+            }
+          ],
+          "audienceIds": [],
+          "variations": [
+            {
+              "variables": [],
+              "id": "11475708558",
+              "key": "11475708558",
+              "featureEnabled": false
+            }
+          ],
+          "forcedVariations": {},
+          "id": "11630490911"
+        }
+      ],
+      "id": "11638870867"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Running",
+          "key": "11488548028",
+          "layerId": "11551226732",
+          "trafficAllocation": [
+            {
+              "entityId": "11557362670",
+              "endOfRange": 10000
+            }
+          ],
+          "audienceIds": [
+            "0"
+          ],
+          "audienceConditions": [
+            "and",
+            [
+              "or",
+              "3468206642",
+              "3988293898"
+            ],
+            [
+              "or",
+              "3988293899",
+              "3468206646",
+              "3468206647",
+              "3468206644",
+              "3468206643"
+            ]
+          ],
+          "variations": [
+            {
+              "variables": [],
+              "id": "11557362670",
+              "key": "11557362670",
+              "featureEnabled": true
+            }
+          ],
+          "forcedVariations": {},
+          "id": "11488548028"
+        }
+      ],
+      "id": "11551226732"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Paused",
+          "key": "11630490912",
+          "layerId": "11638870868",
+          "trafficAllocation": [
+            {
+              "entityId": "11475708559",
+              "endOfRange": 0
+            }
+          ],
+          "audienceIds": [],
+          "variations": [
+            {
+              "variables": [],
+              "id": "11475708559",
+              "key": "11475708559",
+              "featureEnabled": false
+            }
+          ],
+          "forcedVariations": {},
+          "id": "11630490912"
+        }
+      ],
+      "id": "11638870868"
+    }
+  ],
+  "anonymizeIP": false,
+  "projectId": "11624721371",
+  "variables": [],
+  "featureFlags": [
+    {
+      "experimentIds": [],
+      "rolloutId": "11551226731",
+      "variables": [],
+      "id": "11477755619",
+      "key": "feat_no_vars"
+    },
+    {
+      "experimentIds": [
+        "11564051718"
+      ],
+      "rolloutId": "11638870867",
+      "variables": [
+        {
+          "defaultValue": "x",
+          "type": "string",
+          "id": "11535264366",
+          "key": "x"
+        }
+      ],
+      "id": "11567102051",
+      "key": "feat_with_var"
+    },
+    {
+      "experimentIds": [],
+      "rolloutId": "11551226732",
+      "variables": [],
+      "id": "11567102052",
+      "key": "feat2"
+    },
+    {
+      "experimentIds": [
+        "1323241599"
+      ],
+      "rolloutId": "11638870868",
+      "variables": [
+        {
+          "defaultValue": "10",
+          "type": "integer",
+          "id": "11535264367",
+          "key": "z"
+        }
+      ],
+      "id": "11567102053",
+      "key": "feat2_with_var"
+    }
+  ],
+  "experiments": [
+    {
+      "status": "Running",
+      "key": "feat_with_var_test",
+      "layerId": "11504144555",
+      "trafficAllocation": [
+        {
+          "entityId": "11617170975",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [
+        "3468206642",
+        "3988293898",
+        "3988293899",
+        "3468206646",
+        "3468206647",
+        "3468206644",
+        "3468206643"
+      ],
+      "variations": [
+        {
+          "variables": [
+            {
+              "id": "11535264366",
+              "value": "xyz"
+            }
+          ],
+          "id": "11617170975",
+          "key": "variation_2",
+          "featureEnabled": true
+        }
+      ],
+      "forcedVariations": {},
+      "id": "11564051718"
+    },
+    {
+      "id": "1323241597",
+      "key": "typed_audience_experiment",
+      "layerId": "1630555627",
+      "status": "Running",
+      "variations": [
+        {
+          "id": "1423767503",
+          "key": "A",
+          "variables": []
+        }
+      ],
+      "trafficAllocation": [
+        {
+          "entityId": "1423767503",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [
+        "3468206642",
+        "3988293898",
+        "3988293899",
+        "3468206646",
+        "3468206647",
+        "3468206644",
+        "3468206643"
+      ],
+      "forcedVariations": {}
+    },
+    {
+      "id": "1323241598",
+      "key": "audience_combinations_experiment",
+      "layerId": "1323241598",
+      "status": "Running",
+      "variations": [
+        {
+          "id": "1423767504",
+          "key": "A",
+          "variables": []
+        }
+      ],
+      "trafficAllocation": [
+        {
+          "entityId": "1423767504",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [
+        "0"
+      ],
+      "audienceConditions": [
+        "and",
+        [
+          "or",
+          "3468206642",
+          "3988293898"
+        ],
+        [
+          "or",
+          "3988293899",
+          "3468206646",
+          "3468206647",
+          "3468206644",
+          "3468206643"
+        ]
+      ],
+      "forcedVariations": {}
+    },
+    {
+      "id": "1323241599",
+      "key": "feat2_with_var_test",
+      "layerId": "1323241600",
+      "status": "Running",
+      "variations": [
+        {
+          "variables": [
+            {
+              "id": "11535264367",
+              "value": "150"
+            }
+          ],
+          "id": "1423767505",
+          "key": "variation_2",
+          "featureEnabled": true
+        }
+      ],
+      "trafficAllocation": [
+        {
+          "entityId": "1423767505",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [
+        "0"
+      ],
+      "audienceConditions": [
+        "and",
+        [
+          "or",
+          "3468206642",
+          "3988293898"
+        ],
+        [
+          "or",
+          "3988293899",
+          "3468206646",
+          "3468206647",
+          "3468206644",
+          "3468206643"
+        ]
+      ],
+      "forcedVariations": {}
+    }
+  ],
+  "audiences": [
+    {
+      "id": "3468206642",
+      "name": "exactString",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"house\", \"type\": \"custom_attribute\", \"value\": \"Gryffindor\"}]]]"
+    },
+    {
+      "id": "3468206645",
+      "name": "notChrome",
+      "conditions": "[\"and\", [\"or\", [\"not\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\":\"Chrome\"}]]]]"
+    },
+    {
+      "id": "3988293898",
+      "name": "$$dummySubstringString",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3988293899",
+      "name": "$$dummyExists",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3468206646",
+      "name": "$$dummyExactNumber",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3468206647",
+      "name": "$$dummyGtNumber",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3468206644",
+      "name": "$$dummyLtNumber",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3468206643",
+      "name": "$$dummyExactBoolean",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "0",
+      "name": "$$dummy",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "$opt_dummy_audience",
+      "name": "dummy_audience",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    }
+  ],
+  "typedAudiences": [],
+  "groups": [],
+  "integrations": [
+    {
+      "key": "odp",
+      "host": "https://api.zaius.com",
+      "publicKey": "fake-public-key",
+      "k1": 10,
+      "k2": true,
+      "k3": "any-value"
+    }
+  ],
+  "attributes": [
+    {
+      "key": "house",
+      "id": "594015"
+    },
+    {
+      "key": "lasers",
+      "id": "594016"
+    },
+    {
+      "key": "should_do_it",
+      "id": "594017"
+    },
+    {
+      "key": "favorite_ice_cream",
+      "id": "594018"
+    }
+  ],
+  "botFiltering": false,
+  "accountId": "4879520872",
+  "events": [
+    {
+      "key": "item_bought",
+      "id": "594089",
+      "experimentIds": [
+        "11564051718",
+        "1323241597"
+      ]
+    },
+    {
+      "key": "user_signed_up",
+      "id": "594090",
+      "experimentIds": [
+        "1323241598",
+        "1323241599"
+      ]
+    }
+  ],
+  "revision": "3",
+  "sdkKey": "typedAudienceDatafile",
+  "environmentKey": "Production"
 }

--- a/OptimizelySDK.Tests/InvalidEventDispatcher.cs
+++ b/OptimizelySDK.Tests/InvalidEventDispatcher.cs
@@ -13,15 +13,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using OptimizelySDK.Event.Dispatcher;
 using OptimizelySDK.Logger;
 using System;
 
 namespace OptimizelySDK.Tests
 {
-    class InvalidEventDispatcher : IEventDispatcher
+    internal class InvalidEventDispatcher : IEventDispatcher
     {
         public ILogger Logger { get; set; }
+
         public void DispatchEvent(Event.LogEvent logEvent)
         {
             throw new Exception("Invalid dispatch event");

--- a/OptimizelySDK.Tests/InvalidEventDispatcher.cs
+++ b/OptimizelySDK.Tests/InvalidEventDispatcher.cs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+using System;
 using OptimizelySDK.Event.Dispatcher;
 using OptimizelySDK.Logger;
-using System;
 
 namespace OptimizelySDK.Tests
 {

--- a/OptimizelySDK.Tests/NotificationTests/NotificationCenterTests.cs
+++ b/OptimizelySDK.Tests/NotificationTests/NotificationCenterTests.cs
@@ -51,7 +51,9 @@ namespace OptimizelySDK.Tests.NotificationTests
         public void TestAddAndRemoveNotificationListener()
         {
             // Verify that callback added successfully.
-            Assert.AreEqual(1, NotificationCenter.AddNotification(NotificationTypeActivate, TestNotificationCallbacks.TestActivateCallback));
+            Assert.AreEqual(1,
+                NotificationCenter.AddNotification(NotificationTypeActivate,
+                    TestNotificationCallbacks.TestActivateCallback));
             Assert.AreEqual(1, NotificationCenter.NotificationsCount);
 
             // Verify that callback removed successfully.
@@ -62,41 +64,53 @@ namespace OptimizelySDK.Tests.NotificationTests
             Assert.AreEqual(false, NotificationCenter.RemoveNotification(1));
 
             // Verify that callback added successfully and return right notification ID.
-            Assert.AreEqual(NotificationCenter.NotificationId, NotificationCenter.AddNotification(NotificationTypeActivate, TestNotificationCallbacks.TestActivateCallback));
+            Assert.AreEqual(NotificationCenter.NotificationId,
+                NotificationCenter.AddNotification(NotificationTypeActivate,
+                    TestNotificationCallbacks.TestActivateCallback));
             Assert.AreEqual(1, NotificationCenter.NotificationsCount);
         }
 
         [Test]
         public void TestAddMultipleNotificationListeners()
         {
-            NotificationCenter.AddNotification(NotificationTypeActivate, TestNotificationCallbacks.TestActivateCallback);
-            NotificationCenter.AddNotification(NotificationTypeActivate, TestNotificationCallbacks.TestAnotherActivateCallback);
+            NotificationCenter.AddNotification(NotificationTypeActivate,
+                TestNotificationCallbacks.TestActivateCallback);
+            NotificationCenter.AddNotification(NotificationTypeActivate,
+                TestNotificationCallbacks.TestAnotherActivateCallback);
 
             // Verify that multiple notifications will be added for same notification type.
             Assert.AreEqual(2, NotificationCenter.NotificationsCount);
 
             // Verify that notifications of other types will also gets added successfully.
-            NotificationCenter.AddNotification(NotificationTypeTrack, TestNotificationCallbacks.TestTrackCallback);
+            NotificationCenter.AddNotification(NotificationTypeTrack,
+                TestNotificationCallbacks.TestTrackCallback);
             Assert.AreEqual(3, NotificationCenter.NotificationsCount);
 
             // Verify that notifications of other types will also gets added successfully.
-            NotificationCenter.AddNotification(NotificationType.OptimizelyConfigUpdate, TestNotificationCallbacks.TestConfigUpdateCallback);
+            NotificationCenter.AddNotification(NotificationType.OptimizelyConfigUpdate,
+                TestNotificationCallbacks.TestConfigUpdateCallback);
             Assert.AreEqual(4, NotificationCenter.NotificationsCount);
 
             // Verify that notifications of other types will also gets added successfully.
-            NotificationCenter.AddNotification(NotificationType.LogEvent, TestNotificationCallbacks.TestLogEventCallback);
+            NotificationCenter.AddNotification(NotificationType.LogEvent,
+                TestNotificationCallbacks.TestLogEventCallback);
             Assert.AreEqual(5, NotificationCenter.NotificationsCount);
         }
 
         [Test]
         public void TestAddSameNotificationListenerMultipleTimes()
         {
-            NotificationCenter.AddNotification(NotificationTypeActivate, TestNotificationCallbacks.TestActivateCallback);
+            NotificationCenter.AddNotification(NotificationTypeActivate,
+                TestNotificationCallbacks.TestActivateCallback);
 
             // Verify that adding same callback multiple times will gets failed.
-            Assert.AreEqual(-1, NotificationCenter.AddNotification(NotificationTypeActivate, TestNotificationCallbacks.TestActivateCallback));
+            Assert.AreEqual(-1,
+                NotificationCenter.AddNotification(NotificationTypeActivate,
+                    TestNotificationCallbacks.TestActivateCallback));
             Assert.AreEqual(1, NotificationCenter.NotificationsCount);
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "The notification callback already exists."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.ERROR, "The notification callback already exists."),
+                Times.Once);
         }
 
         [Test]
@@ -107,7 +121,10 @@ namespace OptimizelySDK.Tests.NotificationTests
                 TestNotificationCallbacks.TestActivateCallback));
 
 
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, $@"Invalid notification type provided for ""{NotificationTypeActivate}"" callback."),
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.ERROR,
+                    $@"Invalid notification type provided for ""{NotificationTypeActivate
+                    }"" callback."),
                 Times.Once);
 
             // Verify that no notifion has been added.
@@ -118,17 +135,21 @@ namespace OptimizelySDK.Tests.NotificationTests
         public void TestClearNotifications()
         {
             // Add decision notifications.
-            NotificationCenter.AddNotification(NotificationTypeActivate, TestNotificationCallbacks.TestActivateCallback);
-            NotificationCenter.AddNotification(NotificationTypeActivate, TestNotificationCallbacks.TestAnotherActivateCallback);
+            NotificationCenter.AddNotification(NotificationTypeActivate,
+                TestNotificationCallbacks.TestActivateCallback);
+            NotificationCenter.AddNotification(NotificationTypeActivate,
+                TestNotificationCallbacks.TestAnotherActivateCallback);
 
             // Add track notification.
-            NotificationCenter.AddNotification(NotificationTypeTrack, TestNotificationCallbacks.TestTrackCallback);
+            NotificationCenter.AddNotification(NotificationTypeTrack,
+                TestNotificationCallbacks.TestTrackCallback);
 
             // Verify that callbacks added successfully.
             Assert.AreEqual(3, NotificationCenter.NotificationsCount);
 
             // Add config update callback.
-            NotificationCenter.AddNotification(NotificationType.OptimizelyConfigUpdate, TestNotificationCallbacks.TestConfigUpdateCallback);
+            NotificationCenter.AddNotification(NotificationType.OptimizelyConfigUpdate,
+                TestNotificationCallbacks.TestConfigUpdateCallback);
             // Verify that callbacks added successfully.
             Assert.AreEqual(4, NotificationCenter.NotificationsCount);
 
@@ -150,11 +171,14 @@ namespace OptimizelySDK.Tests.NotificationTests
         public void TestClearAllNotifications()
         {
             // Add decision notifications.
-            NotificationCenter.AddNotification(NotificationTypeActivate, TestNotificationCallbacks.TestActivateCallback);
-            NotificationCenter.AddNotification(NotificationTypeActivate, TestNotificationCallbacks.TestAnotherActivateCallback);
+            NotificationCenter.AddNotification(NotificationTypeActivate,
+                TestNotificationCallbacks.TestActivateCallback);
+            NotificationCenter.AddNotification(NotificationTypeActivate,
+                TestNotificationCallbacks.TestAnotherActivateCallback);
 
             // Add track notification.
-            NotificationCenter.AddNotification(NotificationTypeTrack, TestNotificationCallbacks.TestTrackCallback);
+            NotificationCenter.AddNotification(NotificationTypeTrack,
+                TestNotificationCallbacks.TestTrackCallback);
 
             // Verify that callbacks added successfully.
             Assert.AreEqual(3, NotificationCenter.NotificationsCount);
@@ -172,69 +196,94 @@ namespace OptimizelySDK.Tests.NotificationTests
         [Test]
         public void TestSendNotifications()
         {
-            var config = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object, new NoOpErrorHandler());
-            var logEventMocker = new Mock<LogEvent>("http://mockedurl", new Dictionary<string, object>(), "POST", new Dictionary<string, string>());
+            var config = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object,
+                new NoOpErrorHandler());
+            var logEventMocker = new Mock<LogEvent>("http://mockedurl",
+                new Dictionary<string, object>(), "POST", new Dictionary<string, string>());
             // Mocking notification callbacks.
             var notificationCallbackMock = new Mock<TestNotificationCallbacks>();
 
-            notificationCallbackMock.Setup(nc => nc.TestActivateCallback(It.IsAny<Experiment>(), It.IsAny<string>(),
+            notificationCallbackMock.Setup(nc => nc.TestActivateCallback(It.IsAny<Experiment>(),
+                It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), It.IsAny<Variation>(), It.IsAny<LogEvent>()));
 
-            notificationCallbackMock.Setup(nc => nc.TestAnotherActivateCallback(It.IsAny<Experiment>(),
-                It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<Variation>(), It.IsAny<LogEvent>()));
+            notificationCallbackMock.Setup(nc => nc.TestAnotherActivateCallback(
+                It.IsAny<Experiment>(),
+                It.IsAny<string>(), It.IsAny<UserAttributes>(), It.IsAny<Variation>(),
+                It.IsAny<LogEvent>()));
 
             notificationCallbackMock.Setup(nc => nc.TestLogEventCallback(It.IsAny<LogEvent>()));
 
             // Adding decision notifications.
-            NotificationCenter.AddNotification(NotificationTypeActivate, notificationCallbackMock.Object.TestActivateCallback);
-            NotificationCenter.AddNotification(NotificationTypeActivate, notificationCallbackMock.Object.TestAnotherActivateCallback);
+            NotificationCenter.AddNotification(NotificationTypeActivate,
+                notificationCallbackMock.Object.TestActivateCallback);
+            NotificationCenter.AddNotification(NotificationTypeActivate,
+                notificationCallbackMock.Object.TestAnotherActivateCallback);
 
             // Adding track notifications.
-            NotificationCenter.AddNotification(NotificationTypeTrack, notificationCallbackMock.Object.TestTrackCallback);
+            NotificationCenter.AddNotification(NotificationTypeTrack,
+                notificationCallbackMock.Object.TestTrackCallback);
 
             // Fire decision type notifications.
-            NotificationCenter.SendNotifications(NotificationTypeActivate, config.GetExperimentFromKey("test_experiment"),
-                "testUser", new UserAttributes(), config.GetVariationFromId("test_experiment", "7722370027"), logEventMocker.Object);
+            NotificationCenter.SendNotifications(NotificationTypeActivate,
+                config.GetExperimentFromKey("test_experiment"),
+                "testUser", new UserAttributes(),
+                config.GetVariationFromId("test_experiment", "7722370027"), logEventMocker.Object);
 
             // Verify that only the registered notifications of decision type are called.
-            notificationCallbackMock.Verify(nc => nc.TestActivateCallback(It.IsAny<Experiment>(), It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), It.IsAny<Variation>(), It.IsAny<LogEvent>()), Times.Once);
+            notificationCallbackMock.Verify(nc => nc.TestActivateCallback(It.IsAny<Experiment>(),
+                    It.IsAny<string>(),
+                    It.IsAny<UserAttributes>(), It.IsAny<Variation>(), It.IsAny<LogEvent>()),
+                Times.Once);
 
-            notificationCallbackMock.Verify(nc => nc.TestAnotherActivateCallback(It.IsAny<Experiment>(), It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), It.IsAny<Variation>(), It.IsAny<LogEvent>()), Times.Once);
+            notificationCallbackMock.Verify(nc => nc.TestAnotherActivateCallback(
+                    It.IsAny<Experiment>(), It.IsAny<string>(),
+                    It.IsAny<UserAttributes>(), It.IsAny<Variation>(), It.IsAny<LogEvent>()),
+                Times.Once);
 
-            notificationCallbackMock.Verify(nc => nc.TestTrackCallback(It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), It.IsAny<EventTags>(), It.IsAny<LogEvent>()), Times.Never);
+            notificationCallbackMock.Verify(nc => nc.TestTrackCallback(It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<UserAttributes>(), It.IsAny<EventTags>(), It.IsAny<LogEvent>()),
+                Times.Never);
 
             // Add logEvent Notification.
-            NotificationCenter.AddNotification(NotificationType.LogEvent, notificationCallbackMock.Object.TestLogEventCallback);
+            NotificationCenter.AddNotification(NotificationType.LogEvent,
+                notificationCallbackMock.Object.TestLogEventCallback);
 
             // Fire logEvent Notification.
             NotificationCenter.SendNotifications(NotificationType.LogEvent, logEventMocker.Object);
 
             // Verify that registered notifications of logEvent type are called.
-            notificationCallbackMock.Verify(nc => nc.TestLogEventCallback(It.IsAny<LogEvent>()), Times.Once);
+            notificationCallbackMock.Verify(nc => nc.TestLogEventCallback(It.IsAny<LogEvent>()),
+                Times.Once);
 
             // Verify that after clearing notifications, SendNotification should not call any notification
             // which were previously registered. 
             NotificationCenter.ClearAllNotifications();
             notificationCallbackMock.ResetCalls();
 
-            NotificationCenter.SendNotifications(NotificationTypeActivate, config.GetExperimentFromKey("test_experiment"),
-                "testUser", new UserAttributes(), config.GetVariationFromId("test_experiment", "7722370027"), null);
+            NotificationCenter.SendNotifications(NotificationTypeActivate,
+                config.GetExperimentFromKey("test_experiment"),
+                "testUser", new UserAttributes(),
+                config.GetVariationFromId("test_experiment", "7722370027"), null);
 
 
             // Again verify notifications which were registered are not called. 
-            notificationCallbackMock.Verify(nc => nc.TestActivateCallback(It.IsAny<Experiment>(), It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), It.IsAny<Variation>(), It.IsAny<LogEvent>()), Times.Never);
+            notificationCallbackMock.Verify(nc => nc.TestActivateCallback(It.IsAny<Experiment>(),
+                    It.IsAny<string>(),
+                    It.IsAny<UserAttributes>(), It.IsAny<Variation>(), It.IsAny<LogEvent>()),
+                Times.Never);
 
-            notificationCallbackMock.Verify(nc => nc.TestAnotherActivateCallback(It.IsAny<Experiment>(), It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), It.IsAny<Variation>(), It.IsAny<LogEvent>()), Times.Never);
+            notificationCallbackMock.Verify(nc => nc.TestAnotherActivateCallback(
+                    It.IsAny<Experiment>(), It.IsAny<string>(),
+                    It.IsAny<UserAttributes>(), It.IsAny<Variation>(), It.IsAny<LogEvent>()),
+                Times.Never);
 
-            notificationCallbackMock.Verify(nc => nc.TestTrackCallback(It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<UserAttributes>(), It.IsAny<EventTags>(), It.IsAny<LogEvent>()), Times.Never);
+            notificationCallbackMock.Verify(nc => nc.TestTrackCallback(It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<UserAttributes>(), It.IsAny<EventTags>(), It.IsAny<LogEvent>()),
+                Times.Never);
         }
-
     }
 
     #region Test Notification callbacks class.
@@ -244,31 +293,35 @@ namespace OptimizelySDK.Tests.NotificationTests
     /// </summary>
     public class TestNotificationCallbacks
     {
-        public virtual void TestActivateCallback(Experiment experiment, string userId, UserAttributes userAttributes,
-            Variation variation, LogEvent logEvent) {
-        }
+        public virtual void TestActivateCallback(Experiment experiment, string userId,
+            UserAttributes userAttributes,
+            Variation variation, LogEvent logEvent
+        ) { }
 
-        public virtual void TestAnotherActivateCallback(Experiment experiment, string userId, UserAttributes userAttributes,
-            Variation variation, LogEvent logEvent) {
-        }
-        
-        public virtual void TestTrackCallback(string eventKey, string userId, UserAttributes userAttributes,
-            EventTags eventTags, LogEvent logEvent) {
-        }
+        public virtual void TestAnotherActivateCallback(Experiment experiment, string userId,
+            UserAttributes userAttributes,
+            Variation variation, LogEvent logEvent
+        ) { }
 
-        public virtual void TestAnotherTrackCallback(string eventKey, string userId, UserAttributes userAttributes,
-            EventTags eventTags, LogEvent logEvent) {
-        }
-        
-        public virtual void TestDecisionCallback(string type, string userId, UserAttributes userAttributes,
-            Dictionary<string, object> decisionInfo) {
-        }
+        public virtual void TestTrackCallback(string eventKey, string userId,
+            UserAttributes userAttributes,
+            EventTags eventTags, LogEvent logEvent
+        ) { }
 
-        public virtual void TestConfigUpdateCallback() {
-        }
+        public virtual void TestAnotherTrackCallback(string eventKey, string userId,
+            UserAttributes userAttributes,
+            EventTags eventTags, LogEvent logEvent
+        ) { }
 
-        public virtual void TestLogEventCallback(LogEvent logEvent) {
-        }
+        public virtual void TestDecisionCallback(string type, string userId,
+            UserAttributes userAttributes,
+            Dictionary<string, object> decisionInfo
+        ) { }
+
+        public virtual void TestConfigUpdateCallback() { }
+
+        public virtual void TestLogEventCallback(LogEvent logEvent) { }
     }
+
     #endregion // Test Notification callbacks class.
 }

--- a/OptimizelySDK.Tests/NotificationTests/NotificationCenterTests.cs
+++ b/OptimizelySDK.Tests/NotificationTests/NotificationCenterTests.cs
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.Config;
@@ -22,8 +24,6 @@ using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Event;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Notifications;
-using System;
-using System.Collections.Generic;
 using NotificationType = OptimizelySDK.Notifications.NotificationCenter.NotificationType;
 
 namespace OptimizelySDK.Tests.NotificationTests
@@ -48,6 +48,7 @@ namespace OptimizelySDK.Tests.NotificationTests
         }
 
         [Test]
+        [Obsolete]
         public void TestAddAndRemoveNotificationListener()
         {
             // Verify that callback added successfully.
@@ -71,6 +72,7 @@ namespace OptimizelySDK.Tests.NotificationTests
         }
 
         [Test]
+        [Obsolete]
         public void TestAddMultipleNotificationListeners()
         {
             NotificationCenter.AddNotification(NotificationTypeActivate,
@@ -98,6 +100,7 @@ namespace OptimizelySDK.Tests.NotificationTests
         }
 
         [Test]
+        [Obsolete]
         public void TestAddSameNotificationListenerMultipleTimes()
         {
             NotificationCenter.AddNotification(NotificationTypeActivate,
@@ -114,6 +117,7 @@ namespace OptimizelySDK.Tests.NotificationTests
         }
 
         [Test]
+        [Obsolete]
         public void TestAddInvalidNotificationListeners()
         {
             // Verify that AddNotification gets failed on adding invalid notification listeners.
@@ -132,6 +136,7 @@ namespace OptimizelySDK.Tests.NotificationTests
         }
 
         [Test]
+        [Obsolete]
         public void TestClearNotifications()
         {
             // Add decision notifications.
@@ -168,6 +173,7 @@ namespace OptimizelySDK.Tests.NotificationTests
         }
 
         [Test]
+        [Obsolete]
         public void TestClearAllNotifications()
         {
             // Add decision notifications.
@@ -194,6 +200,7 @@ namespace OptimizelySDK.Tests.NotificationTests
         }
 
         [Test]
+        [Obsolete]
         public void TestSendNotifications()
         {
             var config = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object,
@@ -296,27 +303,32 @@ namespace OptimizelySDK.Tests.NotificationTests
         public virtual void TestActivateCallback(Experiment experiment, string userId,
             UserAttributes userAttributes,
             Variation variation, LogEvent logEvent
-        ) { }
+        )
+        { }
 
         public virtual void TestAnotherActivateCallback(Experiment experiment, string userId,
             UserAttributes userAttributes,
             Variation variation, LogEvent logEvent
-        ) { }
+        )
+        { }
 
         public virtual void TestTrackCallback(string eventKey, string userId,
             UserAttributes userAttributes,
             EventTags eventTags, LogEvent logEvent
-        ) { }
+        )
+        { }
 
         public virtual void TestAnotherTrackCallback(string eventKey, string userId,
             UserAttributes userAttributes,
             EventTags eventTags, LogEvent logEvent
-        ) { }
+        )
+        { }
 
         public virtual void TestDecisionCallback(string type, string userId,
             UserAttributes userAttributes,
             Dictionary<string, object> decisionInfo
-        ) { }
+        )
+        { }
 
         public virtual void TestConfigUpdateCallback() { }
 

--- a/OptimizelySDK.Tests/OdpTests/HttpClientTestUtil.cs
+++ b/OptimizelySDK.Tests/OdpTests/HttpClientTestUtil.cs
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-using Moq;
-using Moq.Protected;
 using System;
 using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
 
 namespace OptimizelySDK.Tests.OdpTests
 {

--- a/OptimizelySDK.Tests/OdpTests/HttpClientTestUtil.cs
+++ b/OptimizelySDK.Tests/OdpTests/HttpClientTestUtil.cs
@@ -47,12 +47,12 @@ namespace OptimizelySDK.Tests.OdpTests
             }
 
             var mockedHandler = new Mock<HttpMessageHandler>();
-            mockedHandler.Protected()
-                .Setup<Task<HttpResponseMessage>>(
+            mockedHandler.Protected().
+                Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
-                    ItExpr.IsAny<CancellationToken>())
-                .ReturnsAsync(response);
+                    ItExpr.IsAny<CancellationToken>()).
+                ReturnsAsync(response);
             return new HttpClient(mockedHandler.Object);
         }
 
@@ -63,12 +63,12 @@ namespace OptimizelySDK.Tests.OdpTests
         public static HttpClient MakeHttpClientWithTimeout()
         {
             var mockedHandler = new Mock<HttpMessageHandler>();
-            mockedHandler.Protected()
-                .Setup<Task<HttpResponseMessage>>(
+            mockedHandler.Protected().
+                Setup<Task<HttpResponseMessage>>(
                     "SendAsync",
                     ItExpr.IsAny<HttpRequestMessage>(),
-                    ItExpr.IsAny<CancellationToken>())
-                .Throws<TimeoutException>();
+                    ItExpr.IsAny<CancellationToken>()).
+                Throws<TimeoutException>();
             return new HttpClient(mockedHandler.Object);
         }
     }

--- a/OptimizelySDK.Tests/OdpTests/LruCacheTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/LruCacheTest.cs
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-using NUnit.Framework;
-using OptimizelySDK.Odp;
 using System;
 using System.Collections.Generic;
 using System.Threading;
+using NUnit.Framework;
+using OptimizelySDK.Odp;
 
 namespace OptimizelySDK.Tests.OdpTests
 {

--- a/OptimizelySDK.Tests/OdpTests/LruCacheTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/LruCacheTest.cs
@@ -142,7 +142,7 @@ namespace OptimizelySDK.Tests.OdpTests
         [Test]
         public void ShouldHandleWhenCacheIsDisabled()
         {
-            var cache = new LruCache<List<string>>(maxSize: 0);
+            var cache = new LruCache<List<string>>(0);
 
             cache.Save("user1", _segments1And2);
             cache.Save("user2", _segments3And4);
@@ -172,7 +172,7 @@ namespace OptimizelySDK.Tests.OdpTests
         [Test]
         public void ShouldHandleWhenCacheReachesMaxSize()
         {
-            var cache = new LruCache<List<string>>(maxSize: 2);
+            var cache = new LruCache<List<string>>(2);
 
             cache.Save("user1", _segments1And2);
             cache.Save("user2", _segments3And4);

--- a/OptimizelySDK.Tests/OdpTests/OdpConfigTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpConfigTest.cs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using NUnit.Framework;
 using OptimizelySDK.Odp;
-using System.Collections.Generic;
 
 namespace OptimizelySDK.Tests.OdpTests
 {

--- a/OptimizelySDK.Tests/OdpTests/OdpEventApiManagerTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpEventApiManagerTest.cs
@@ -121,7 +121,8 @@ namespace OptimizelySDK.Tests.OdpTests
         }
 
         [Test]
-        public void ShouldSuggestRetryForNetworkTimeout() { 
+        public void ShouldSuggestRetryForNetworkTimeout()
+        {
             var httpClient = HttpClientTestUtil.MakeHttpClientWithTimeout();
             var manger =
                 new OdpEventApiManager(_mockLogger.Object, _mockErrorHandler.Object, httpClient);
@@ -129,6 +130,7 @@ namespace OptimizelySDK.Tests.OdpTests
             var shouldRetry = manger.SendEvents(VALID_ODP_PUBLIC_KEY, ODP_REST_API_HOST,
                 _odpEvents);
 
-            Assert.IsTrue(shouldRetry);}
+            Assert.IsTrue(shouldRetry);
+        }
     }
 }

--- a/OptimizelySDK.Tests/OdpTests/OdpEventApiManagerTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpEventApiManagerTest.cs
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
+using System.Net;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Odp;
 using OptimizelySDK.Odp.Entity;
-using System.Collections.Generic;
-using System.Net;
 
 namespace OptimizelySDK.Tests.OdpTests
 {

--- a/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-using Moq;
-using NUnit.Framework;
-using OptimizelySDK.Logger;
-using OptimizelySDK.Odp;
-using OptimizelySDK.Odp.Entity;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Moq;
+using NUnit.Framework;
+using OptimizelySDK.Logger;
+using OptimizelySDK.Odp;
+using OptimizelySDK.Odp.Entity;
 
 namespace OptimizelySDK.Tests.OdpTests
 {

--- a/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
@@ -345,7 +345,7 @@ namespace OptimizelySDK.Tests.OdpTests
                 Build();
             eventManager.UpdateSettings(_odpConfig);
 
-            for (int i = 0; i < 25; i++)
+            for (var i = 0; i < 25; i++)
             {
                 eventManager.SendEvent(MakeEvent(i));
             }
@@ -412,7 +412,7 @@ namespace OptimizelySDK.Tests.OdpTests
                 Build();
             eventManager.UpdateSettings(_odpConfig);
 
-            for (int i = 0; i < 4; i++) // send 4 events in batches of 1
+            for (var i = 0; i < 4; i++) // send 4 events in batches of 1
             {
                 eventManager.SendEvent(MakeEvent(i));
             }
@@ -436,7 +436,7 @@ namespace OptimizelySDK.Tests.OdpTests
                 Build();
             eventManager.UpdateSettings(_odpConfig);
 
-            for (int i = 0; i < 25; i++)
+            for (var i = 0; i < 25; i++)
             {
                 eventManager.SendEvent(MakeEvent(i));
             }
@@ -509,23 +509,26 @@ namespace OptimizelySDK.Tests.OdpTests
             Assert.IsFalse(_odpConfig.Equals(eventManager.OdpConfigForTesting));
         }
 
-        private static OdpEvent MakeEvent(int id) =>
-            new OdpEvent($"test-type-{id}", $"test-action-{id}", new Dictionary<string, string>
-            {
+        private static OdpEvent MakeEvent(int id)
+        {
+            return new OdpEvent($"test-type-{id}", $"test-action-{id}",
+                new Dictionary<string, string>
                 {
-                    "an-identifier", $"value1-{id}"
-                },
+                    {
+                        "an-identifier", $"value1-{id}"
+                    },
+                    {
+                        "another-identity", $"value2-{id}"
+                    },
+                }, new Dictionary<string, object>
                 {
-                    "another-identity", $"value2-{id}"
-                },
-            }, new Dictionary<string, object>
-            {
-                {
-                    "data1", $"data1-value1-{id}"
-                },
-                {
-                    "data2", id
-                },
-            });
+                    {
+                        "data1", $"data1-value1-{id}"
+                    },
+                    {
+                        "data2", id
+                    },
+                });
+        }
     }
 }

--- a/OptimizelySDK.Tests/OdpTests/OdpManagerTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpManagerTest.cs
@@ -87,7 +87,7 @@ namespace OptimizelySDK.Tests.OdpTests
                 WithLogger(_mockLogger.Object).
                 Build();
 
-            var eventManager = (manager.EventManager as OdpEventManager);
+            var eventManager = manager.EventManager as OdpEventManager;
             var segmentCache =
                 (manager.SegmentManager as OdpSegmentManager)?.SegmentsCacheForTesting as
                 LruCache<List<string>>;
@@ -96,7 +96,8 @@ namespace OptimizelySDK.Tests.OdpTests
             Assert.AreEqual(Constants.DEFAULT_TIMEOUT_INTERVAL,
                 eventManager.TimeoutIntervalForTesting);
             Assert.AreEqual(Constants.DEFAULT_MAX_CACHE_SIZE, segmentCache?.MaxSizeForTesting);
-            Assert.AreEqual(TimeSpan.FromSeconds(Constants.DEFAULT_CACHE_SECONDS), segmentCache.TimeoutForTesting);
+            Assert.AreEqual(TimeSpan.FromSeconds(Constants.DEFAULT_CACHE_SECONDS),
+                segmentCache.TimeoutForTesting);
         }
 
         [Test]

--- a/OptimizelySDK.Tests/OdpTests/OdpManagerTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpManagerTest.cs
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Odp;
 using OptimizelySDK.Odp.Entity;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace OptimizelySDK.Tests.OdpTests
 {

--- a/OptimizelySDK.Tests/OdpTests/OdpSegmentApiManagerTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpSegmentApiManagerTest.cs
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
+using System.Net;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.AudienceConditions;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Odp;
-using System.Collections.Generic;
-using System.Net;
 
 namespace OptimizelySDK.Tests.OdpTests
 {

--- a/OptimizelySDK.Tests/OdpTests/OdpSegmentManagerTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpSegmentManagerTest.cs
@@ -36,7 +36,8 @@ namespace OptimizelySDK.Tests.OdpTests
 
         private static readonly string expectedCacheKey = $"fs_user_id-$-{FS_USER_ID}";
 
-        private static readonly List<string> segmentsToCheck = new List<string> { "segment1", "segment2", };
+        private static readonly List<string> segmentsToCheck = new List<string>
+            { "segment1", "segment2" };
 
         private OdpConfig _odpConfig;
         private Mock<IOdpSegmentApiManager> _mockApiManager;
@@ -60,10 +61,11 @@ namespace OptimizelySDK.Tests.OdpTests
         public void ShouldFetchSegmentsOnCacheMiss()
         {
             var keyCollector = new List<string>();
-            _mockCache.Setup(c => c.Lookup(Capture.In(keyCollector))).Returns(default(List<string>));
+            _mockCache.Setup(c => c.Lookup(Capture.In(keyCollector))).
+                Returns(default(List<string>));
             _mockApiManager.Setup(a => a.FetchSegments(It.IsAny<string>(), It.IsAny<string>(),
-                    It.IsAny<OdpUserKeyType>(), It.IsAny<string>(), It.IsAny<List<string>>()))
-                .Returns(segmentsToCheck.ToArray());
+                    It.IsAny<OdpUserKeyType>(), It.IsAny<string>(), It.IsAny<List<string>>())).
+                Returns(segmentsToCheck.ToArray());
             var manager = new OdpSegmentManager(_mockApiManager.Object, _mockCache.Object,
                 _mockLogger.Object);
             manager.UpdateSettings(_odpConfig);
@@ -119,8 +121,8 @@ namespace OptimizelySDK.Tests.OdpTests
         {
             // OdpSegmentApiManager.FetchSegments() return null on any error
             _mockApiManager.Setup(a => a.FetchSegments(It.IsAny<string>(), It.IsAny<string>(),
-                    It.IsAny<OdpUserKeyType>(), It.IsAny<string>(), It.IsAny<List<string>>()))
-                .Returns(null as string[]);
+                    It.IsAny<OdpUserKeyType>(), It.IsAny<string>(), It.IsAny<List<string>>())).
+                Returns(null as string[]);
             var manager = new OdpSegmentManager(_mockApiManager.Object, _mockCache.Object,
                 _mockLogger.Object);
             manager.UpdateSettings(_odpConfig);
@@ -178,7 +180,8 @@ namespace OptimizelySDK.Tests.OdpTests
                 _mockLogger.Object);
             manager.UpdateSettings(_odpConfig);
 
-            manager.FetchQualifiedSegments(FS_USER_ID, new List<OdpSegmentOption> { OdpSegmentOption.IGNORE_CACHE, });
+            manager.FetchQualifiedSegments(FS_USER_ID,
+                new List<OdpSegmentOption> { OdpSegmentOption.IGNORE_CACHE });
 
             _mockCache.Verify(c => c.Reset(), Times.Never);
             _mockCache.Verify(c => c.Lookup(It.IsAny<string>()), Times.Never);
@@ -196,7 +199,8 @@ namespace OptimizelySDK.Tests.OdpTests
                 _mockLogger.Object);
             manager.UpdateSettings(_odpConfig);
 
-            manager.FetchQualifiedSegments(FS_USER_ID, new List<OdpSegmentOption> { OdpSegmentOption.RESET_CACHE, });
+            manager.FetchQualifiedSegments(FS_USER_ID,
+                new List<OdpSegmentOption> { OdpSegmentOption.RESET_CACHE });
 
             _mockCache.Verify(c => c.Reset(), Times.Once);
             _mockCache.Verify(c => c.Lookup(It.IsAny<string>()), Times.Once);

--- a/OptimizelySDK.Tests/OdpTests/OdpSegmentManagerTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpSegmentManagerTest.cs
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.AudienceConditions;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Odp;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
 
 namespace OptimizelySDK.Tests.OdpTests
 {

--- a/OptimizelySDK.Tests/OptimizelyConfigTests/OptimizelyConfigTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyConfigTests/OptimizelyConfigTest.cs
@@ -40,23 +40,25 @@ namespace OptimizelySDK.Tests.OptimizelyConfigTests
 
         #region Test OptimizelyConfigService
 
-        private static Type[] ParameterTypes = {
-                typeof(ProjectConfig),
-            };
+        private static Type[] ParameterTypes =
+        {
+            typeof(ProjectConfig),
+        };
 
         private PrivateObject CreatePrivateOptimizelyConfigService(ProjectConfig projectConfig)
         {
             return new PrivateObject(typeof(OptimizelyConfigService), ParameterTypes,
-                    new object[]
-                    {
-                        projectConfig
-                    });
+                new object[]
+                {
+                    projectConfig,
+                });
         }
 
         [Test]
         public void TestGetOptimizelyConfigServiceSerializedAudiences()
         {
-            var datafileProjectConfig = DatafileProjectConfig.Create(TestData.TypedAudienceDatafile, new NoOpLogger(), new ErrorHandler.NoOpErrorHandler());
+            var datafileProjectConfig = DatafileProjectConfig.Create(TestData.TypedAudienceDatafile,
+                new NoOpLogger(), new ErrorHandler.NoOpErrorHandler());
             var optlyConfigService = CreatePrivateOptimizelyConfigService(datafileProjectConfig);
 
             var audienceConditions = new List<List<object>>
@@ -68,8 +70,16 @@ namespace OptimizelySDK.Tests.OptimizelyConfigTests
                 new List<object>() { "and", "3468206642" },
                 new List<object>() { "3468206642" },
                 new List<object>() { "3468206642", "3988293898" },
-                new List<object>() { "and", new JArray() { "or", "3468206642", "3988293898" }, "3468206646" },
-                new List<object>() { "and", new JArray() { "or", "3468206642", new JArray() { "and", "3988293898", "3468206646" } }, new JArray() { "and", "3988293899", new JArray() { "or", "3468206647", "3468206643" } } },
+                new List<object>()
+                    { "and", new JArray() { "or", "3468206642", "3988293898" }, "3468206646" },
+                new List<object>()
+                {
+                    "and",
+                    new JArray()
+                        { "or", "3468206642", new JArray() { "and", "3988293898", "3468206646" } },
+                    new JArray()
+                        { "and", "3988293899", new JArray() { "or", "3468206647", "3468206643" } },
+                },
                 new List<object>() { "and", "and" },
                 new List<object>() { "not", new JArray() { "and", "3468206642", "3988293898" } },
                 new List<object>() { },
@@ -93,9 +103,10 @@ namespace OptimizelySDK.Tests.OptimizelyConfigTests
                 "\"exactString\" OR \"999999999\"",
             };
 
-            for (int testNo = 0; testNo < audienceConditions.Count; testNo++)
+            for (var testNo = 0; testNo < audienceConditions.Count; testNo++)
             {
-                var result = (string)optlyConfigService.Invoke("GetSerializedAudiences", audienceConditions[testNo], datafileProjectConfig.AudienceIdMap);
+                var result = (string)optlyConfigService.Invoke("GetSerializedAudiences",
+                    audienceConditions[testNo], datafileProjectConfig.AudienceIdMap);
                 Assert.AreEqual(result, expectedAudienceOutputs[testNo]);
             }
         }
@@ -103,12 +114,12 @@ namespace OptimizelySDK.Tests.OptimizelyConfigTests
         [Test]
         public void TestAfterDisposeGetOptimizelyConfigIsNoLongerValid()
         {
-            var httpManager = new HttpProjectConfigManager.Builder()
-                                                          .WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z")
-                                                          .WithDatafile(TestData.Datafile)
-                                                          .WithPollingInterval(TimeSpan.FromMilliseconds(50000))
-                                                          .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500))
-                                                          .Build(true);
+            var httpManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("QBw9gFM8oTn7ogY9ANCC1z").
+                WithDatafile(TestData.Datafile).
+                WithPollingInterval(TimeSpan.FromMilliseconds(50000)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500)).
+                Build(true);
             var optimizely = new Optimizely(httpManager);
             httpManager.Start();
 
@@ -128,20 +139,24 @@ namespace OptimizelySDK.Tests.OptimizelyConfigTests
         [Test]
         public void TestGetOptimizelyConfigServiceNullConfig()
         {
-            OptimizelyConfig optimizelyConfig = new OptimizelyConfigService(null).GetOptimizelyConfig();
+            var optimizelyConfig = new OptimizelyConfigService(null).GetOptimizelyConfig();
             Assert.IsNull(optimizelyConfig);
         }
 
         [Test]
         public void TestGetOptimizelyConfigWithDuplicateExperimentKeys()
         {
-            var datafileProjectConfig = DatafileProjectConfig.Create(TestData.DuplicateExpKeysDatafile, new NoOpLogger(), new ErrorHandler.NoOpErrorHandler());
+            var datafileProjectConfig = DatafileProjectConfig.Create(
+                TestData.DuplicateExpKeysDatafile, new NoOpLogger(),
+                new ErrorHandler.NoOpErrorHandler());
             var optimizelyConfigService = new OptimizelyConfigService(datafileProjectConfig);
             var optimizelyConfig = optimizelyConfigService.GetOptimizelyConfig();
             Assert.AreEqual(optimizelyConfig.ExperimentsMap.Count, 1);
 
-            var experimentMapFlag1 = optimizelyConfig.FeaturesMap["flag1"].ExperimentsMap; //9300000007569
-            var experimentMapFlag2 = optimizelyConfig.FeaturesMap["flag2"].ExperimentsMap; // 9300000007573
+            var experimentMapFlag1 =
+                optimizelyConfig.FeaturesMap["flag1"].ExperimentsMap; //9300000007569
+            var experimentMapFlag2 =
+                optimizelyConfig.FeaturesMap["flag2"].ExperimentsMap; // 9300000007573
             Assert.AreEqual(experimentMapFlag1["targeted_delivery"].Id, "9300000007569");
             Assert.AreEqual(experimentMapFlag2["targeted_delivery"].Id, "9300000007573");
         }
@@ -149,14 +164,19 @@ namespace OptimizelySDK.Tests.OptimizelyConfigTests
         [Test]
         public void TestGetOptimizelyConfigWithDuplicateRuleKeys()
         {
-            var datafileProjectConfig = DatafileProjectConfig.Create(TestData.DuplicateRuleKeysDatafile, new NoOpLogger(), new ErrorHandler.NoOpErrorHandler());
+            var datafileProjectConfig = DatafileProjectConfig.Create(
+                TestData.DuplicateRuleKeysDatafile, new NoOpLogger(),
+                new ErrorHandler.NoOpErrorHandler());
             var optimizelyConfigService = new OptimizelyConfigService(datafileProjectConfig);
             var optimizelyConfig = optimizelyConfigService.GetOptimizelyConfig();
             Assert.AreEqual(optimizelyConfig.ExperimentsMap.Count, 0);
 
-            var rolloutFlag1 = optimizelyConfig.FeaturesMap["flag_1"].DeliveryRules[0]; // 9300000004977,
-            var rolloutFlag2 = optimizelyConfig.FeaturesMap["flag_2"].DeliveryRules[0]; // 9300000004979
-            var rolloutFlag3 = optimizelyConfig.FeaturesMap["flag_3"].DeliveryRules[0]; // 9300000004981
+            var rolloutFlag1 =
+                optimizelyConfig.FeaturesMap["flag_1"].DeliveryRules[0]; // 9300000004977,
+            var rolloutFlag2 =
+                optimizelyConfig.FeaturesMap["flag_2"].DeliveryRules[0]; // 9300000004979
+            var rolloutFlag3 =
+                optimizelyConfig.FeaturesMap["flag_3"].DeliveryRules[0]; // 9300000004981
             Assert.AreEqual(rolloutFlag1.Id, "9300000004977");
             Assert.AreEqual(rolloutFlag1.Key, "targeted_delivery");
             Assert.AreEqual(rolloutFlag2.Id, "9300000004979");
@@ -168,7 +188,9 @@ namespace OptimizelySDK.Tests.OptimizelyConfigTests
         [Test]
         public void TestGetOptimizelyConfigSDKAndEnvironmentKeyDefault()
         {
-            var datafileProjectConfig = DatafileProjectConfig.Create(TestData.DuplicateRuleKeysDatafile, new NoOpLogger(), new ErrorHandler.NoOpErrorHandler());
+            var datafileProjectConfig = DatafileProjectConfig.Create(
+                TestData.DuplicateRuleKeysDatafile, new NoOpLogger(),
+                new ErrorHandler.NoOpErrorHandler());
             var optimizelyConfigService = new OptimizelyConfigService(datafileProjectConfig);
             var optimizelyConfig = optimizelyConfigService.GetOptimizelyConfig();
 
@@ -179,376 +201,405 @@ namespace OptimizelySDK.Tests.OptimizelyConfigTests
         [Test]
         public void TestGetOptimizelyConfigService()
         {
-            var datafileProjectConfig = DatafileProjectConfig.Create(TestData.TypedAudienceDatafile, new NoOpLogger(), new ErrorHandler.NoOpErrorHandler());
-            IDictionary<string, OptimizelyExperiment> experimentsMap = new Dictionary<string, OptimizelyExperiment>
-            {
+            var datafileProjectConfig = DatafileProjectConfig.Create(TestData.TypedAudienceDatafile,
+                new NoOpLogger(), new ErrorHandler.NoOpErrorHandler());
+            IDictionary<string, OptimizelyExperiment> experimentsMap =
+                new Dictionary<string, OptimizelyExperiment>
                 {
-                    "feat_with_var_test", new OptimizelyExperiment (
-                        id: "11564051718",
-                        key:"feat_with_var_test",
-                        audiences: "",
-                        variationsMap: new Dictionary<string, OptimizelyVariation>
-                        {
+                    {
+                        "feat_with_var_test", new OptimizelyExperiment(
+                            "11564051718",
+                            "feat_with_var_test",
+                            "",
+                            new Dictionary<string, OptimizelyVariation>
                             {
-                                "variation_2", new OptimizelyVariation (
-                                    id: "11617170975",
-                                    key: "variation_2",
-                                    featureEnabled: true,
-                                    variablesMap: new Dictionary<string, OptimizelyVariable>
-                                    {
+                                {
+                                    "variation_2", new OptimizelyVariation(
+                                        "11617170975",
+                                        "variation_2",
+                                        true,
+                                        new Dictionary<string, OptimizelyVariable>
                                         {
-                                            "x" , new OptimizelyVariable (
-                                                id: "11535264366",
-                                                key: "x",
-                                                type: "string",
-                                                value: "xyz")
-                                        }
-                                    })
+                                            {
+                                                "x", new OptimizelyVariable(
+                                                    "11535264366",
+                                                    "x",
+                                                    "string",
+                                                    "xyz")
+                                            },
+                                        })
+                                },
                             }
-                        }
-                    )
-                },
-                {
-                    "typed_audience_experiment", new OptimizelyExperiment (
-                        id: "1323241597",
-                        key:"typed_audience_experiment",
-                        audiences: "",
-                        variationsMap: new Dictionary<string, OptimizelyVariation>
-                        {
+                        )
+                    },
+                    {
+                        "typed_audience_experiment", new OptimizelyExperiment(
+                            "1323241597",
+                            "typed_audience_experiment",
+                            "",
+                            new Dictionary<string, OptimizelyVariation>
                             {
-                                "A", new OptimizelyVariation (
-                                    id: "1423767503",
-                                    key: "A",
-                                    featureEnabled: null,
-                                    variablesMap: new Dictionary<string, OptimizelyVariable> ())
+                                {
+                                    "A", new OptimizelyVariation(
+                                        "1423767503",
+                                        "A",
+                                        null,
+                                        new Dictionary<string, OptimizelyVariable>())
+                                },
                             }
-                        }
-                    )
-                },
-                {
-                    "audience_combinations_experiment", new OptimizelyExperiment (
-                        id: "1323241598",
-                        key:"audience_combinations_experiment",
-                        audiences: "(\"exactString\" OR \"substringString\") AND (\"exists\" OR \"exactNumber\" OR \"gtNumber\" OR \"ltNumber\" OR \"exactBoolean\")",
-                        variationsMap: new Dictionary<string, OptimizelyVariation>
-                        {
+                        )
+                    },
+                    {
+                        "audience_combinations_experiment", new OptimizelyExperiment(
+                            "1323241598",
+                            "audience_combinations_experiment",
+                            "(\"exactString\" OR \"substringString\") AND (\"exists\" OR \"exactNumber\" OR \"gtNumber\" OR \"ltNumber\" OR \"exactBoolean\")",
+                            new Dictionary<string, OptimizelyVariation>
                             {
-                                "A", new OptimizelyVariation (
-                                    id: "1423767504",
-                                    key: "A",
-                                    featureEnabled: null,
-                                    variablesMap: new Dictionary<string, OptimizelyVariable> ())
+                                {
+                                    "A", new OptimizelyVariation(
+                                        "1423767504",
+                                        "A",
+                                        null,
+                                        new Dictionary<string, OptimizelyVariable>())
+                                },
                             }
-                        }
-                    )
-                },
-                {
-                    "feat2_with_var_test", new OptimizelyExperiment(
-                        id: "1323241599",
-                        key:"feat2_with_var_test",
-                        audiences: "(\"exactString\" OR \"substringString\") AND (\"exists\" OR \"exactNumber\" OR \"gtNumber\" OR \"ltNumber\" OR \"exactBoolean\")",
-                        variationsMap: new Dictionary<string, OptimizelyVariation>
-                        {
+                        )
+                    },
+                    {
+                        "feat2_with_var_test", new OptimizelyExperiment(
+                            "1323241599",
+                            "feat2_with_var_test",
+                            "(\"exactString\" OR \"substringString\") AND (\"exists\" OR \"exactNumber\" OR \"gtNumber\" OR \"ltNumber\" OR \"exactBoolean\")",
+                            new Dictionary<string, OptimizelyVariation>
                             {
-                                "variation_2", new OptimizelyVariation (
-                                    id: "1423767505",
-                                    key: "variation_2",
-                                    featureEnabled: true,
-                                    variablesMap: new Dictionary<string, OptimizelyVariable>
-                                    {
+                                {
+                                    "variation_2", new OptimizelyVariation(
+                                        "1423767505",
+                                        "variation_2",
+                                        true,
+                                        new Dictionary<string, OptimizelyVariable>
                                         {
-                                            "z" , new OptimizelyVariable (
-                                                id: "11535264367",
-                                                key: "z",
-                                                type: "integer",
-                                                value: "150")
-                                        }
-                                    })
+                                            {
+                                                "z", new OptimizelyVariable(
+                                                    "11535264367",
+                                                    "z",
+                                                    "integer",
+                                                    "150")
+                                            },
+                                        })
+                                },
                             }
-                        }
-                    )
-                }
-            };
+                        )
+                    },
+                };
 
             var featuresMap = new Dictionary<string, OptimizelyFeature>
             {
                 {
-                    "feat_no_vars", new OptimizelyFeature (
-                        id: "11477755619",
-                        key: "feat_no_vars",
-                        experimentRules: new List<OptimizelyExperiment>(),
-                        deliveryRules: new List<OptimizelyExperiment>() { new OptimizelyExperiment(
-                                            id: "11488548027",
-                                            key:"feat_no_vars_rule",
-                                            audiences: "",
-                                            variationsMap: new Dictionary<string, OptimizelyVariation>
-                                            {
-                                                {
-                                                    "11557362669", new OptimizelyVariation (
-                                                        id: "11557362669",
-                                                        key: "11557362669",
-                                                        featureEnabled: true,
-                                                        variablesMap: new Dictionary<string, OptimizelyVariable>())
-                                                }
-                                            }
-                                        ) },
-                        experimentsMap: new Dictionary<string, OptimizelyExperiment>(),
-                        variablesMap: new Dictionary<string, OptimizelyVariable>())
+                    "feat_no_vars", new OptimizelyFeature(
+                        "11477755619",
+                        "feat_no_vars",
+                        new List<OptimizelyExperiment>(),
+                        new List<OptimizelyExperiment>()
+                        {
+                            new OptimizelyExperiment(
+                                "11488548027",
+                                "feat_no_vars_rule",
+                                "",
+                                new Dictionary<string, OptimizelyVariation>
+                                {
+                                    {
+                                        "11557362669", new OptimizelyVariation(
+                                            "11557362669",
+                                            "11557362669",
+                                            true,
+                                            new Dictionary<string, OptimizelyVariable>())
+                                    },
+                                }
+                            ),
+                        },
+                        new Dictionary<string, OptimizelyExperiment>(),
+                        new Dictionary<string, OptimizelyVariable>())
                 },
                 {
-                    "feat_with_var", new OptimizelyFeature (
-                        id: "11567102051",
-                        key: "feat_with_var",
-                        experimentRules: new List<OptimizelyExperiment>() {
+                    "feat_with_var", new OptimizelyFeature(
+                        "11567102051",
+                        "feat_with_var",
+                        new List<OptimizelyExperiment>()
+                        {
                             new OptimizelyExperiment(
-                                    id: "11564051718",
-                                    key:"feat_with_var_test",
-                                    audiences: "",
-                                    variationsMap: new Dictionary<string, OptimizelyVariation>
+                                "11564051718",
+                                "feat_with_var_test",
+                                "",
+                                new Dictionary<string, OptimizelyVariation>
+                                {
                                     {
-                                        {
-                                            "variation_2", new OptimizelyVariation (
-                                                id: "11617170975",
-                                                key: "variation_2",
-                                                featureEnabled: true,
-                                                variablesMap: new Dictionary<string, OptimizelyVariable>
-                                                {
-                                                    {
-                                                        "x" , new OptimizelyVariable (
-                                                            id: "11535264366",
-                                                            key: "x",
-                                                            type: "string",
-                                                            value: "xyz")
-                                                    }
-                                                })
-                                        }
-                                    }
-                                )
-                        },
-                        deliveryRules: new List<OptimizelyExperiment>() { new OptimizelyExperiment(
-                                            id: "11630490911",
-                                            key:"feat_with_var_rule",
-                                            audiences: "",
-                                            variationsMap: new Dictionary<string, OptimizelyVariation>
+                                        "variation_2", new OptimizelyVariation(
+                                            "11617170975",
+                                            "variation_2",
+                                            true,
+                                            new Dictionary<string, OptimizelyVariable>
                                             {
                                                 {
-                                                    "11475708558", new OptimizelyVariation (
-                                                        id: "11475708558",
-                                                        key: "11475708558",
-                                                        featureEnabled: false,
-                                                        variablesMap: new Dictionary<string, OptimizelyVariable>()
-                                                        {
-                                                            { "x" , new OptimizelyVariable("11535264366", "x", "string", "x")  }
-                                                        })
-                                                }
-                                            }
-                                        ) },
-                        experimentsMap: new Dictionary<string, OptimizelyExperiment>
+                                                    "x", new OptimizelyVariable(
+                                                        "11535264366",
+                                                        "x",
+                                                        "string",
+                                                        "xyz")
+                                                },
+                                            })
+                                    },
+                                }
+                            ),
+                        },
+                        new List<OptimizelyExperiment>()
+                        {
+                            new OptimizelyExperiment(
+                                "11630490911",
+                                "feat_with_var_rule",
+                                "",
+                                new Dictionary<string, OptimizelyVariation>
+                                {
+                                    {
+                                        "11475708558", new OptimizelyVariation(
+                                            "11475708558",
+                                            "11475708558",
+                                            false,
+                                            new Dictionary<string, OptimizelyVariable>()
+                                            {
+                                                {
+                                                    "x",
+                                                    new OptimizelyVariable("11535264366", "x",
+                                                        "string", "x")
+                                                },
+                                            })
+                                    },
+                                }
+                            ),
+                        },
+                        new Dictionary<string, OptimizelyExperiment>
                         {
                             {
                                 "feat_with_var_test", new OptimizelyExperiment(
-                                    id: "11564051718",
-                                    key:"feat_with_var_test",
-                                    audiences: "",
-                                    variationsMap: new Dictionary<string, OptimizelyVariation>
+                                    "11564051718",
+                                    "feat_with_var_test",
+                                    "",
+                                    new Dictionary<string, OptimizelyVariation>
                                     {
                                         {
-                                            "variation_2", new OptimizelyVariation (
-                                                id: "11617170975",
-                                                key: "variation_2",
-                                                featureEnabled: true,
-                                                variablesMap: new Dictionary<string, OptimizelyVariable>
+                                            "variation_2", new OptimizelyVariation(
+                                                "11617170975",
+                                                "variation_2",
+                                                true,
+                                                new Dictionary<string, OptimizelyVariable>
                                                 {
                                                     {
-                                                        "x" , new OptimizelyVariable (
-                                                            id: "11535264366",
-                                                            key: "x",
-                                                            type: "string",
-                                                            value: "xyz")
-                                                    }
+                                                        "x", new OptimizelyVariable(
+                                                            "11535264366",
+                                                            "x",
+                                                            "string",
+                                                            "xyz")
+                                                    },
                                                 })
-                                        }
+                                        },
                                     }
                                 )
-                            }
+                            },
                         },
-                        variablesMap: new Dictionary<string, OptimizelyVariable>
+                        new Dictionary<string, OptimizelyVariable>
                         {
                             {
-                                "x", new OptimizelyVariable (id: "11535264366" , key: "x", type: "string", value: "x")
-                            }
+                                "x", new OptimizelyVariable("11535264366", "x", "string", "x")
+                            },
                         })
                 },
                 {
-                    "feat2", new OptimizelyFeature (
-                        id: "11567102052",
-                        key: "feat2",
-                        deliveryRules: new List<OptimizelyExperiment>() { new OptimizelyExperiment(
-                                            id: "11488548028",
-                                            key:"11488548028",
-                                            audiences: "(\"exactString\" OR \"substringString\") AND (\"exists\" OR \"exactNumber\" OR \"gtNumber\" OR \"ltNumber\" OR \"exactBoolean\")",
-                                            variationsMap: new Dictionary<string, OptimizelyVariation>
-                                            {
-                                                {
-                                                    "11557362670", new OptimizelyVariation (
-                                                        id: "11557362670",
-                                                        key: "11557362670",
-                                                        featureEnabled: true,
-                                                        variablesMap: new Dictionary<string, OptimizelyVariable>()
-                                                        )
-                                                }
-                                            }
-                                        ) },
+                    "feat2", new OptimizelyFeature(
+                        "11567102052",
+                        "feat2",
+                        deliveryRules: new List<OptimizelyExperiment>()
+                        {
+                            new OptimizelyExperiment(
+                                "11488548028",
+                                "11488548028",
+                                "(\"exactString\" OR \"substringString\") AND (\"exists\" OR \"exactNumber\" OR \"gtNumber\" OR \"ltNumber\" OR \"exactBoolean\")",
+                                new Dictionary<string, OptimizelyVariation>
+                                {
+                                    {
+                                        "11557362670", new OptimizelyVariation(
+                                            "11557362670",
+                                            "11557362670",
+                                            true,
+                                            new Dictionary<string, OptimizelyVariable>()
+                                        )
+                                    },
+                                }
+                            ),
+                        },
                         experimentRules: new List<OptimizelyExperiment>(),
                         experimentsMap: new Dictionary<string, OptimizelyExperiment>(),
                         variablesMap: new Dictionary<string, OptimizelyVariable>())
                 },
                 {
-                    "feat2_with_var", new OptimizelyFeature (
-                        id: "11567102053",
-                        key: "feat2_with_var",
+                    "feat2_with_var", new OptimizelyFeature(
+                        "11567102053",
+                        "feat2_with_var",
                         deliveryRules: new List<OptimizelyExperiment>()
                         {
                             new OptimizelyExperiment(
-                                            id: "11630490912",
-                                            key:"11630490912",
-                                            audiences: "",
-                                            variationsMap: new Dictionary<string, OptimizelyVariation>
+                                "11630490912",
+                                "11630490912",
+                                "",
+                                new Dictionary<string, OptimizelyVariation>
+                                {
+                                    {
+                                        "11475708559", new OptimizelyVariation(
+                                            "11475708559",
+                                            "11475708559",
+                                            false,
+                                            new Dictionary<string, OptimizelyVariable>()
                                             {
                                                 {
-                                                    "11475708559", new OptimizelyVariation (
-                                                        id: "11475708559",
-                                                        key: "11475708559",
-                                                        featureEnabled: false,
-                                                        variablesMap: new Dictionary<string, OptimizelyVariable>()
-                                                        {
-                                                            {
-                                                                "z" , new OptimizelyVariable (
-                                                                    id: "11535264367",
-                                                                    key: "z",
-                                                                    type: "integer",
-                                                                    value: "10")
-                                                            }
-                                                        })
-                                                }
-                                            }
-                                        )
+                                                    "z", new OptimizelyVariable(
+                                                        "11535264367",
+                                                        "z",
+                                                        "integer",
+                                                        "10")
+                                                },
+                                            })
+                                    },
+                                }
+                            ),
                         },
                         experimentRules: new List<OptimizelyExperiment>()
                         {
-                            new OptimizelyExperiment (
-                                    id: "1323241599",
-                                    key:"feat2_with_var_test",
-                                    audiences: "(\"exactString\" OR \"substringString\") AND (\"exists\" OR \"exactNumber\" OR \"gtNumber\" OR \"ltNumber\" OR \"exactBoolean\")",
-                                    variationsMap: new Dictionary<string, OptimizelyVariation>
+                            new OptimizelyExperiment(
+                                "1323241599",
+                                "feat2_with_var_test",
+                                "(\"exactString\" OR \"substringString\") AND (\"exists\" OR \"exactNumber\" OR \"gtNumber\" OR \"ltNumber\" OR \"exactBoolean\")",
+                                new Dictionary<string, OptimizelyVariation>
+                                {
                                     {
-                                        {
-                                            "variation_2", new OptimizelyVariation (
-                                                id: "1423767505",
-                                                key: "variation_2",
-                                                featureEnabled: true,
-                                                variablesMap: new Dictionary<string, OptimizelyVariable>
+                                        "variation_2", new OptimizelyVariation(
+                                            "1423767505",
+                                            "variation_2",
+                                            true,
+                                            new Dictionary<string, OptimizelyVariable>
+                                            {
                                                 {
-                                                    {
-                                                        "z" , new OptimizelyVariable (
-                                                            id: "11535264367",
-                                                            key: "z",
-                                                            type: "integer",
-                                                            value: "150")
-                                                    }
-                                                })
-                                        }
-                                    }
-                                )
+                                                    "z", new OptimizelyVariable(
+                                                        "11535264367",
+                                                        "z",
+                                                        "integer",
+                                                        "150")
+                                                },
+                                            })
+                                    },
+                                }
+                            ),
                         },
                         experimentsMap: new Dictionary<string, OptimizelyExperiment>
                         {
                             {
-                                "feat2_with_var_test", new OptimizelyExperiment (
-                                    id: "1323241599",
-                                    key:"feat2_with_var_test",
-                                    audiences: "(\"exactString\" OR \"substringString\") AND (\"exists\" OR \"exactNumber\" OR \"gtNumber\" OR \"ltNumber\" OR \"exactBoolean\")",
-                                    variationsMap: new Dictionary<string, OptimizelyVariation>
+                                "feat2_with_var_test", new OptimizelyExperiment(
+                                    "1323241599",
+                                    "feat2_with_var_test",
+                                    "(\"exactString\" OR \"substringString\") AND (\"exists\" OR \"exactNumber\" OR \"gtNumber\" OR \"ltNumber\" OR \"exactBoolean\")",
+                                    new Dictionary<string, OptimizelyVariation>
                                     {
                                         {
-                                            "variation_2", new OptimizelyVariation (
-                                                id: "1423767505",
-                                                key: "variation_2",
-                                                featureEnabled: true,
-                                                variablesMap: new Dictionary<string, OptimizelyVariable>
+                                            "variation_2", new OptimizelyVariation(
+                                                "1423767505",
+                                                "variation_2",
+                                                true,
+                                                new Dictionary<string, OptimizelyVariable>
                                                 {
                                                     {
-                                                        "z" , new OptimizelyVariable (
-                                                            id: "11535264367",
-                                                            key: "z",
-                                                            type: "integer",
-                                                            value: "150")
-                                                    }
+                                                        "z", new OptimizelyVariable(
+                                                            "11535264367",
+                                                            "z",
+                                                            "integer",
+                                                            "150")
+                                                    },
                                                 })
-                                        }
+                                        },
                                     }
                                 )
-                            }
+                            },
                         },
                         variablesMap: new Dictionary<string, OptimizelyVariable>
                         {
                             {
-                                "z", new OptimizelyVariable (id: "11535264367" , key: "z", type: "integer", value: "10")
-                            }
+                                "z", new OptimizelyVariable("11535264367", "z", "integer", "10")
+                            },
                         })
-                }
+                },
             };
 
-            OptimizelyConfig optimizelyConfig = new OptimizelyConfigService(datafileProjectConfig).GetOptimizelyConfig();
-            OptimizelyConfig expectedOptimizelyConfig = new OptimizelyConfig(datafileProjectConfig.Revision,
+            var optimizelyConfig =
+                new OptimizelyConfigService(datafileProjectConfig).GetOptimizelyConfig();
+            var expectedOptimizelyConfig = new OptimizelyConfig(datafileProjectConfig.Revision,
                 datafileProjectConfig.SDKKey,
                 datafileProjectConfig.EnvironmentKey,
-                attributes: new OptimizelyAttribute[]
+                new OptimizelyAttribute[]
                 {
                     new OptimizelyAttribute
                     {
-                       Id = "594015", Key = "house"
+                        Id = "594015", Key = "house",
                     },
                     new OptimizelyAttribute
                     {
-                       Id = "594016", Key = "lasers"
+                        Id = "594016", Key = "lasers",
                     },
                     new OptimizelyAttribute
                     {
-                       Id = "594017", Key = "should_do_it"
+                        Id = "594017", Key = "should_do_it",
                     },
                     new OptimizelyAttribute
                     {
-                       Id = "594018", Key = "favorite_ice_cream"
-                    }
+                        Id = "594018", Key = "favorite_ice_cream",
+                    },
                 },
-                audiences: new OptimizelyAudience[]
+                new OptimizelyAudience[]
                 {
-                    new OptimizelyAudience("0", "$$dummy", "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"),
-                    new OptimizelyAudience("3468206643", "exactBoolean", "[\"and\",[\"or\",[\"or\",{\"name\":\"should_do_it\",\"type\":\"custom_attribute\",\"match\":\"exact\",\"value\":true}]]]"),
-                    new OptimizelyAudience("3468206646", "exactNumber", "[\"and\",[\"or\",[\"or\",{\"name\":\"lasers\",\"type\":\"custom_attribute\",\"match\":\"exact\",\"value\":45.5}]]]"),
-                    new OptimizelyAudience("3468206642", "exactString", "[\"and\", [\"or\", [\"or\", {\"name\": \"house\", \"type\": \"custom_attribute\", \"value\": \"Gryffindor\"}]]]"),
-                    new OptimizelyAudience("3988293899", "exists", "[\"and\",[\"or\",[\"or\",{\"name\":\"favorite_ice_cream\",\"type\":\"custom_attribute\",\"match\":\"exists\"}]]]"),
-                    new OptimizelyAudience("3468206647", "gtNumber", "[\"and\",[\"or\",[\"or\",{\"name\":\"lasers\",\"type\":\"custom_attribute\",\"match\":\"gt\",\"value\":70}]]]"),
-                    new OptimizelyAudience("3468206644", "ltNumber", "[\"and\",[\"or\",[\"or\",{\"name\":\"lasers\",\"type\":\"custom_attribute\",\"match\":\"lt\",\"value\":1.0}]]]"),
-                    new OptimizelyAudience("3468206645", "notChrome", "[\"and\", [\"or\", [\"not\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\":\"Chrome\"}]]]]"),
-                    new OptimizelyAudience("3468206648", "notExist", "[\"not\",{\"name\":\"input_value\",\"type\":\"custom_attribute\",\"match\":\"exists\"}]"),
-                    new OptimizelyAudience("3988293898", "substringString", "[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"match\":\"substring\",\"value\":\"Slytherin\"}]]]"),
+                    new OptimizelyAudience("0", "$$dummy",
+                        "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"),
+                    new OptimizelyAudience("3468206643", "exactBoolean",
+                        "[\"and\",[\"or\",[\"or\",{\"name\":\"should_do_it\",\"type\":\"custom_attribute\",\"match\":\"exact\",\"value\":true}]]]"),
+                    new OptimizelyAudience("3468206646", "exactNumber",
+                        "[\"and\",[\"or\",[\"or\",{\"name\":\"lasers\",\"type\":\"custom_attribute\",\"match\":\"exact\",\"value\":45.5}]]]"),
+                    new OptimizelyAudience("3468206642", "exactString",
+                        "[\"and\", [\"or\", [\"or\", {\"name\": \"house\", \"type\": \"custom_attribute\", \"value\": \"Gryffindor\"}]]]"),
+                    new OptimizelyAudience("3988293899", "exists",
+                        "[\"and\",[\"or\",[\"or\",{\"name\":\"favorite_ice_cream\",\"type\":\"custom_attribute\",\"match\":\"exists\"}]]]"),
+                    new OptimizelyAudience("3468206647", "gtNumber",
+                        "[\"and\",[\"or\",[\"or\",{\"name\":\"lasers\",\"type\":\"custom_attribute\",\"match\":\"gt\",\"value\":70}]]]"),
+                    new OptimizelyAudience("3468206644", "ltNumber",
+                        "[\"and\",[\"or\",[\"or\",{\"name\":\"lasers\",\"type\":\"custom_attribute\",\"match\":\"lt\",\"value\":1.0}]]]"),
+                    new OptimizelyAudience("3468206645", "notChrome",
+                        "[\"and\", [\"or\", [\"not\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\":\"Chrome\"}]]]]"),
+                    new OptimizelyAudience("3468206648", "notExist",
+                        "[\"not\",{\"name\":\"input_value\",\"type\":\"custom_attribute\",\"match\":\"exists\"}]"),
+                    new OptimizelyAudience("3988293898", "substringString",
+                        "[\"and\",[\"or\",[\"or\",{\"name\":\"house\",\"type\":\"custom_attribute\",\"match\":\"substring\",\"value\":\"Slytherin\"}]]]"),
                 },
-                events: new OptimizelyEvent[]
+                new OptimizelyEvent[]
                 {
                     new OptimizelyEvent()
                     {
-                       Id = "594089", Key = "item_bought", ExperimentIds = new string[] { "11564051718", "1323241597" }
+                        Id = "594089", Key = "item_bought",
+                        ExperimentIds = new string[] { "11564051718", "1323241597" },
                     },
                     new OptimizelyEvent()
                     {
-                       Id = "594090", Key = "user_signed_up", ExperimentIds = new string[] { "1323241598", "1323241599" }
-                    }
+                        Id = "594090", Key = "user_signed_up",
+                        ExperimentIds = new string[] { "1323241598", "1323241599" },
+                    },
                 },
-                experimentsMap: experimentsMap,
-                featuresMap: featuresMap,
-                datafile: TestData.TypedAudienceDatafile);
+                experimentsMap,
+                featuresMap,
+                TestData.TypedAudienceDatafile);
 
             Assertions.AreEqual(expectedOptimizelyConfig, optimizelyConfig);
         }
@@ -560,75 +611,91 @@ namespace OptimizelySDK.Tests.OptimizelyConfigTests
         [Test]
         public void TestOptimizelyConfigEntity()
         {
-            OptimizelyConfig expectedOptlyFeature = new OptimizelyConfig("123",
+            var expectedOptlyFeature = new OptimizelyConfig("123",
                 "testSdkKey",
                 "Development",
-                attributes: new OptimizelyAttribute[0],
-                audiences: new OptimizelyAudience[0],
-                events: new OptimizelyEvent[0],
-                experimentsMap: new Dictionary<string, OptimizelyExperiment>(),
-                featuresMap: new Dictionary<string, OptimizelyFeature>()
-                );
+                new OptimizelyAttribute[0],
+                new OptimizelyAudience[0],
+                new OptimizelyEvent[0],
+                new Dictionary<string, OptimizelyExperiment>(),
+                new Dictionary<string, OptimizelyFeature>()
+            );
             Assert.AreEqual(expectedOptlyFeature.Revision, "123");
             Assert.AreEqual(expectedOptlyFeature.SDKKey, "testSdkKey");
             Assert.AreEqual(expectedOptlyFeature.EnvironmentKey, "Development");
             Assert.AreEqual(expectedOptlyFeature.Attributes, new Entity.Attribute[0]);
             Assert.AreEqual(expectedOptlyFeature.Audiences, new OptimizelyAudience[0]);
             Assert.AreEqual(expectedOptlyFeature.Events, new Entity.Event[0]);
-            Assert.AreEqual(expectedOptlyFeature.ExperimentsMap, new Dictionary<string, OptimizelyExperiment>());
-            Assert.AreEqual(expectedOptlyFeature.FeaturesMap, new Dictionary<string, OptimizelyFeature>());
+            Assert.AreEqual(expectedOptlyFeature.ExperimentsMap,
+                new Dictionary<string, OptimizelyExperiment>());
+            Assert.AreEqual(expectedOptlyFeature.FeaturesMap,
+                new Dictionary<string, OptimizelyFeature>());
         }
 
         [Test]
         public void TestOptimizelyFeatureEntity()
         {
-            OptimizelyFeature expectedOptlyFeature = new OptimizelyFeature("1", "featKey",
+            var expectedOptlyFeature = new OptimizelyFeature("1", "featKey",
                 new List<OptimizelyExperiment>(),
                 new List<OptimizelyExperiment>(),
                 new Dictionary<string, OptimizelyExperiment>(),
                 new Dictionary<string, OptimizelyVariable>()
-                );
+            );
             Assert.AreEqual(expectedOptlyFeature.Id, "1");
             Assert.AreEqual(expectedOptlyFeature.Key, "featKey");
             Assert.AreEqual(expectedOptlyFeature.ExperimentRules, new List<OptimizelyExperiment>());
             Assert.AreEqual(expectedOptlyFeature.DeliveryRules, new List<OptimizelyExperiment>());
             Assert.AreEqual(expectedOptlyFeature.Key, "featKey");
-            Assert.AreEqual(expectedOptlyFeature.ExperimentsMap, new Dictionary<string, OptimizelyExperiment>());
-            Assert.AreEqual(expectedOptlyFeature.VariablesMap, new Dictionary<string, OptimizelyVariable>());
+            Assert.AreEqual(expectedOptlyFeature.ExperimentsMap,
+                new Dictionary<string, OptimizelyExperiment>());
+            Assert.AreEqual(expectedOptlyFeature.VariablesMap,
+                new Dictionary<string, OptimizelyVariable>());
         }
 
         [Test]
         public void TestOptimizelyExperimentEntity()
         {
-            OptimizelyExperiment expectedOptlyExp = new OptimizelyExperiment("1", "exKey",
+            var expectedOptlyExp = new OptimizelyExperiment("1", "exKey",
                 "",
-                new Dictionary<string, OptimizelyVariation> {
+                new Dictionary<string, OptimizelyVariation>
+                {
                     {
-                        "varKey", new OptimizelyVariation("1", "varKey", true, new Dictionary<string, OptimizelyVariable>())
-                    }
+                        "varKey",
+                        new OptimizelyVariation("1", "varKey", true,
+                            new Dictionary<string, OptimizelyVariable>())
+                    },
                 });
             Assert.AreEqual(expectedOptlyExp.Id, "1");
             Assert.AreEqual(expectedOptlyExp.Key, "exKey");
             Assert.AreEqual(expectedOptlyExp.Audiences, "");
-            Assert.AreEqual(expectedOptlyExp.VariationsMap["varKey"], new OptimizelyVariation("1", "varKey", true, new Dictionary<string, OptimizelyVariable>()));
+            Assert.AreEqual(expectedOptlyExp.VariationsMap["varKey"],
+                new OptimizelyVariation("1", "varKey", true,
+                    new Dictionary<string, OptimizelyVariable>()));
         }
 
         [Test]
         public void TestOptimizelyVariationEntity()
         {
-            OptimizelyVariation expectedOptlyVariation = new OptimizelyVariation("1", "varKey", true, new Dictionary<string, OptimizelyVariable> {
-                { "variableKey", new OptimizelyVariable("varId", "variableKey", "integer", "2")}
-            });
+            var expectedOptlyVariation = new OptimizelyVariation("1", "varKey", true,
+                new Dictionary<string, OptimizelyVariable>
+                {
+                    {
+                        "variableKey",
+                        new OptimizelyVariable("varId", "variableKey", "integer", "2")
+                    },
+                });
             Assert.AreEqual(expectedOptlyVariation.Id, "1");
             Assert.AreEqual(expectedOptlyVariation.Key, "varKey");
             Assert.AreEqual(expectedOptlyVariation.FeatureEnabled, true);
-            Assert.AreEqual(expectedOptlyVariation.VariablesMap["variableKey"], new OptimizelyVariable("varId", "variableKey", "integer", "2"));
+            Assert.AreEqual(expectedOptlyVariation.VariablesMap["variableKey"],
+                new OptimizelyVariable("varId", "variableKey", "integer", "2"));
         }
 
         [Test]
         public void TestOptimizelyVariableEntity()
         {
-            OptimizelyVariable expectedOptlyVariable = new OptimizelyVariable("varId", "variableKey", "integer", "2");
+            var expectedOptlyVariable =
+                new OptimizelyVariable("varId", "variableKey", "integer", "2");
             Assert.AreEqual(expectedOptlyVariable.Id, "varId");
             Assert.AreEqual(expectedOptlyVariable.Key, "variableKey");
             Assert.AreEqual(expectedOptlyVariable.Type, "integer");

--- a/OptimizelySDK.Tests/OptimizelyConfigTests/OptimizelyConfigTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyConfigTests/OptimizelyConfigTest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2020-2022, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
 using Moq;
 using Newtonsoft.Json.Linq;
 using NUnit.Framework;
@@ -21,8 +23,6 @@ using OptimizelySDK.Config;
 using OptimizelySDK.Logger;
 using OptimizelySDK.OptlyConfig;
 using OptimizelySDK.Tests.UtilsTests;
-using System;
-using System.Collections.Generic;
 
 namespace OptimizelySDK.Tests.OptimizelyConfigTests
 {
@@ -144,6 +144,7 @@ namespace OptimizelySDK.Tests.OptimizelyConfigTests
         }
 
         [Test]
+        [Obsolete]
         public void TestGetOptimizelyConfigWithDuplicateExperimentKeys()
         {
             var datafileProjectConfig = DatafileProjectConfig.Create(
@@ -633,6 +634,7 @@ namespace OptimizelySDK.Tests.OptimizelyConfigTests
         }
 
         [Test]
+        [Obsolete]
         public void TestOptimizelyFeatureEntity()
         {
             var expectedOptlyFeature = new OptimizelyFeature("1", "featKey",

--- a/OptimizelySDK.Tests/OptimizelyDecisions/OptimizelyDecisionTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyDecisions/OptimizelyDecisionTest.cs
@@ -40,15 +40,18 @@ namespace OptimizelySDK.Tests.OptimizelyDecisions
             LoggerMock = new Mock<ILogger>();
             LoggerMock.Setup(i => i.Log(It.IsAny<LogLevel>(), It.IsAny<string>()));
         }
-        
+
         [Test]
         public void TestNewErrorDecision()
         {
-            var optimizelyDecision = OptimizelyDecision.NewErrorDecision("var_key", null, "some error message", ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyDecision = OptimizelyDecision.NewErrorDecision("var_key", null,
+                "some error message", ErrorHandlerMock.Object, LoggerMock.Object);
             Assert.IsNull(optimizelyDecision.VariationKey);
             Assert.AreEqual(optimizelyDecision.FlagKey, "var_key");
-            Assert.AreEqual(optimizelyDecision.Variables.ToDictionary(), new Dictionary<string, object>());
-            Assert.AreEqual(optimizelyDecision.Reasons, new List<string>() { "some error message" });
+            Assert.AreEqual(optimizelyDecision.Variables.ToDictionary(),
+                new Dictionary<string, object>());
+            Assert.AreEqual(optimizelyDecision.Reasons,
+                new List<string>() { "some error message" });
             Assert.IsNull(optimizelyDecision.RuleKey);
             Assert.False(optimizelyDecision.Enabled);
         }
@@ -56,16 +59,21 @@ namespace OptimizelySDK.Tests.OptimizelyDecisions
         [Test]
         public void TestNewDecision()
         {
-            var variableMap = new Dictionary<string, object>() {
+            var variableMap = new Dictionary<string, object>()
+            {
                 { "strField", "john doe" },
                 { "intField", 12 },
-                { "objectField", new Dictionary<string, object> () {
-                        { "inner_field_int", 3 }
+                {
+                    "objectField", new Dictionary<string, object>()
+                    {
+                        { "inner_field_int", 3 },
                     }
-                }
+                },
             };
-            var optimizelyJSONUsingMap = new OptimizelyJSON(variableMap, ErrorHandlerMock.Object, LoggerMock.Object);
-            string expectedStringObj = "{\"strField\":\"john doe\",\"intField\":12,\"objectField\":{\"inner_field_int\":3}}";
+            var optimizelyJSONUsingMap =
+                new OptimizelyJSON(variableMap, ErrorHandlerMock.Object, LoggerMock.Object);
+            var expectedStringObj =
+                "{\"strField\":\"john doe\",\"intField\":12,\"objectField\":{\"inner_field_int\":3}}";
 
             var optimizelyDecision = new OptimizelyDecision("var_key",
                 true,
@@ -86,25 +94,41 @@ namespace OptimizelySDK.Tests.OptimizelyDecisions
         public void TestNewDecisionReasonWithIncludeReasons()
         {
             var decisionReasons = new DecisionReasons();
-            var decideOptions = new OptimizelyDecideOption[] { OptimizelyDecideOption.INCLUDE_REASONS };
-            decisionReasons.AddError(DecisionMessage.Reason(DecisionMessage.FLAG_KEY_INVALID, "invalid_key"));
-            
-            Assert.AreEqual(decisionReasons.ToReport(decideOptions.Contains(OptimizelyDecideOption.INCLUDE_REASONS))[0], "No flag was found for key \"invalid_key\".");
-            decisionReasons.AddError(DecisionMessage.Reason(DecisionMessage.VARIABLE_VALUE_INVALID, "invalid_key"));
-            Assert.AreEqual(decisionReasons.ToReport(decideOptions.Contains(OptimizelyDecideOption.INCLUDE_REASONS))[1], "Variable value for key \"invalid_key\" is invalid or wrong type.");
+            var decideOptions = new OptimizelyDecideOption[]
+                { OptimizelyDecideOption.INCLUDE_REASONS };
+            decisionReasons.AddError(DecisionMessage.Reason(DecisionMessage.FLAG_KEY_INVALID,
+                "invalid_key"));
+
+            Assert.AreEqual(
+                decisionReasons.ToReport(
+                    decideOptions.Contains(OptimizelyDecideOption.INCLUDE_REASONS))[0],
+                "No flag was found for key \"invalid_key\".");
+            decisionReasons.AddError(DecisionMessage.Reason(DecisionMessage.VARIABLE_VALUE_INVALID,
+                "invalid_key"));
+            Assert.AreEqual(
+                decisionReasons.ToReport(
+                    decideOptions.Contains(OptimizelyDecideOption.INCLUDE_REASONS))[1],
+                "Variable value for key \"invalid_key\" is invalid or wrong type.");
             decisionReasons.AddInfo("Some info message.");
-            Assert.AreEqual(decisionReasons.ToReport(decideOptions.Contains(OptimizelyDecideOption.INCLUDE_REASONS))[2], "Some info message.");
+            Assert.AreEqual(
+                decisionReasons.ToReport(
+                    decideOptions.Contains(OptimizelyDecideOption.INCLUDE_REASONS))[2],
+                "Some info message.");
         }
 
         [Test]
         public void TestNewDecisionReasonWithoutIncludeReasons()
         {
             var decisionReasons = new DecisionReasons();
-            decisionReasons.AddError(DecisionMessage.Reason(DecisionMessage.FLAG_KEY_INVALID, "invalid_key"));
+            decisionReasons.AddError(DecisionMessage.Reason(DecisionMessage.FLAG_KEY_INVALID,
+                "invalid_key"));
 
-            Assert.AreEqual(decisionReasons.ToReport()[0], "No flag was found for key \"invalid_key\".");
-            decisionReasons.AddError(DecisionMessage.Reason(DecisionMessage.VARIABLE_VALUE_INVALID, "invalid_key"));
-            Assert.AreEqual(decisionReasons.ToReport()[1], "Variable value for key \"invalid_key\" is invalid or wrong type.");
+            Assert.AreEqual(decisionReasons.ToReport()[0],
+                "No flag was found for key \"invalid_key\".");
+            decisionReasons.AddError(DecisionMessage.Reason(DecisionMessage.VARIABLE_VALUE_INVALID,
+                "invalid_key"));
+            Assert.AreEqual(decisionReasons.ToReport()[1],
+                "Variable value for key \"invalid_key\" is invalid or wrong type.");
             decisionReasons.AddInfo("Some info message.");
             Assert.AreEqual(decisionReasons.ToReport().Count, 2);
         }

--- a/OptimizelySDK.Tests/OptimizelyDecisions/OptimizelyDecisionTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyDecisions/OptimizelyDecisionTest.cs
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
 using OptimizelySDK.OptimizelyDecisions;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace OptimizelySDK.Tests.OptimizelyDecisions
 {

--- a/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
@@ -26,12 +26,14 @@ using OptimizelySDK.Tests.ConfigTest;
 using OptimizelySDK.Tests.EventTest;
 using OptimizelySDK.Tests.Utils;
 using System;
+
 namespace OptimizelySDK.Tests
 {
     [TestFixture]
     public class OptimizelyFactoryTest
     {
         private Mock<ILogger> LoggerMock;
+
         [SetUp]
         public void Initialize()
         {
@@ -55,7 +57,7 @@ namespace OptimizelySDK.Tests
                 AutoUpdate = true,
                 DatafileAccessToken = "testingtoken123",
                 BlockingTimeout = TimeSpan.FromSeconds(10),
-                PollingInterval = TimeSpan.FromSeconds(2)
+                PollingInterval = TimeSpan.FromSeconds(2),
             };
 
             Assert.AreEqual(actualConfigManagerProps, expectedConfigManagerProps);
@@ -78,7 +80,7 @@ namespace OptimizelySDK.Tests
                 LastModified = "",
                 AutoUpdate = true,
                 BlockingTimeout = TimeSpan.FromSeconds(30),
-                PollingInterval = TimeSpan.FromMilliseconds(2023)
+                PollingInterval = TimeSpan.FromMilliseconds(2023),
             };
 
             Assert.AreEqual(actualConfigManagerProps, expectedConfigManagerProps);
@@ -88,7 +90,8 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestProjectConfigManagerWithDatafileAccessToken()
         {
-            var optimizely = OptimizelyFactory.NewDefaultInstance("my-sdk-key", null, "access-token");
+            var optimizely =
+                OptimizelyFactory.NewDefaultInstance("my-sdk-key", null, "access-token");
 
             // Check values are loaded from app.config or not.
             var projectConfigManager = optimizely.ProjectConfigManager as HttpProjectConfigManager;
@@ -102,7 +105,7 @@ namespace OptimizelySDK.Tests
                 DatafileAccessToken = "access-token",
                 AutoUpdate = true,
                 BlockingTimeout = TimeSpan.FromSeconds(30),
-                PollingInterval = TimeSpan.FromMilliseconds(2023)
+                PollingInterval = TimeSpan.FromMilliseconds(2023),
             };
 
             Assert.AreEqual(actualConfigManagerProps, expectedConfigManagerProps);
@@ -111,7 +114,8 @@ namespace OptimizelySDK.Tests
         }
 
         [Test]
-        public void TestOptimizelyInstanceUsingConfigNotUseFactoryClassBlockingTimeoutAndPollingInterval()
+        public void
+            TestOptimizelyInstanceUsingConfigNotUseFactoryClassBlockingTimeoutAndPollingInterval()
         {
             OptimizelyFactory.SetBlockingTimeOutPeriod(TimeSpan.FromSeconds(30));
             OptimizelyFactory.SetPollingInterval(TimeSpan.FromMilliseconds(2023));
@@ -128,7 +132,7 @@ namespace OptimizelySDK.Tests
                 AutoUpdate = true,
                 DatafileAccessToken = "testingtoken123",
                 BlockingTimeout = TimeSpan.FromMilliseconds(10000),
-                PollingInterval = TimeSpan.FromMilliseconds(2000)
+                PollingInterval = TimeSpan.FromMilliseconds(2000),
             };
 
             Assert.AreEqual(actualConfigManagerProps, expectedConfigManagerProps);
@@ -138,18 +142,20 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestProjectConfigManagerWithCustomProjectConfigManager()
         {
-            var projectConfigManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("10192104166")
-                .WithFormat("https://optimizely.com/json/{0}.json")
-                .WithPollingInterval(TimeSpan.FromMilliseconds(3000))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(4500))
-                .WithStartByDefault()
-                .WithAccessToken("access-token")
-                .Build(true);
+            var projectConfigManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("10192104166").
+                WithFormat("https://optimizely.com/json/{0}.json").
+                WithPollingInterval(TimeSpan.FromMilliseconds(3000)).
+                WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(4500)).
+                WithStartByDefault().
+                WithAccessToken("access-token").
+                Build(true);
 
             var optimizely = OptimizelyFactory.NewDefaultInstance(projectConfigManager);
-            var actualProjectConfigManager = optimizely.ProjectConfigManager as HttpProjectConfigManager;
-            var actualConfigManagerProps = new ProjectConfigManagerProps(actualProjectConfigManager);
+            var actualProjectConfigManager =
+                optimizely.ProjectConfigManager as HttpProjectConfigManager;
+            var actualConfigManagerProps =
+                new ProjectConfigManagerProps(actualProjectConfigManager);
             var expectedConfigManagerProps = new ProjectConfigManagerProps(projectConfigManager);
             Assert.AreEqual(actualConfigManagerProps, expectedConfigManagerProps);
             optimizely.Dispose();
@@ -160,13 +166,15 @@ namespace OptimizelySDK.Tests
         {
             var optimizely = OptimizelyFactory.NewDefaultInstance();
 
-            var batchEventProcessor = Reflection.GetFieldValue<BatchEventProcessor, Optimizely>(optimizely, "EventProcessor");
+            var batchEventProcessor =
+                Reflection.GetFieldValue<BatchEventProcessor, Optimizely>(optimizely,
+                    "EventProcessor");
             var actualEventProcessorProps = new EventProcessorProps(batchEventProcessor);
             var expectedEventProcessorProps = new EventProcessorProps
             {
                 BatchSize = 10,
                 FlushInterval = TimeSpan.FromSeconds(2),
-                TimeoutInterval = TimeSpan.FromSeconds(10)
+                TimeoutInterval = TimeSpan.FromSeconds(10),
             };
             Assert.AreEqual(actualEventProcessorProps, expectedEventProcessorProps);
             optimizely.Dispose();
@@ -180,13 +188,15 @@ namespace OptimizelySDK.Tests
 
             var optimizely = OptimizelyFactory.NewDefaultInstance("sdk-Key");
 
-            var batchEventProcessor = Reflection.GetFieldValue<BatchEventProcessor, Optimizely>(optimizely, "EventProcessor");
+            var batchEventProcessor =
+                Reflection.GetFieldValue<BatchEventProcessor, Optimizely>(optimizely,
+                    "EventProcessor");
             var actualEventProcessorProps = new EventProcessorProps(batchEventProcessor);
             var expectedEventProcessorProps = new EventProcessorProps
             {
                 BatchSize = 2,
                 FlushInterval = TimeSpan.FromSeconds(4),
-                TimeoutInterval = TimeSpan.FromMinutes(5)
+                TimeoutInterval = TimeSpan.FromMinutes(5),
             };
             Assert.AreEqual(actualEventProcessorProps, expectedEventProcessorProps);
             optimizely.Dispose();
@@ -197,21 +207,24 @@ namespace OptimizelySDK.Tests
         {
             var eventDispatcher = new DefaultEventDispatcher(LoggerMock.Object);
             var notificationCenter = new NotificationCenter();
-            var projectConfigManager = new HttpProjectConfigManager.Builder()
-                .WithSdkKey("10192104166")
-                .Build(true);
+            var projectConfigManager = new HttpProjectConfigManager.Builder().
+                WithSdkKey("10192104166").
+                Build(true);
 
-            var batchEventProcessor = new BatchEventProcessor.Builder()
-                .WithLogger(LoggerMock.Object)
-                .WithMaxBatchSize(20)
-                .WithFlushInterval(TimeSpan.FromSeconds(3))
-                .WithEventDispatcher(eventDispatcher)
-                .WithNotificationCenter(notificationCenter)
-                .Build();
+            var batchEventProcessor = new BatchEventProcessor.Builder().
+                WithLogger(LoggerMock.Object).
+                WithMaxBatchSize(20).
+                WithFlushInterval(TimeSpan.FromSeconds(3)).
+                WithEventDispatcher(eventDispatcher).
+                WithNotificationCenter(notificationCenter).
+                Build();
 
-            var optimizely = OptimizelyFactory.NewDefaultInstance(projectConfigManager, notificationCenter, eventProcessor: batchEventProcessor);
+            var optimizely = OptimizelyFactory.NewDefaultInstance(projectConfigManager,
+                notificationCenter, eventProcessor: batchEventProcessor);
 
-            var actualbatchEventProcessor = Reflection.GetFieldValue<BatchEventProcessor, Optimizely>(optimizely, "EventProcessor");
+            var actualbatchEventProcessor =
+                Reflection.GetFieldValue<BatchEventProcessor, Optimizely>(optimizely,
+                    "EventProcessor");
             var actualEventProcessorProps = new EventProcessorProps(actualbatchEventProcessor);
             var expectedEventProcessorProps = new EventProcessorProps(batchEventProcessor);
             Assert.AreEqual(actualEventProcessorProps, expectedEventProcessorProps);
@@ -222,11 +235,13 @@ namespace OptimizelySDK.Tests
         public void TestGetFeatureVariableJSONEmptyDatafileTest()
         {
             var httpClientMock = new Mock<HttpProjectConfigManager.HttpClient>();
-            var task = TestHttpProjectConfigManagerUtil.MockSendAsync(httpClientMock, TestData.EmptyDatafile, TimeSpan.Zero, System.Net.HttpStatusCode.OK);
+            var task = TestHttpProjectConfigManagerUtil.MockSendAsync(httpClientMock,
+                TestData.EmptyDatafile, TimeSpan.Zero, System.Net.HttpStatusCode.OK);
             TestHttpProjectConfigManagerUtil.SetClientFieldValue(httpClientMock.Object);
 
             var optimizely = OptimizelyFactory.NewDefaultInstance("sdk-key");
-            Assert.Null(optimizely.GetFeatureVariableJSON("no-feature-variable", "no-variable-key", "userId"));
+            Assert.Null(optimizely.GetFeatureVariableJSON("no-feature-variable", "no-variable-key",
+                "userId"));
             optimizely.Dispose();
         }
     }

--- a/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyFactoryTest.cs
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+using System;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.Config;
@@ -25,7 +26,6 @@ using OptimizelySDK.Notifications;
 using OptimizelySDK.Tests.ConfigTest;
 using OptimizelySDK.Tests.EventTest;
 using OptimizelySDK.Tests.Utils;
-using System;
 
 namespace OptimizelySDK.Tests
 {

--- a/OptimizelySDK.Tests/OptimizelyJSONTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyJSONTest.cs
@@ -15,13 +15,13 @@
  *    limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Exceptions;
 using OptimizelySDK.Logger;
-using System;
-using System.Collections.Generic;
 
 namespace OptimizelySDK.Tests
 {

--- a/OptimizelySDK.Tests/OptimizelyJSONTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyJSONTest.cs
@@ -25,29 +25,30 @@ using System.Collections.Generic;
 
 namespace OptimizelySDK.Tests
 {
-    class ParentJson
+    internal class ParentJson
     {
         public string strField { get; set; }
         public int intField { get; set; }
         public double doubleField { get; set; }
         public bool boolField { get; set; }
         public ObjectJson objectField { get; set; }
-        
     }
-    class ObjectJson
+
+    internal class ObjectJson
     {
         public int inner_field_int { get; set; }
         public double inner_field_double { get; set; }
-        public string inner_field_string {get;set;}
+        public string inner_field_string { get; set; }
         public bool inner_field_boolean { get; set; }
     }
 
-    class Field4
+    internal class Field4
     {
         public long inner_field1 { get; set; }
         public InnerField2 inner_field2 { get; set; }
     }
-    class InnerField2 : List<object> { }
+
+    internal class InnerField2 : List<object> { }
 
 
     [TestFixture]
@@ -67,88 +68,114 @@ namespace OptimizelySDK.Tests
             LoggerMock = new Mock<ILogger>();
             LoggerMock.Setup(i => i.Log(It.IsAny<LogLevel>(), It.IsAny<string>()));
 
-            Payload = "{ \"field1\": 1, \"field2\": 2.5, \"field3\": \"three\", \"field4\": {\"inner_field1\":3,\"inner_field2\":[\"1\",\"2\", 3, 4.23, true]}, \"field5\": true, }";
-            Map = new Dictionary<string, object>() {
+            Payload =
+                "{ \"field1\": 1, \"field2\": 2.5, \"field3\": \"three\", \"field4\": {\"inner_field1\":3,\"inner_field2\":[\"1\",\"2\", 3, 4.23, true]}, \"field5\": true, }";
+            Map = new Dictionary<string, object>()
+            {
                 { "strField", "john doe" },
                 { "intField", 12 },
                 { "doubleField", 2.23 },
-                { "boolField", true},
-                { "objectField", new Dictionary<string, object> () {
+                { "boolField", true },
+                {
+                    "objectField", new Dictionary<string, object>()
+                    {
                         { "inner_field_int", 3 },
                         { "inner_field_double", 13.21 },
                         { "inner_field_string", "john" },
-                        { "inner_field_boolean", true }
+                        { "inner_field_boolean", true },
                     }
-                }
+                },
             };
         }
 
         [Test]
         public void TestOptimizelyJsonObjectIsValid()
         {
-            var optimizelyJSONUsingMap = new OptimizelyJSON(Map, ErrorHandlerMock.Object, LoggerMock.Object);
-            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingMap =
+                new OptimizelyJSON(Map, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString =
+                new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
 
             Assert.IsNotNull(optimizelyJSONUsingMap);
             Assert.IsNotNull(optimizelyJSONUsingString);
         }
+
         [Test]
         public void TestToStringReturnValidString()
         {
-            var map = new Dictionary<string, object>() {
+            var map = new Dictionary<string, object>()
+            {
                 { "strField", "john doe" },
                 { "intField", 12 },
-                { "objectField", new Dictionary<string, object> () {
-                        { "inner_field_int", 3 }
+                {
+                    "objectField", new Dictionary<string, object>()
+                    {
+                        { "inner_field_int", 3 },
                     }
-                }
+                },
             };
-            var optimizelyJSONUsingMap = new OptimizelyJSON(map, ErrorHandlerMock.Object, LoggerMock.Object);
-            string str = optimizelyJSONUsingMap.ToString();
-            string expectedStringObj = "{\"strField\":\"john doe\",\"intField\":12,\"objectField\":{\"inner_field_int\":3}}";
+            var optimizelyJSONUsingMap =
+                new OptimizelyJSON(map, ErrorHandlerMock.Object, LoggerMock.Object);
+            var str = optimizelyJSONUsingMap.ToString();
+            var expectedStringObj =
+                "{\"strField\":\"john doe\",\"intField\":12,\"objectField\":{\"inner_field_int\":3}}";
             Assert.AreEqual(expectedStringObj, str);
         }
 
         [Test]
         public void TestGettingErrorUponInvalidJsonString()
         {
-            var optimizelyJSONUsingString = new OptimizelyJSON("{\"invalid\":}", ErrorHandlerMock.Object, LoggerMock.Object);
-            LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Provided string could not be converted to map."), Times.Once);
-            ErrorHandlerMock.Verify(er => er.HandleError(It.IsAny<InvalidJsonException>()), Times.Once);
+            var optimizelyJSONUsingString = new OptimizelyJSON("{\"invalid\":}",
+                ErrorHandlerMock.Object, LoggerMock.Object);
+            LoggerMock.Verify(
+                log => log.Log(LogLevel.ERROR, "Provided string could not be converted to map."),
+                Times.Once);
+            ErrorHandlerMock.Verify(er => er.HandleError(It.IsAny<InvalidJsonException>()),
+                Times.Once);
         }
 
         [Test]
         public void TestOptimizelyJsonGetVariablesWhenSetUsingMap()
         {
-            var optimizelyJSONUsingMap = new OptimizelyJSON(Map, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingMap =
+                new OptimizelyJSON(Map, ErrorHandlerMock.Object, LoggerMock.Object);
 
             Assert.AreEqual(optimizelyJSONUsingMap.GetValue<string>("strField"), "john doe");
             Assert.AreEqual(optimizelyJSONUsingMap.GetValue<int>("intField"), 12);
             Assert.AreEqual(optimizelyJSONUsingMap.GetValue<double>("doubleField"), 2.23);
             Assert.AreEqual(optimizelyJSONUsingMap.GetValue<bool>("boolField"), true);
             Assert.AreEqual(optimizelyJSONUsingMap.GetValue<int>("objectField.inner_field_int"), 3);
-            Assert.AreEqual(optimizelyJSONUsingMap.GetValue<double>("objectField.inner_field_double"), 13.21);
-            Assert.AreEqual(optimizelyJSONUsingMap.GetValue<string>("objectField.inner_field_string"), "john");
-            Assert.AreEqual(optimizelyJSONUsingMap.GetValue<bool>("objectField.inner_field_boolean"), true);
-            Assert.IsTrue(optimizelyJSONUsingMap.GetValue<Dictionary<string, object>>("objectField") is Dictionary<string, object>);
+            Assert.AreEqual(
+                optimizelyJSONUsingMap.GetValue<double>("objectField.inner_field_double"), 13.21);
+            Assert.AreEqual(
+                optimizelyJSONUsingMap.GetValue<string>("objectField.inner_field_string"), "john");
+            Assert.AreEqual(
+                optimizelyJSONUsingMap.GetValue<bool>("objectField.inner_field_boolean"), true);
+            Assert.IsTrue(
+                optimizelyJSONUsingMap.GetValue<Dictionary<string, object>>("objectField") is
+                    Dictionary<string, object>);
         }
 
         [Test]
         public void TestOptimizelyJsonGetVariablesWhenSetUsingString()
         {
-            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString =
+                new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
 
             Assert.AreEqual(optimizelyJSONUsingString.GetValue<long>("field1"), 1);
             Assert.AreEqual(optimizelyJSONUsingString.GetValue<double>("field2"), 2.5);
             Assert.AreEqual(optimizelyJSONUsingString.GetValue<string>("field3"), "three");
             Assert.AreEqual(optimizelyJSONUsingString.GetValue<long>("field4.inner_field1"), 3);
-            Assert.True(TestData.CompareObjects(optimizelyJSONUsingString.GetValue<List<object>>("field4.inner_field2"), new List<object>() { "1", "2", 3, 4.23, true }));
+            Assert.True(TestData.CompareObjects(
+                optimizelyJSONUsingString.GetValue<List<object>>("field4.inner_field2"),
+                new List<object>() { "1", "2", 3, 4.23, true }));
         }
 
         [Test]
         public void TestGetValueReturnsEntireDictWhenJsonPathIsEmptyAndTypeIsValid()
         {
-            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString =
+                new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var actualDict = optimizelyJSONUsingString.ToDictionary();
             var expectedValue = optimizelyJSONUsingString.GetValue<Dictionary<string, object>>("");
             Assert.NotNull(expectedValue);
@@ -159,8 +186,10 @@ namespace OptimizelySDK.Tests
         public void TestGetValueReturnsDefaultValueWhenJsonIsInvalid()
         {
             var payload = "{ \"field1\" : {1:\"Csharp\", 2:\"Java\"} }";
-            var optimizelyJSONUsingString = new OptimizelyJSON(payload, ErrorHandlerMock.Object, LoggerMock.Object);
-            var expectedValue = optimizelyJSONUsingString.GetValue<Dictionary<float, string>>("field1");
+            var optimizelyJSONUsingString =
+                new OptimizelyJSON(payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var expectedValue =
+                optimizelyJSONUsingString.GetValue<Dictionary<float, string>>("field1");
             // Even though above given JSON is not valid, newtonsoft is parsing it so
             Assert.IsNotNull(expectedValue);
         }
@@ -169,15 +198,18 @@ namespace OptimizelySDK.Tests
         public void TestGetValueReturnsDefaultValueWhenTypeIsInvalid()
         {
             var payload = "{ \"field1\" : {\"1\":\"Csharp\",\"2\":\"Java\"} }";
-            var optimizelyJSONUsingString = new OptimizelyJSON(payload, ErrorHandlerMock.Object, LoggerMock.Object);
-            var expectedValue = optimizelyJSONUsingString.GetValue<Dictionary<float, string>>("field1");
+            var optimizelyJSONUsingString =
+                new OptimizelyJSON(payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var expectedValue =
+                optimizelyJSONUsingString.GetValue<Dictionary<float, string>>("field1");
             Assert.IsNotNull(expectedValue);
         }
 
         [Test]
         public void TestGetValueReturnsNullWhenJsonPathIsEmptyAndTypeIsOfObject()
         {
-            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString =
+                new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<object>("");
             Assert.NotNull(expectedValue);
         }
@@ -185,47 +217,61 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetValueReturnsDefaultValueWhenJsonPathIsEmptyAndTypeIsNotValid()
         {
-            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString =
+                new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<string>("");
             Assert.IsNull(expectedValue);
-            LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Value for path could not be assigned to provided type."), Times.Once);
-            ErrorHandlerMock.Verify(er => er.HandleError(It.IsAny<OptimizelyRuntimeException>()), Times.Once);
+            LoggerMock.Verify(
+                log => log.Log(LogLevel.ERROR,
+                    "Value for path could not be assigned to provided type."), Times.Once);
+            ErrorHandlerMock.Verify(er => er.HandleError(It.IsAny<OptimizelyRuntimeException>()),
+                Times.Once);
         }
 
         [Test]
         public void TestGetValueReturnsDefaultValueWhenJsonPathIsInvalid()
         {
-            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString =
+                new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<string>("field11");
             Assert.IsNull(expectedValue);
-            LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Value for JSON key not found."), Times.Once);
-            ErrorHandlerMock.Verify(er => er.HandleError(It.IsAny<OptimizelyRuntimeException>()), Times.Once);
+            LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Value for JSON key not found."),
+                Times.Once);
+            ErrorHandlerMock.Verify(er => er.HandleError(It.IsAny<OptimizelyRuntimeException>()),
+                Times.Once);
         }
 
         [Test]
         public void TestGetValueReturnsDefaultValueWhenJsonPath1IsInvalid()
         {
-            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString =
+                new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<string>("field4.");
             Assert.IsNull(expectedValue);
-            LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Value for JSON key not found."), Times.Once);
-            ErrorHandlerMock.Verify(er => er.HandleError(It.IsAny<OptimizelyRuntimeException>()), Times.Once);
+            LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Value for JSON key not found."),
+                Times.Once);
+            ErrorHandlerMock.Verify(er => er.HandleError(It.IsAny<OptimizelyRuntimeException>()),
+                Times.Once);
         }
 
         [Test]
         public void TestGetValueReturnsDefaultValueWhenJsonPath2IsInvalid()
         {
-            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString =
+                new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<string>("field4..inner_field1");
             Assert.IsNull(expectedValue);
-            LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Value for JSON key not found."), Times.Once);
-            ErrorHandlerMock.Verify(er => er.HandleError(It.IsAny<OptimizelyRuntimeException>()), Times.Once);
-        } 
-        
+            LoggerMock.Verify(log => log.Log(LogLevel.ERROR, "Value for JSON key not found."),
+                Times.Once);
+            ErrorHandlerMock.Verify(er => er.HandleError(It.IsAny<OptimizelyRuntimeException>()),
+                Times.Once);
+        }
+
         [Test]
         public void TestGetValueObjectNotModifiedIfCalledTwice()
         {
-            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString =
+                new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<string>("field4.inner_field1");
             var expectedValue2 = optimizelyJSONUsingString.GetValue<string>("field4.inner_field1");
 
@@ -235,20 +281,23 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestGetValueReturnsUsingGivenClassType()
         {
-            var optimizelyJSONUsingString = new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJSONUsingString =
+                new OptimizelyJSON(Payload, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJSONUsingString.GetValue<Field4>("field4");
-            
+
             Assert.AreEqual(expectedValue.inner_field1, 3);
-            Assert.AreEqual(expectedValue.inner_field2, new List<object>() { "1", "2", 3, 4.23, true });
+            Assert.AreEqual(expectedValue.inner_field2,
+                new List<object>() { "1", "2", 3, 4.23, true });
         }
 
         [Test]
         public void TestGetValueReturnsCastedObject()
         {
-            var optimizelyJson = new OptimizelyJSON(Map, ErrorHandlerMock.Object, LoggerMock.Object);
+            var optimizelyJson =
+                new OptimizelyJSON(Map, ErrorHandlerMock.Object, LoggerMock.Object);
             var expectedValue = optimizelyJson.ToDictionary();
             var actualValue = optimizelyJson.GetValue<ParentJson>(null);
-            
+
             Assert.IsTrue(TestData.CompareObjects(actualValue, expectedValue));
         }
     }

--- a/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
+++ b/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
@@ -14,7 +14,7 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <!--ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids-->
-    <TargetFrameworkProfile />
+    <TargetFrameworkProfile/>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <ReleaseVersion>1.2.1</ReleaseVersion>
@@ -41,7 +41,7 @@
       <HintPath>..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="Microsoft.CSharp"/>
     <Reference Include="Moq, Version=4.7.1.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\packages\Moq.4.7.1\lib\net45\Moq.dll</HintPath>
       <Private>True</Private>
@@ -54,97 +54,97 @@
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.ComponentModel.DataAnnotations" />
-    <Reference Include="System.Configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Web" />
-    <Reference Include="System.Web.ApplicationServices" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Web.Abstractions" />
-    <Reference Include="System.Web.Routing" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System"/>
+    <Reference Include="System.ComponentModel.DataAnnotations"/>
+    <Reference Include="System.Configuration"/>
+    <Reference Include="System.Core"/>
+    <Reference Include="System.Data"/>
+    <Reference Include="System.Web"/>
+    <Reference Include="System.Web.ApplicationServices"/>
+    <Reference Include="System.Web.Extensions"/>
+    <Reference Include="System.Web.Abstractions"/>
+    <Reference Include="System.Web.Routing"/>
+    <Reference Include="System.Xml"/>
+    <Reference Include="System.Xml.Linq"/>
+    <Reference Include="System.Net.Http"/>
+    <Reference Include="System.Net.Http.WebRequest"/>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Assertions.cs" />
-    <Compile Include="AudienceConditionsTests\ConditionEvaluationTest.cs" />
-    <Compile Include="AudienceConditionsTests\ConditionsTest.cs" />
-    <Compile Include="AudienceConditionsTests\SegmentsTests.cs" />
-    <Compile Include="ConfigTest\HttpProjectConfigManagerTest.cs" />
-    <Compile Include="ConfigTest\PollingProjectConfigManagerTest.cs" />
-    <Compile Include="ConfigTest\FallbackProjectConfigManagerTest.cs" />
-    <Compile Include="DecisionServiceTest.cs" />
-    <Compile Include="DefaultErrorHandlerTest.cs" />
-    <Compile Include="EntityTests\IntegrationTest.cs" />
-    <Compile Include="EventTests\EventProcessorProps.cs" />
-    <Compile Include="OdpTests\OdpConfigTest.cs" />
-    <Compile Include="OdpTests\OdpManagerTest.cs" />
-    <Compile Include="OdpTests\OdpSegmentApiManagerTest.cs" />
-    <Compile Include="OdpTests\HttpClientTestUtil.cs" />
-    <Compile Include="OdpTests\LruCacheTest.cs" />
-    <Compile Include="OdpTests\OdpEventManagerTests.cs" />
-    <Compile Include="OdpTests\OdpEventApiManagerTest.cs" />
-    <Compile Include="OdpTests\OdpSegmentManagerTest.cs" />
-    <Compile Include="OptimizelyConfigTests\OptimizelyConfigTest.cs" />
-    <Compile Include="OptimizelyDecisions\OptimizelyDecisionTest.cs" />
-    <Compile Include="OptimizelyJSONTest.cs" />
-    <Compile Include="EventTests\BatchEventProcessorTest.cs" />
-    <Compile Include="EventTests\DefaultEventDispatcherTest.cs" />
-    <Compile Include="EventTests\EventBuilderTest.cs" />
-    <Compile Include="EventTests\ForwardingEventProcessorTest.cs" />
-    <Compile Include="EventTests\LogEventTest.cs" />
-    <Compile Include="EventTests\TestEventDispatcher.cs" />
-    <Compile Include="EventTests\TestForwardingEventDispatcher.cs" />
-    <Compile Include="InvalidEventDispatcher.cs" />
-    <Compile Include="NotificationTests\NotificationCenterTests.cs" />
-    <Compile Include="ClientConfigHandlerTest.cs" />
-    <Compile Include="OptimizelyTest.cs" />
-    <Compile Include="ForcedDecisionsStoreTest.cs" />
-    <Compile Include="OptimizelyUserContextTest.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="TestBucketer.cs" />
-    <Compile Include="BucketerTest.cs" />
-    <Compile Include="ProjectConfigTest.cs" />
-    <Compile Include="TestSetup.cs" />
-    <Compile Include="UtilsTests\ConditionParserTest.cs" />
-    <Compile Include="UtilsTests\EventTagUtilsTest.cs" />
-    <Compile Include="UtilsTests\ExceptionExtensionsTest.cs" />
-    <Compile Include="UtilsTests\ExperimentUtilsTest.cs" />
-    <Compile Include="UtilsTests\PrivateObject.cs" />
-    <Compile Include="UtilsTests\ValidatorTest.cs" />
-    <Compile Include="Utils\TestConversionExtensions.cs" />
-    <Compile Include="ValidEventDispatcher.cs" />
-    <Compile Include="ConfigTest\TestPollingProjectConfigManager.cs" />
-    <Compile Include="EntityTests\FeatureVariableTest.cs" />
-    <Compile Include="EventTests\EventEntitiesTest.cs" />
-    <Compile Include="EventTests\UserEventFactoryTest.cs" />
-    <Compile Include="EventTests\EventFactoryTest.cs" />
-    <Compile Include="EventTests\CanonicalEvent.cs" />
-    <Compile Include="OptimizelyFactoryTest.cs" />
-    <Compile Include="Utils\TestData.cs" />
-    <Compile Include="Utils\Reflection.cs" />
-    <Compile Include="ConfigTest\ProjectConfigProps.cs" />
-    <Compile Include="Utils\TestHttpProjectConfigManagerUtil.cs" />
+    <Compile Include="Assertions.cs"/>
+    <Compile Include="AudienceConditionsTests\ConditionEvaluationTest.cs"/>
+    <Compile Include="AudienceConditionsTests\ConditionsTest.cs"/>
+    <Compile Include="AudienceConditionsTests\SegmentsTests.cs"/>
+    <Compile Include="ConfigTest\HttpProjectConfigManagerTest.cs"/>
+    <Compile Include="ConfigTest\PollingProjectConfigManagerTest.cs"/>
+    <Compile Include="ConfigTest\FallbackProjectConfigManagerTest.cs"/>
+    <Compile Include="DecisionServiceTest.cs"/>
+    <Compile Include="DefaultErrorHandlerTest.cs"/>
+    <Compile Include="EntityTests\IntegrationTest.cs"/>
+    <Compile Include="EventTests\EventProcessorProps.cs"/>
+    <Compile Include="OdpTests\OdpConfigTest.cs"/>
+    <Compile Include="OdpTests\OdpManagerTest.cs"/>
+    <Compile Include="OdpTests\OdpSegmentApiManagerTest.cs"/>
+    <Compile Include="OdpTests\HttpClientTestUtil.cs"/>
+    <Compile Include="OdpTests\LruCacheTest.cs"/>
+    <Compile Include="OdpTests\OdpEventManagerTests.cs"/>
+    <Compile Include="OdpTests\OdpEventApiManagerTest.cs"/>
+    <Compile Include="OdpTests\OdpSegmentManagerTest.cs"/>
+    <Compile Include="OptimizelyConfigTests\OptimizelyConfigTest.cs"/>
+    <Compile Include="OptimizelyDecisions\OptimizelyDecisionTest.cs"/>
+    <Compile Include="OptimizelyJSONTest.cs"/>
+    <Compile Include="EventTests\BatchEventProcessorTest.cs"/>
+    <Compile Include="EventTests\DefaultEventDispatcherTest.cs"/>
+    <Compile Include="EventTests\EventBuilderTest.cs"/>
+    <Compile Include="EventTests\ForwardingEventProcessorTest.cs"/>
+    <Compile Include="EventTests\LogEventTest.cs"/>
+    <Compile Include="EventTests\TestEventDispatcher.cs"/>
+    <Compile Include="EventTests\TestForwardingEventDispatcher.cs"/>
+    <Compile Include="InvalidEventDispatcher.cs"/>
+    <Compile Include="NotificationTests\NotificationCenterTests.cs"/>
+    <Compile Include="ClientConfigHandlerTest.cs"/>
+    <Compile Include="OptimizelyTest.cs"/>
+    <Compile Include="ForcedDecisionsStoreTest.cs"/>
+    <Compile Include="OptimizelyUserContextTest.cs"/>
+    <Compile Include="Properties\AssemblyInfo.cs"/>
+    <Compile Include="TestBucketer.cs"/>
+    <Compile Include="BucketerTest.cs"/>
+    <Compile Include="ProjectConfigTest.cs"/>
+    <Compile Include="TestSetup.cs"/>
+    <Compile Include="UtilsTests\ConditionParserTest.cs"/>
+    <Compile Include="UtilsTests\EventTagUtilsTest.cs"/>
+    <Compile Include="UtilsTests\ExceptionExtensionsTest.cs"/>
+    <Compile Include="UtilsTests\ExperimentUtilsTest.cs"/>
+    <Compile Include="UtilsTests\PrivateObject.cs"/>
+    <Compile Include="UtilsTests\ValidatorTest.cs"/>
+    <Compile Include="Utils\TestConversionExtensions.cs"/>
+    <Compile Include="ValidEventDispatcher.cs"/>
+    <Compile Include="ConfigTest\TestPollingProjectConfigManager.cs"/>
+    <Compile Include="EntityTests\FeatureVariableTest.cs"/>
+    <Compile Include="EventTests\EventEntitiesTest.cs"/>
+    <Compile Include="EventTests\UserEventFactoryTest.cs"/>
+    <Compile Include="EventTests\EventFactoryTest.cs"/>
+    <Compile Include="EventTests\CanonicalEvent.cs"/>
+    <Compile Include="OptimizelyFactoryTest.cs"/>
+    <Compile Include="Utils\TestData.cs"/>
+    <Compile Include="Utils\Reflection.cs"/>
+    <Compile Include="ConfigTest\ProjectConfigProps.cs"/>
+    <Compile Include="Utils\TestHttpProjectConfigManagerUtil.cs"/>
   </ItemGroup>
   <ItemGroup>
-    <Content Include="App.config" />
-    <EmbeddedResource Include="OdpSegmentsDatafile.json" />
+    <Content Include="App.config"/>
+    <EmbeddedResource Include="OdpSegmentsDatafile.json"/>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="IntegrationEmptyDatafile.json" />
-    <EmbeddedResource Include="IntegrationNonOdpDatafile.json" />
-    <EmbeddedResource Include="IntegrationOdpDatafile.json" />
-    <EmbeddedResource Include="IntegrationOdpWithOtherFieldsDatafile.json" />
-    <EmbeddedResource Include="TestData.json" />
-    <EmbeddedResource Include="simple_ab_experiments.json" />
-    <EmbeddedResource Include="EmptyRolloutRule.json" />
-    <EmbeddedResource Include="emptydatafile.json" />
-    <EmbeddedResource Include="similar_exp_keys.json" />
-    <EmbeddedResource Include="similar_rule_keys_bucketing.json" />
+    <EmbeddedResource Include="IntegrationEmptyDatafile.json"/>
+    <EmbeddedResource Include="IntegrationNonOdpDatafile.json"/>
+    <EmbeddedResource Include="IntegrationOdpDatafile.json"/>
+    <EmbeddedResource Include="IntegrationOdpWithOtherFieldsDatafile.json"/>
+    <EmbeddedResource Include="TestData.json"/>
+    <EmbeddedResource Include="simple_ab_experiments.json"/>
+    <EmbeddedResource Include="EmptyRolloutRule.json"/>
+    <EmbeddedResource Include="emptydatafile.json"/>
+    <EmbeddedResource Include="similar_exp_keys.json"/>
+    <EmbeddedResource Include="similar_rule_keys_bucketing.json"/>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\OptimizelySDK\OptimizelySDK.csproj">
@@ -156,14 +156,14 @@
     <None Include="..\keypair.snk">
       <Link>keypair.snk</Link>
     </None>
-    <None Include="packages.config" />
-    <EmbeddedResource Include="unsupported_version_datafile.json" />
-    <EmbeddedResource Include="typed_audience_datafile.json" />
+    <None Include="packages.config"/>
+    <EmbeddedResource Include="unsupported_version_datafile.json"/>
+    <EmbeddedResource Include="typed_audience_datafile.json"/>
   </ItemGroup>
   <ItemGroup>
-    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}"/>
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets"/>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -83,9 +83,9 @@ namespace OptimizelySDK.Tests
             EventProcessorMock.Setup(b => b.Process(It.IsAny<UserEvent>()));
             DecisionReasons = new DecisionReasons();
             var config = DatafileProjectConfig.Create(
-                content: TestData.Datafile,
-                logger: LoggerMock.Object,
-                errorHandler: new NoOpErrorHandler());
+                TestData.Datafile,
+                LoggerMock.Object,
+                new NoOpErrorHandler());
             ConfigManager = new FallbackProjectConfigManager(config);
             Config = ConfigManager.GetConfig();
             EventDispatcherMock = new Mock<IEventDispatcher>();
@@ -106,7 +106,7 @@ namespace OptimizelySDK.Tests
             OptimizelyMock = new Mock<Optimizely>(TestData.Datafile, EventDispatcherMock.Object,
                 LoggerMock.Object, ErrorHandlerMock.Object, null, false, null, null, null)
             {
-                CallBase = true
+                CallBase = true,
             };
 
             DecisionServiceMock = new Mock<DecisionService>(new Bucketer(LoggerMock.Object),
@@ -137,7 +137,7 @@ namespace OptimizelySDK.Tests
             private static Type[] ParameterTypes =
             {
                 typeof(string), typeof(IEventDispatcher), typeof(ILogger), typeof(IErrorHandler),
-                typeof(bool), typeof(EventProcessor)
+                typeof(bool), typeof(EventProcessor),
             };
 
             public static Dictionary<string, object> SingleParameter =
@@ -145,7 +145,7 @@ namespace OptimizelySDK.Tests
                 {
                     {
                         "param1", "val1"
-                    }
+                    },
                 };
 
             public static UserAttributes UserAttributes = new UserAttributes
@@ -158,7 +158,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             // NullUserAttributes extends copy of UserAttributes with key-value
@@ -182,7 +182,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "bad_food", null
-                }
+                },
             };
 
             public string Datafile { get; set; }
@@ -222,7 +222,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
             var optlyUserContext = Optimizely.CreateUserContext(TestUserId, attribute);
             Assert.AreEqual(TestUserId, optlyUserContext.GetUserId());
@@ -249,7 +249,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
             var optlyUserContext1 = Optimizely.CreateUserContext("userId1", attribute1);
 
@@ -260,7 +260,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location2", "California"
-                }
+                },
             };
             var optlyUserContext2 = Optimizely.CreateUserContext("userId2", attribute2);
 
@@ -285,7 +285,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
             Config.SendFlagDecisions = false;
             var fallbackConfigManager = new FallbackProjectConfigManager(Config);
@@ -334,7 +334,7 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "decisionEventDispatched", true
-                        }
+                        },
                     }))), Times.Once);
             EventDispatcherMock.Verify(dispatcher => dispatcher.DispatchEvent(It.IsAny<LogEvent>()),
                 Times.Once);
@@ -352,7 +352,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
             var fallbackConfigManager = new FallbackProjectConfigManager(Config);
             var optimizely = new Optimizely(fallbackConfigManager,
@@ -400,7 +400,7 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "decisionEventDispatched", true
-                        }
+                        },
                     }))), Times.Once);
             EventDispatcherMock.Verify(dispatcher => dispatcher.DispatchEvent(It.IsAny<LogEvent>()),
                 Times.Once);
@@ -419,7 +419,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
             var experiment = Config.GetRolloutFromId("166660").Experiments[1];
             var ruleKey = experiment.Key;
@@ -471,7 +471,7 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "decisionEventDispatched", false
-                        }
+                        },
                     }))), Times.Once);
             EventDispatcherMock.Verify(dispatcher => dispatcher.DispatchEvent(It.IsAny<LogEvent>()),
                 Times.Never);
@@ -490,7 +490,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
             var experiment = Config.GetRolloutFromId("166660").Experiments[1];
             var ruleKey = experiment.Key;
@@ -542,7 +542,7 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "decisionEventDispatched", true
-                        }
+                        },
                     }))), Times.Once);
             EventDispatcherMock.Verify(dispatcher => dispatcher.DispatchEvent(It.IsAny<LogEvent>()),
                 Times.Once);
@@ -559,7 +559,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
             var optlyUserContext = Optimizely.CreateUserContext(userId, attribute);
             Assert.AreEqual(TestUserId, optlyUserContext.GetUserId());
@@ -576,7 +576,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
             Assert.AreEqual("testUserId", optlyUserContext.GetUserId());
             Assert.AreEqual(Optimizely, optlyUserContext.GetOptimizely());
@@ -590,7 +590,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestInvalidInstanceLogMessages()
         {
-            string datafile = "{\"name\":\"optimizely\"}";
+            var datafile = "{\"name\":\"optimizely\"}";
             var optimizely = new Optimizely(datafile, null, LoggerMock.Object);
 
             Assert.IsNull(optimizely.GetVariation(string.Empty, string.Empty));
@@ -651,16 +651,16 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestValidateInputsInvalidFileJsonValidationNotSkipped()
         {
-            string datafile = "{\"name\":\"optimizely\"}";
-            Optimizely optimizely = new Optimizely(datafile);
+            var datafile = "{\"name\":\"optimizely\"}";
+            var optimizely = new Optimizely(datafile);
             Assert.IsFalse(optimizely.IsValid);
         }
 
         [Test]
         public void TestValidateInputsInvalidFileJsonValidationSkipped()
         {
-            string datafile = "{\"name\":\"optimizely\"}";
-            Optimizely optimizely =
+            var datafile = "{\"name\":\"optimizely\"}";
+            var optimizely =
                 new Optimizely(datafile, null, null, null, skipJsonValidation: true);
             Assert.IsFalse(optimizely.IsValid);
         }
@@ -715,7 +715,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             var variation = Optimizely.GetVariation("test_experiment", "test_user", attributes);
@@ -797,7 +797,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "param2", "val2"
-                }
+                },
             };
 
             var optly = Helper.CreatePrivateOptimizely();
@@ -948,7 +948,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "double_key", 3.14
-                }
+                },
             };
 
             var optly = Helper.CreatePrivateOptimizely();
@@ -1015,7 +1015,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             var variation = Optimizely.GetVariation("test_experiment", "test_user", attributes);
@@ -1078,7 +1078,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "abc", "43"
-                }
+                },
             };
 
             Optimizely.Track("purchase", TestUserId, attributes);
@@ -1140,7 +1140,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "revenue", 42
-                }
+                },
             });
             EventProcessorMock.Verify(ep => ep.Process(It.IsAny<ConversionEvent>()), Times.Once);
 
@@ -1169,7 +1169,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "revenue", 42
-                }
+                },
             });
 
             EventProcessorMock.Verify(ep => ep.Process(It.IsAny<ConversionEvent>()), Times.Once);
@@ -1193,7 +1193,7 @@ namespace OptimizelySDK.Tests
                     },
                     {
                         "wont_send_null", null
-                    }
+                    },
                 });
 
             EventProcessorMock.Verify(ep => ep.Process(It.IsAny<ConversionEvent>()), Times.Once);
@@ -1233,7 +1233,9 @@ namespace OptimizelySDK.Tests
                 l => l.Log(LogLevel.INFO,
                     "Activating user test_user in experiment test_experiment."), Times.Once);
             // Need to see how error handler can be verified.
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Attribute key \"company\" is not in datafile."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.ERROR, "Attribute key \"company\" is not in datafile."),
+                Times.Once);
 
             Assert.IsTrue(TestData.CompareObjects(VariationWithKeyControl, variation));
         }
@@ -1269,7 +1271,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "revenue", 4200
-                }
+                },
             });
         }
 
@@ -1284,7 +1286,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "revenue", 42
-                }
+                },
             });
         }
 
@@ -1295,8 +1297,8 @@ namespace OptimizelySDK.Tests
                 LoggerMock.Object, ErrorHandlerMock.Object);
             var projectConfig = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object,
                 ErrorHandlerMock.Object);
-            Variation expectedVariation1 = projectConfig.GetVariationFromKey("etag3", "vtag5");
-            Variation expectedVariation2 = projectConfig.GetVariationFromKey("etag3", "vtag6");
+            var expectedVariation1 = projectConfig.GetVariationFromKey("etag3", "vtag5");
+            var expectedVariation2 = projectConfig.GetVariationFromKey("etag3", "vtag6");
 
             //Check whitelisted experiment
             var variation = optimizely.GetVariation("etag3", "testUser1");
@@ -1348,12 +1350,12 @@ namespace OptimizelySDK.Tests
             var variationKey = "vtag2";
             var fbVariationKey = "vtag1";
 
-            UserProfile userProfile = new UserProfile(userId,
+            var userProfile = new UserProfile(userId,
                 new Dictionary<string, Bucketing.Decision>
                 {
                     {
                         experimentKey, new Bucketing.Decision(variationKey)
-                    }
+                    },
                 });
 
             userProfileServiceMock.Setup(_ => _.Lookup(userId)).Returns(userProfile.ToMap());
@@ -1362,9 +1364,9 @@ namespace OptimizelySDK.Tests
                 LoggerMock.Object, ErrorHandlerMock.Object, userProfileServiceMock.Object);
             var projectConfig = DatafileProjectConfig.Create(TestData.Datafile, LoggerMock.Object,
                 ErrorHandlerMock.Object);
-            Variation expectedFbVariation =
+            var expectedFbVariation =
                 projectConfig.GetVariationFromKey(experimentKey, fbVariationKey);
-            Variation expectedVariation =
+            var expectedVariation =
                 projectConfig.GetVariationFromKey(experimentKey, variationKey);
 
             var variationUserProfile = optimizely.GetVariation(experimentKey, userId);
@@ -1435,7 +1437,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             Optimizely.Activate(experimentKey, TestUserId, userAttributes);
@@ -1476,7 +1478,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             Optimizely.Activate(experimentKey, TestUserId, userAttributes);
@@ -1556,12 +1558,12 @@ namespace OptimizelySDK.Tests
             var expectedForcedVariation = new Variation
             {
                 Key = "variation",
-                Id = "7721010009"
+                Id = "7721010009",
             };
             var expectedForcedVariation2 = new Variation
             {
                 Key = "variation",
-                Id = "7721010509"
+                Id = "7721010509",
             };
             var userAttributes = new UserAttributes
             {
@@ -1570,7 +1572,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             Optimizely.Activate(experimentKey, TestUserId, userAttributes);
@@ -1648,7 +1650,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             Assert.True(Optimizely.SetForcedVariation(experimentKey, userId, variationKey),
@@ -1683,7 +1685,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             Assert.True(Optimizely.SetForcedVariation(experimentKey, userId, variationKey),
@@ -1740,10 +1742,10 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "param2", "val2"
-                }
+                },
             };
 
-            Experiment experiment = new Experiment();
+            var experiment = new Experiment();
             experiment.Key = "group_experiment_1";
 
             var optly = Helper.CreatePrivateOptimizely();
@@ -1808,7 +1810,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "param1", "val1"
-                }
+                },
             };
 
             var optly = Helper.CreatePrivateOptimizely();
@@ -1852,7 +1854,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             var userAttributesWithBucketingId = new UserAttributes
@@ -1868,7 +1870,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     ControlAttributes.BUCKETING_ID_ATTRIBUTE, testBucketingIdVariation
-                }
+                },
             };
 
             // confirm that a valid variation is bucketed without the bucketing ID
@@ -2040,7 +2042,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "boolean_key", false
-                }
+                },
             };
 
             SetCulture("en-US");
@@ -2239,25 +2241,25 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "string", "Test String"
-                }
+                },
             };
             var expectedIntegerDict = new Dictionary<string, object>()
             {
                 {
                     "integer", 123
-                }
+                },
             };
             var expectedDoubleDict = new Dictionary<string, object>()
             {
                 {
                     "double", 123.28
-                }
+                },
             };
             var expectedBooleanDict = new Dictionary<string, object>()
             {
                 {
                     "boolean", true
-                }
+                },
             };
 
             OptimizelyMock.Setup(om => om.GetFeatureVariableValueForType<OptimizelyJSON>(
@@ -2383,7 +2385,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             DecisionServiceMock.
@@ -2463,7 +2465,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             DecisionServiceMock.
@@ -2541,7 +2543,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             DecisionServiceMock.
@@ -2589,7 +2591,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             DecisionServiceMock.
@@ -2636,7 +2638,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             DecisionServiceMock.
@@ -2713,7 +2715,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             DecisionServiceMock.
@@ -2913,7 +2915,7 @@ namespace OptimizelySDK.Tests
             var variableValue = (double?)optly.InvokeGeneric("GetFeatureVariableValueForType",
                 new Type[]
                 {
-                    typeof(double?)
+                    typeof(double?),
                 }, featureKey, variableKey, TestUserId, null, variableType);
             Assert.AreEqual(expectedValue, variableValue);
 
@@ -2955,7 +2957,7 @@ namespace OptimizelySDK.Tests
             var variableValue = (double?)optly.InvokeGeneric("GetFeatureVariableValueForType",
                 new Type[]
                 {
-                    typeof(double?)
+                    typeof(double?),
                 }, featureKey, variableKey, TestUserId, null, variableType);
             Assert.AreEqual(expectedValue, variableValue);
 
@@ -2996,7 +2998,7 @@ namespace OptimizelySDK.Tests
             var variableValue = (double?)optly.InvokeGeneric("GetFeatureVariableValueForType",
                 new Type[]
                 {
-                    typeof(double?)
+                    typeof(double?),
                 }, featureKey, variableKey, TestUserId, null, variableType);
             Assert.AreEqual(expectedValue, variableValue);
 
@@ -3089,7 +3091,7 @@ namespace OptimizelySDK.Tests
             // Set such an experiment to the list of experiment ids, that does not belong to the feature.
             featureFlag.ExperimentIds = new List<string>
             {
-                "4209211"
+                "4209211",
             };
 
             // Should return false when the experiment in feature flag does not get found in the datafile.
@@ -3123,7 +3125,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
             optly.SetFieldOrProperty("ProjectConfigManager", ConfigManager);
 
-            bool result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
+            var result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
             Assert.False(result);
 
             LoggerMock.Verify(l => l.Log(LogLevel.INFO,
@@ -3154,7 +3156,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
             optly.SetFieldOrProperty("ProjectConfigManager", ConfigManager);
 
-            bool result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
+            var result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
             Assert.True(result);
 
             // SendImpressionEvent() does not get called.
@@ -3189,7 +3191,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
             optly.SetFieldOrProperty("ProjectConfigManager", ConfigManager);
 
-            bool result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
+            var result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
             Assert.True(result);
 
             // SendImpressionEvent() gets called.
@@ -3225,7 +3227,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
             optly.SetFieldOrProperty("ProjectConfigManager", ConfigManager);
 
-            bool result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
+            var result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
             Assert.False(result);
 
             // SendImpressionEvent() gets called.
@@ -3252,7 +3254,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "company", "Optimizely"
-                }
+                },
             };
 
             Assert.True(Optimizely.IsFeatureEnabled(featureKey, TestUserId, userAttributes));
@@ -3320,7 +3322,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
 
             // Verify that IsFeatureEnabled returns true when feature experiment variation's 'featureEnabled' property is true.
-            bool result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
+            var result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
             Assert.True(result);
 
             // Verify that IsFeatureEnabled returns false when feature experiment variation's 'featureEnabled' property is false.
@@ -3345,7 +3347,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
 
             // Verify that IsFeatureEnabled returns false when user does not get bucketed into the rollout rule's variation.
-            bool result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
+            var result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
             Assert.False(result);
         }
 
@@ -3372,7 +3374,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             TestActivateListener(userAttributes);
@@ -3403,7 +3405,7 @@ namespace OptimizelySDK.Tests
                 It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), It.IsAny<EventTags>(), It.IsAny<LogEvent>()));
 
-            Mock<OptimizelyUserContext> mockUserContext =
+            var mockUserContext =
                 new Mock<OptimizelyUserContext>(OptimizelyMock.Object, TestUserId, userAttributes,
                     ErrorHandlerMock.Object, LoggerMock.Object);
             mockUserContext.Setup(ouc => ouc.GetUserId()).Returns(TestUserId);
@@ -3462,7 +3464,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             TestTrackListener(userAttributes, null);
@@ -3481,14 +3483,14 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             var eventTags = new EventTags
             {
                 {
                     "revenue", 42
-                }
+                },
             };
 
             TestTrackListener(userAttributes, eventTags);
@@ -3518,7 +3520,7 @@ namespace OptimizelySDK.Tests
                 It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), It.IsAny<EventTags>(), It.IsAny<LogEvent>()));
 
-            Mock<OptimizelyUserContext> mockUserContext =
+            var mockUserContext =
                 new Mock<OptimizelyUserContext>(Optimizely, TestUserId, new UserAttributes(),
                     ErrorHandlerMock.Object, LoggerMock.Object);
             mockUserContext.Setup(ouc => ouc.GetUserId()).Returns(TestUserId);
@@ -3571,7 +3573,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             // Mocking objects.
@@ -3628,7 +3630,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             // Mocking objects.
@@ -3723,7 +3725,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             var optly = Helper.CreatePrivateOptimizely();
@@ -3736,7 +3738,7 @@ namespace OptimizelySDK.Tests
                 It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), It.IsAny<Dictionary<string, object>>()));
 
-            Mock<OptimizelyUserContext> mockUserContext =
+            var mockUserContext =
                 new Mock<OptimizelyUserContext>(optStronglyTyped, TestUserId, new UserAttributes(),
                     ErrorHandlerMock.Object, LoggerMock.Object);
             mockUserContext.Setup(ouc => ouc.GetUserId()).Returns(TestUserId);
@@ -3786,7 +3788,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             var optly = Helper.CreatePrivateOptimizely();
@@ -3797,7 +3799,7 @@ namespace OptimizelySDK.Tests
                 It.IsAny<string>(),
                 It.IsAny<UserAttributes>(), It.IsAny<Dictionary<string, object>>()));
 
-            Mock<OptimizelyUserContext> mockUserContext =
+            var mockUserContext =
                 new Mock<OptimizelyUserContext>(optStronglyTyped, TestUserId, new UserAttributes(),
                     ErrorHandlerMock.Object, LoggerMock.Object);
             mockUserContext.Setup(ouc => ouc.GetUserId()).Returns(TestUserId);
@@ -3902,7 +3904,7 @@ namespace OptimizelySDK.Tests
                 NotificationCallbackMock.Object.TestDecisionCallback);
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
 
-            bool result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
+            var result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
             Assert.True(result);
 
             var decisionInfo = new Dictionary<string, object>
@@ -3966,7 +3968,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
             optly.SetFieldOrProperty("ProjectConfigManager", ConfigManager);
 
-            bool result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
+            var result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
             Assert.False(result);
 
             var decisionInfo = new Dictionary<string, object>
@@ -4012,7 +4014,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "company", "Optimizely"
-                }
+                },
             };
             var experiment = Config.GetRolloutFromId("166660").Experiments[0];
             var variation = Config.GetVariationFromKey("177770", "177771");
@@ -4039,7 +4041,7 @@ namespace OptimizelySDK.Tests
                 NotificationCallbackMock.Object.TestDecisionCallback);
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
 
-            bool result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId,
+            var result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId,
                 userAttributes);
             Assert.True(result);
 
@@ -4078,7 +4080,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "company", "Optimizely"
-                }
+                },
             };
             var experiment = Config.GetRolloutFromId("166660").Experiments[3];
             var variation = Config.GetVariationFromKey("188880", "188881");
@@ -4105,7 +4107,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
             optly.SetFieldOrProperty("ProjectConfigManager", ConfigManager);
 
-            bool result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId,
+            var result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId,
                 userAttributes);
             Assert.False(result);
 
@@ -4160,7 +4162,7 @@ namespace OptimizelySDK.Tests
             optly.SetFieldOrProperty("DecisionService", DecisionServiceMock.Object);
             optly.SetFieldOrProperty("ProjectConfigManager", ConfigManager);
 
-            bool result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
+            var result = (bool)optly.Invoke("IsFeatureEnabled", featureKey, TestUserId, null);
             Assert.False(result);
 
             var decisionInfo = new Dictionary<string, object>
@@ -4193,7 +4195,7 @@ namespace OptimizelySDK.Tests
             string[] enabledFeatures =
             {
                 "double_single_variable_feature", "boolean_single_variable_feature",
-                "string_single_variable_feature"
+                "string_single_variable_feature",
             };
 
             var userAttributes = new UserAttributes
@@ -4203,7 +4205,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             NotificationCallbackMock.Setup(nc => nc.TestDecisionCallback(It.IsAny<string>(),
@@ -4265,7 +4267,7 @@ namespace OptimizelySDK.Tests
                                 },
                                 {
                                     "variationKey", "control"
-                                }
+                                },
                             }
                         },
                     }))), Times.Once);
@@ -4511,7 +4513,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "string_var", "cta_4"
-                }
+                },
             };
             var experiment = Config.GetRolloutFromId("166661").Experiments[0];
             var variation = Config.GetVariationFromKey(experiment.Key, "177775");
@@ -4528,7 +4530,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             DecisionServiceMock.
@@ -4609,7 +4611,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             DecisionServiceMock.
@@ -4774,7 +4776,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             DecisionServiceMock.
@@ -4928,7 +4930,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             DecisionServiceMock.
@@ -5075,7 +5077,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             DecisionServiceMock.
@@ -5215,7 +5217,7 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "string_var", "cta_4"
-                        }
+                        },
                     }
                 },
                 {
@@ -5226,9 +5228,9 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "string_var", "cta_5"
-                        }
+                        },
                     }
-                }
+                },
             };
             var experiment = Config.GetRolloutFromId("166661").Experiments[0];
             var variation = Config.GetVariationFromKey(experiment.Key, "177775");
@@ -5245,7 +5247,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             DecisionServiceMock.
@@ -5313,7 +5315,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
             var optimizely = new Optimizely(TestData.Datafile, EventDispatcherMock.Object,
                 LoggerMock.Object, ErrorHandlerMock.Object);
@@ -5374,7 +5376,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             var featureFlag = Config.GetFeatureFlagFromKey(featureKey);
@@ -5415,7 +5417,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "double_variable", 42.42
-                }
+                },
             };
 
             var optimizely = new Optimizely(TestData.Datafile, EventDispatcherMock.Object,
@@ -5446,7 +5448,7 @@ namespace OptimizelySDK.Tests
                 TestData.Datafile, TimeSpan.FromMilliseconds(300));
             TestHttpProjectConfigManagerUtil.SetClientFieldValue(httpClientMock.Object);
 
-            NotificationCenter notificationCenter = new NotificationCenter();
+            var notificationCenter = new NotificationCenter();
             NotificationCallbackMock.Setup(notification => notification.TestConfigUpdateCallback());
 
             var httpManager = new HttpProjectConfigManager.Builder().
@@ -5526,7 +5528,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             OptimizelyMock.Setup(om =>
@@ -5542,12 +5544,12 @@ namespace OptimizelySDK.Tests
             string[] enabledFeatures =
             {
                 "boolean_feature", "double_single_variable_feature",
-                "string_single_variable_feature", "multi_variate_feature", "empty_feature"
+                "string_single_variable_feature", "multi_variate_feature", "empty_feature",
             };
             string[] notEnabledFeatures =
             {
                 "integer_single_variable_feature", "boolean_single_variable_feature",
-                "mutex_group_feature", "no_rollout_experiment_feature"
+                "mutex_group_feature", "no_rollout_experiment_feature",
             };
             var userAttributes = new UserAttributes
             {
@@ -5556,7 +5558,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             };
 
             OptimizelyMock.Setup(om => om.IsFeatureEnabled(It.IsIn<string>(enabledFeatures),
@@ -5586,11 +5588,11 @@ namespace OptimizelySDK.Tests
         {
             var optly = Helper.CreatePrivateOptimizely();
 
-            bool result = (bool)optly.Invoke("ValidateStringInputs", new Dictionary<string, string>
+            var result = (bool)optly.Invoke("ValidateStringInputs", new Dictionary<string, string>
             {
                 {
                     Optimizely.EXPERIMENT_KEY, "test_experiment"
-                }
+                },
             });
             Assert.True(result);
 
@@ -5598,7 +5600,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     Optimizely.EVENT_KEY, "buy_now_event"
-                }
+                },
             });
             Assert.True(result);
         }
@@ -5608,11 +5610,11 @@ namespace OptimizelySDK.Tests
         {
             var optly = Helper.CreatePrivateOptimizely();
 
-            bool result = (bool)optly.Invoke("ValidateStringInputs", new Dictionary<string, string>
+            var result = (bool)optly.Invoke("ValidateStringInputs", new Dictionary<string, string>
             {
                 {
                     Optimizely.EXPERIMENT_KEY, ""
-                }
+                },
             });
             Assert.False(result);
 
@@ -5620,7 +5622,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     Optimizely.EVENT_KEY, null
-                }
+                },
             });
             Assert.False(result);
         }
@@ -5630,11 +5632,11 @@ namespace OptimizelySDK.Tests
         {
             var optly = Helper.CreatePrivateOptimizely();
 
-            bool result = (bool)optly.Invoke("ValidateStringInputs", new Dictionary<string, string>
+            var result = (bool)optly.Invoke("ValidateStringInputs", new Dictionary<string, string>
             {
                 {
                     Optimizely.USER_ID, "testUser"
-                }
+                },
             });
             Assert.True(result);
 
@@ -5642,7 +5644,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     Optimizely.USER_ID, ""
-                }
+                },
             });
             Assert.True(result);
 
@@ -5650,7 +5652,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     Optimizely.USER_ID, null
-                }
+                },
             });
             Assert.False(result);
         }
@@ -5726,7 +5728,7 @@ namespace OptimizelySDK.Tests
                 {
                     {
                         "house", "Gryffindor"
-                    }
+                    },
                 });
 
             Assert.AreEqual("A", variation.Key);
@@ -5738,7 +5740,7 @@ namespace OptimizelySDK.Tests
                 {
                     {
                         "lasers", 45.5
-                    }
+                    },
                 });
 
             Assert.AreEqual("A", variation.Key);
@@ -5754,7 +5756,7 @@ namespace OptimizelySDK.Tests
                 {
                     {
                         "house", "Hufflepuff"
-                    }
+                    },
                 });
 
             Assert.Null(variation);
@@ -5769,7 +5771,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "house", "Welcome to Slytherin!"
-                }
+                },
             });
 
             EventDispatcherMock.Verify(dispatcher => dispatcher.DispatchEvent(It.IsAny<LogEvent>()),
@@ -5784,7 +5786,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "house", "Hufflepuff"
-                }
+                },
             });
 
             EventDispatcherMock.Verify(dispatcher => dispatcher.DispatchEvent(It.IsAny<LogEvent>()),
@@ -5799,7 +5801,7 @@ namespace OptimizelySDK.Tests
                 {
                     {
                         "favorite_ice_cream", "chocolate"
-                    }
+                    },
                 });
 
             Assert.True(featureEnabled);
@@ -5809,7 +5811,7 @@ namespace OptimizelySDK.Tests
                 {
                     {
                         "lasers", 45.5
-                    }
+                    },
                 });
 
             Assert.True(featureEnabled);
@@ -5831,7 +5833,7 @@ namespace OptimizelySDK.Tests
                 {
                     {
                         "lasers", 71
-                    }
+                    },
                 });
 
             Assert.AreEqual(variableValue, "xyz");
@@ -5841,7 +5843,7 @@ namespace OptimizelySDK.Tests
                 {
                     {
                         "should_do_it", true
-                    }
+                    },
                 });
 
             Assert.AreEqual(variableValue, "xyz");
@@ -5855,7 +5857,7 @@ namespace OptimizelySDK.Tests
                 {
                     {
                         "lasers", 50
-                    }
+                    },
                 });
 
             Assert.AreEqual(variableValue, "x");
@@ -5875,7 +5877,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "lasers", 45.5
-                }
+                },
             };
 
             // Should be included via substring match string audience with id '3988293898' and exact match number audience with id '3468206646'
@@ -5898,7 +5900,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "lasers", 45.5
-                }
+                },
             };
 
             // Should be excluded as substring audience with id '3988293898' does not match, so the overall conditions fail.
@@ -5921,7 +5923,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "should_do_it", true
-                }
+                },
             };
 
             // Should be included via exact match string audience with id '3468206642' and exact match boolean audience with id '3468206646'
@@ -5942,7 +5944,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "should_do_it", false
-                }
+                },
             };
 
             // Should be excluded as exact match boolean audience with id '3468206643' does not match so the overall conditions fail.
@@ -5962,7 +5964,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "favorite_ice_cream", "walls"
-                }
+                },
             };
 
             // Should be included via substring match string audience with id '3988293898' and exists audience with id '3988293899'
@@ -5981,7 +5983,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "lasers", 45.5
-                }
+                },
             };
 
             // Should be excluded - substring match string audience with id '3988293898' does not match,
@@ -6002,7 +6004,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "lasers", 700
-                }
+                },
             };
 
             // Should be included via substring match string audience with id '3988293898' and exists audience with id '3988293899'
@@ -6078,7 +6080,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "location", "San Francisco"
-                }
+                },
             });
             Assert.NotNull(activate);
             optimizely.Dispose();
@@ -6090,7 +6092,7 @@ namespace OptimizelySDK.Tests
                     },
                     {
                         "location", "San Francisco"
-                    }
+                    },
                 });
             Assert.Null(activateAfterDispose);
             httpManager.Dispose();

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Threading;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.Bucketing;
@@ -32,10 +36,6 @@ using OptimizelySDK.Tests.NotificationTests;
 using OptimizelySDK.Tests.Utils;
 using OptimizelySDK.Tests.UtilsTests;
 using OptimizelySDK.Utils;
-using System;
-using System.Collections.Generic;
-using System.Globalization;
-using System.Threading;
 
 namespace OptimizelySDK.Tests
 {
@@ -3380,6 +3380,7 @@ namespace OptimizelySDK.Tests
             TestActivateListener(userAttributes);
         }
 
+        [Obsolete]
         public void TestActivateListener(UserAttributes userAttributes)
         {
             var experimentKey = "group_experiment_1";

--- a/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
@@ -14,6 +14,9 @@
  *    limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Threading;
 using Castle.Core.Internal;
 using Moq;
 using NUnit.Framework;
@@ -29,9 +32,6 @@ using OptimizelySDK.Odp;
 using OptimizelySDK.OptimizelyDecisions;
 using OptimizelySDK.Tests.NotificationTests;
 using OptimizelySDK.Utils;
-using System;
-using System.Collections.Generic;
-using System.Threading;
 
 namespace OptimizelySDK.Tests
 {

--- a/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
@@ -38,7 +38,7 @@ namespace OptimizelySDK.Tests
     [TestFixture]
     public class OptimizelyUserContextTest
     {
-        const string UserID = "testUserID";
+        private const string UserID = "testUserID";
         private Optimizely Optimizely;
         private Mock<ILogger> LoggerMock;
         private Mock<IErrorHandler> ErrorHandlerMock;
@@ -69,9 +69,9 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "house", "GRYFFINDOR"
-                }
+                },
             };
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, attributes,
+            var user = new OptimizelyUserContext(Optimizely, UserID, attributes,
                 ErrorHandlerMock.Object, LoggerMock.Object);
 
             Assert.AreEqual(user.GetOptimizely(), Optimizely);
@@ -82,7 +82,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void OptimizelyUserContextNoAttributes()
         {
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, null,
+            var user = new OptimizelyUserContext(Optimizely, UserID, null,
                 ErrorHandlerMock.Object, LoggerMock.Object);
 
             Assert.AreEqual(user.GetOptimizely(), Optimizely);
@@ -97,9 +97,9 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "house", "GRYFFINDOR"
-                }
+                },
             };
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, attributes,
+            var user = new OptimizelyUserContext(Optimizely, UserID, attributes,
                 ErrorHandlerMock.Object, LoggerMock.Object);
 
             user.SetAttribute("k1", "v1");
@@ -120,7 +120,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void SetAttributeNoAttribute()
         {
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, null,
+            var user = new OptimizelyUserContext(Optimizely, UserID, null,
                 ErrorHandlerMock.Object, LoggerMock.Object);
 
             user.SetAttribute("k1", "v1");
@@ -140,9 +140,9 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "house", "GRYFFINDOR"
-                }
+                },
             };
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, attributes,
+            var user = new OptimizelyUserContext(Optimizely, UserID, attributes,
                 ErrorHandlerMock.Object, LoggerMock.Object);
 
             user.SetAttribute("k1", "v1");
@@ -160,9 +160,9 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "k1", null
-                }
+                },
             };
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, attributes,
+            var user = new OptimizelyUserContext(Optimizely, UserID, attributes,
                 ErrorHandlerMock.Object, LoggerMock.Object);
 
             var newAttributes = user.GetAttributes();
@@ -180,7 +180,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void SetAttributeToOverrideAttribute()
         {
-            OptimizelyUserContext user = new OptimizelyUserContext(Optimizely, UserID, null,
+            var user = new OptimizelyUserContext(Optimizely, UserID, null,
                 ErrorHandlerMock.Object, LoggerMock.Object);
 
             Assert.AreEqual(user.GetOptimizely(), Optimizely);
@@ -392,7 +392,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void DecideWhenConfigIsNull()
         {
-            Optimizely optimizely = new Optimizely(TestData.UnsupportedVersionDatafile,
+            var optimizely = new Optimizely(TestData.UnsupportedVersionDatafile,
                 EventDispatcherMock.Object, LoggerMock.Object, ErrorHandlerMock.Object);
 
             var flagKey = "multi_variate_feature";
@@ -419,7 +419,7 @@ namespace OptimizelySDK.Tests
             var flagKey = "multi_variate_feature";
             var flagKeys = new string[]
             {
-                flagKey
+                flagKey,
             };
 
             var variablesExpected = Optimizely.GetAllFeatureVariables(flagKey, UserID);
@@ -432,7 +432,7 @@ namespace OptimizelySDK.Tests
             Assert.True(decisions.Count == 1);
             var decision = decisions[flagKey];
 
-            OptimizelyDecision expDecision = new OptimizelyDecision(
+            var expDecision = new OptimizelyDecision(
                 "Gred",
                 false,
                 variablesExpected,
@@ -450,7 +450,7 @@ namespace OptimizelySDK.Tests
             var flagKey2 = "string_single_variable_feature";
             var flagKeys = new string[]
             {
-                flagKey1, flagKey2
+                flagKey1, flagKey2,
             };
 
             var variablesExpected1 = Optimizely.GetAllFeatureVariables(flagKey1, UserID);
@@ -473,7 +473,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "browser_type", "chrome"
-                }
+                },
             };
 
             Assert.True(decisions.Count == 2);
@@ -481,7 +481,7 @@ namespace OptimizelySDK.Tests
                 nc => nc.TestDecisionCallback(DecisionNotificationTypes.FLAG, UserID,
                     userAttributes, It.IsAny<Dictionary<string, object>>()),
                 Times.Exactly(2));
-            OptimizelyDecision expDecision1 = new OptimizelyDecision(
+            var expDecision1 = new OptimizelyDecision(
                 "Gred",
                 false,
                 variablesExpected1,
@@ -491,7 +491,7 @@ namespace OptimizelySDK.Tests
                 new string[0]);
             Assert.IsTrue(TestData.CompareObjects(decisions[flagKey1], expDecision1));
 
-            OptimizelyDecision expDecision2 = new OptimizelyDecision(
+            var expDecision2 = new OptimizelyDecision(
                 "control",
                 true,
                 variablesExpected2,
@@ -544,7 +544,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "browser_type", "chrome"
-                }
+                },
             };
 
             Assert.True(decisions.Count == 10);
@@ -553,7 +553,7 @@ namespace OptimizelySDK.Tests
                     userAttributes, It.IsAny<Dictionary<string, object>>()),
                 Times.Exactly(10));
 
-            OptimizelyDecision expDecision1 = new OptimizelyDecision(
+            var expDecision1 = new OptimizelyDecision(
                 null,
                 false,
                 variablesExpected1,
@@ -563,7 +563,7 @@ namespace OptimizelySDK.Tests
                 new string[0]);
             Assert.IsTrue(TestData.CompareObjects(decisions[flagKey1], expDecision1));
 
-            OptimizelyDecision expDecision2 = new OptimizelyDecision(
+            var expDecision2 = new OptimizelyDecision(
                 "variation",
                 false,
                 variablesExpected2,
@@ -573,7 +573,7 @@ namespace OptimizelySDK.Tests
                 new string[0]);
             Assert.IsTrue(TestData.CompareObjects(decisions[flagKey2], expDecision2));
 
-            OptimizelyDecision expDecision3 = new OptimizelyDecision(
+            var expDecision3 = new OptimizelyDecision(
                 "control",
                 false,
                 variablesExpected3,
@@ -583,7 +583,7 @@ namespace OptimizelySDK.Tests
                 new string[0]);
             Assert.IsTrue(TestData.CompareObjects(decisions[flagKey3], expDecision3));
 
-            OptimizelyDecision expDecision4 = new OptimizelyDecision(
+            var expDecision4 = new OptimizelyDecision(
                 "188881",
                 false,
                 variablesExpected4,
@@ -593,7 +593,7 @@ namespace OptimizelySDK.Tests
                 new string[0]);
             Assert.IsTrue(TestData.CompareObjects(decisions[flagKey4], expDecision4));
 
-            OptimizelyDecision expDecision5 = new OptimizelyDecision(
+            var expDecision5 = new OptimizelyDecision(
                 "control",
                 true,
                 variablesExpected5,
@@ -603,7 +603,7 @@ namespace OptimizelySDK.Tests
                 new string[0]);
             Assert.IsTrue(TestData.CompareObjects(decisions[flagKey5], expDecision5));
 
-            OptimizelyDecision expDecision6 = new OptimizelyDecision(
+            var expDecision6 = new OptimizelyDecision(
                 "Gred",
                 false,
                 variablesExpected6,
@@ -613,7 +613,7 @@ namespace OptimizelySDK.Tests
                 new string[0]);
             Assert.IsTrue(TestData.CompareObjects(decisions[flagKey6], expDecision6));
 
-            OptimizelyDecision expDecision7 = new OptimizelyDecision(
+            var expDecision7 = new OptimizelyDecision(
                 null,
                 false,
                 variablesExpected7,
@@ -623,7 +623,7 @@ namespace OptimizelySDK.Tests
                 new string[0]);
             Assert.IsTrue(TestData.CompareObjects(decisions[flagKey7], expDecision7));
 
-            OptimizelyDecision expDecision8 = new OptimizelyDecision(
+            var expDecision8 = new OptimizelyDecision(
                 null,
                 false,
                 variablesExpected8,
@@ -633,7 +633,7 @@ namespace OptimizelySDK.Tests
                 new string[0]);
             Assert.IsTrue(TestData.CompareObjects(decisions[flagKey8], expDecision8));
 
-            OptimizelyDecision expDecision9 = new OptimizelyDecision(
+            var expDecision9 = new OptimizelyDecision(
                 null,
                 false,
                 variablesExpected9,
@@ -643,7 +643,7 @@ namespace OptimizelySDK.Tests
                 new string[0]);
             Assert.IsTrue(TestData.CompareObjects(decisions[flagKey9], expDecision9));
 
-            OptimizelyDecision expDecision10 = new OptimizelyDecision(
+            var expDecision10 = new OptimizelyDecision(
                 null,
                 false,
                 variablesExpected10,
@@ -663,7 +663,7 @@ namespace OptimizelySDK.Tests
 
             var decideOptions = new OptimizelyDecideOption[]
             {
-                OptimizelyDecideOption.ENABLED_FLAGS_ONLY
+                OptimizelyDecideOption.ENABLED_FLAGS_ONLY,
             };
             var user = Optimizely.CreateUserContext(UserID);
             user.SetAttribute("browser_type", "chrome");
@@ -672,7 +672,7 @@ namespace OptimizelySDK.Tests
 
             Assert.True(decisions.Count == 1);
 
-            OptimizelyDecision expDecision1 = new OptimizelyDecision(
+            var expDecision1 = new OptimizelyDecision(
                 "control",
                 true,
                 variablesExpected1,
@@ -689,7 +689,7 @@ namespace OptimizelySDK.Tests
             var flagKey1 = "string_single_variable_feature";
             var decideOptions = new OptimizelyDecideOption[]
             {
-                OptimizelyDecideOption.ENABLED_FLAGS_ONLY
+                OptimizelyDecideOption.ENABLED_FLAGS_ONLY,
             };
 
             var optimizely = new Optimizely(TestData.Datafile,
@@ -707,7 +707,7 @@ namespace OptimizelySDK.Tests
 
             Assert.True(decisions.Count == 1);
 
-            OptimizelyDecision expDecision1 = new OptimizelyDecision(
+            var expDecision1 = new OptimizelyDecision(
                 "control",
                 true,
                 variablesExpected1,
@@ -724,7 +724,7 @@ namespace OptimizelySDK.Tests
             var flagKey1 = "string_single_variable_feature";
             var decideOptions = new OptimizelyDecideOption[]
             {
-                OptimizelyDecideOption.ENABLED_FLAGS_ONLY
+                OptimizelyDecideOption.ENABLED_FLAGS_ONLY,
             };
 
             var optimizely = new Optimizely(TestData.Datafile,
@@ -737,14 +737,14 @@ namespace OptimizelySDK.Tests
             user.SetAttribute("browser_type", "chrome");
             decideOptions = new OptimizelyDecideOption[]
             {
-                OptimizelyDecideOption.EXCLUDE_VARIABLES
+                OptimizelyDecideOption.EXCLUDE_VARIABLES,
             };
 
             var decisions = user.DecideAll(decideOptions);
 
             Assert.True(decisions.Count == 1);
             var expectedOptlyJson = new Dictionary<string, object>();
-            OptimizelyDecision expDecision1 = new OptimizelyDecision(
+            var expDecision1 = new OptimizelyDecision(
                 "control",
                 true,
                 new OptimizelyJSON(expectedOptlyJson, ErrorHandlerMock.Object, LoggerMock.Object),
@@ -765,7 +765,7 @@ namespace OptimizelySDK.Tests
             user.SetAttribute("browser_type", "chrome");
             var decideOptions = new OptimizelyDecideOption[]
             {
-                OptimizelyDecideOption.EXCLUDE_VARIABLES
+                OptimizelyDecideOption.EXCLUDE_VARIABLES,
             };
 
             var decision = user.Decide(flagKey, decideOptions);
@@ -794,7 +794,7 @@ namespace OptimizelySDK.Tests
 
             var decideOptions = new OptimizelyDecideOption[]
             {
-                OptimizelyDecideOption.INCLUDE_REASONS
+                OptimizelyDecideOption.INCLUDE_REASONS,
             };
 
             decision = user.Decide(flagKey, decideOptions);
@@ -837,7 +837,7 @@ namespace OptimizelySDK.Tests
 
             var decideOptions = new OptimizelyDecideOption[]
             {
-                OptimizelyDecideOption.DISABLE_DECISION_EVENT
+                OptimizelyDecideOption.DISABLE_DECISION_EVENT,
             };
             var decision = user.Decide(flagKey, decideOptions);
             EventDispatcherMock.Verify(dispatcher => dispatcher.DispatchEvent(It.IsAny<LogEvent>()),
@@ -863,7 +863,7 @@ namespace OptimizelySDK.Tests
             var variablesExpected = Optimizely.GetAllFeatureVariables(flagKey, UserID);
             var decideOptions = new OptimizelyDecideOption[]
             {
-                OptimizelyDecideOption.DISABLE_DECISION_EVENT
+                OptimizelyDecideOption.DISABLE_DECISION_EVENT,
             };
 
             var optimizely = new Optimizely(TestData.Datafile,
@@ -930,7 +930,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "browser_type", "chrome"
-                }
+                },
             };
 
             // Mocking objects.
@@ -966,7 +966,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     experimentId, new Decision(fbVariationId)
-                }
+                },
             });
 
             userProfileServiceMock.Setup(_ => _.Lookup(userId)).Returns(userProfile.ToMap());
@@ -984,7 +984,7 @@ namespace OptimizelySDK.Tests
 
             var decideOptions = new OptimizelyDecideOption[]
             {
-                OptimizelyDecideOption.IGNORE_USER_PROFILE_SERVICE
+                OptimizelyDecideOption.IGNORE_USER_PROFILE_SERVICE,
             };
             variationUserProfile = user.Decide(flagKey, decideOptions);
             Assert.AreEqual(variationKey, variationUserProfile.VariationKey);
@@ -1005,7 +1005,7 @@ namespace OptimizelySDK.Tests
 
             var decideOptions = new OptimizelyDecideOption[]
             {
-                OptimizelyDecideOption.IGNORE_USER_PROFILE_SERVICE
+                OptimizelyDecideOption.IGNORE_USER_PROFILE_SERVICE,
             };
             var variationUserProfile = user.Decide(flagKey, decideOptions);
             userProfileServiceMock.Verify(l => l.Save(It.IsAny<Dictionary<string, object>>()),
@@ -1030,7 +1030,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "should_do_it", false
-                }
+                },
             };
 
             var user = OptimizelyWithTypedAudiences.CreateUserContext(UserID, userAttributes);
@@ -1058,7 +1058,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "wont_send_null", null
-                }
+                },
             });
 
             EventDispatcherMock.Verify(dispatcher => dispatcher.DispatchEvent(It.IsAny<LogEvent>()),
@@ -1072,7 +1072,7 @@ namespace OptimizelySDK.Tests
         {
             var odpManager = new OdpManager.Builder().Build();
             var cde = new CountdownEvent(1);
-            bool callbackResult = false;
+            var callbackResult = false;
             var optimizely = new Optimizely(TestData.OdpIntegrationDatafile,
                 EventDispatcherMock.Object, LoggerMock.Object, ErrorHandlerMock.Object,
                 odpManager: odpManager);

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -54,7 +54,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     name, entityObject
-                }
+                },
             };
         }
 
@@ -125,7 +125,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "etag4", Config.GetExperimentFromKey("etag4")
-                }
+                },
             };
 
             Assert.IsTrue(TestData.CompareObjects(experimentKeyMap, Config.ExperimentKeyMap));
@@ -169,7 +169,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "119", Config.GetExperimentFromId("119")
-                }
+                },
             };
 
             Assert.IsTrue(TestData.CompareObjects(experimentIdMap, Config.ExperimentIdMap));
@@ -179,7 +179,7 @@ namespace OptimizelySDK.Tests
             {
                 {
                     "purchase", Config.GetEvent("purchase")
-                }
+                },
             };
             Assert.IsTrue(TestData.CompareObjects(eventKeyMap, Config.EventKeyMap));
 
@@ -203,7 +203,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "double_key", Config.GetAttribute("double_key")
-                }
+                },
             };
             Assert.IsTrue(TestData.CompareObjects(attributeKeyMap, Config.AttributeKeyMap));
 
@@ -218,7 +218,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "100", Config.GetAudience("100")
-                }
+                },
             };
             Assert.IsTrue(TestData.CompareObjects(audienceIdMap, Config.AudienceIdMap));
 
@@ -233,7 +233,7 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "variation", Config.GetVariationFromKey("test_experiment", "variation")
-                        }
+                        },
                     }
                 },
                 {
@@ -245,7 +245,7 @@ namespace OptimizelySDK.Tests
                         {
                             "variation",
                             Config.GetVariationFromKey("paused_experiment", "variation")
-                        }
+                        },
                     }
                 },
                 {
@@ -258,7 +258,7 @@ namespace OptimizelySDK.Tests
                         {
                             "group_exp_1_var_2",
                             Config.GetVariationFromKey("group_experiment_1", "group_exp_1_var_2")
-                        }
+                        },
                     }
                 },
                 {
@@ -271,7 +271,7 @@ namespace OptimizelySDK.Tests
                         {
                             "group_exp_2_var_2",
                             Config.GetVariationFromKey("group_experiment_2", "group_exp_2_var_2")
-                        }
+                        },
                     }
                 },
                 {
@@ -292,7 +292,7 @@ namespace OptimizelySDK.Tests
                         {
                             "George",
                             Config.GetVariationFromKey("test_experiment_multivariate", "George")
-                        }
+                        },
                     }
                 },
                 {
@@ -307,7 +307,7 @@ namespace OptimizelySDK.Tests
                             "variation", Config.GetVariationFromKey(
                                 "test_experiment_with_feature_rollout",
                                 "variation")
-                        }
+                        },
                     }
                 },
                 {
@@ -321,7 +321,7 @@ namespace OptimizelySDK.Tests
                             "variation", Config.GetVariationFromKey(
                                 "test_experiment_double_feature",
                                 "variation")
-                        }
+                        },
                     }
                 },
                 {
@@ -335,7 +335,7 @@ namespace OptimizelySDK.Tests
                             "variation", Config.GetVariationFromKey(
                                 "test_experiment_integer_feature",
                                 "variation")
-                        }
+                        },
                     }
                 },
                 {
@@ -343,7 +343,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177771", Config.GetVariationFromKey("177770", "177771")
-                        }
+                        },
                     }
                 },
                 {
@@ -351,7 +351,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177773", Config.GetVariationFromKey("177772", "177773")
-                        }
+                        },
                     }
                 },
                 {
@@ -359,7 +359,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177778", Config.GetVariationFromKey("177776", "177778")
-                        }
+                        },
                     }
                 },
                 {
@@ -367,7 +367,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177775", Config.GetVariationFromKey("177774", "177775")
-                        }
+                        },
                     }
                 },
                 {
@@ -375,7 +375,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177780", Config.GetVariationFromKey("177779", "177780")
-                        }
+                        },
                     }
                 },
                 {
@@ -383,7 +383,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177782", Config.GetVariationFromKey("177781", "177782")
-                        }
+                        },
                     }
                 },
                 {
@@ -391,7 +391,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177784", Config.GetVariationFromKey("177783", "177784")
-                        }
+                        },
                     }
                 },
                 {
@@ -399,7 +399,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "188881", Config.GetVariationFromKey("188880", "188881")
-                        }
+                        },
                     }
                 },
                 {
@@ -410,7 +410,7 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "vtag2", Config.GetVariationFromKey("etag1", "vtag2")
-                        }
+                        },
                     }
                 },
                 {
@@ -421,7 +421,7 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "vtag4", Config.GetVariationFromKey("etag2", "vtag4")
-                        }
+                        },
                     }
                 },
                 {
@@ -432,7 +432,7 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "vtag6", Config.GetVariationFromKey("etag3", "vtag6")
-                        }
+                        },
                     }
                 },
                 {
@@ -443,9 +443,9 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "vtag8", Config.GetVariationFromKey("etag4", "vtag8")
-                        }
+                        },
                     }
-                }
+                },
             };
 
             Assert.IsTrue(TestData.CompareObjects(expectedVariationKeyMap, Config.VariationKeyMap));
@@ -461,7 +461,7 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "7721010009", Config.GetVariationFromId("test_experiment", "7721010009")
-                        }
+                        },
                     }
                 },
                 {
@@ -474,7 +474,7 @@ namespace OptimizelySDK.Tests
                         {
                             "7721010509",
                             Config.GetVariationFromId("paused_experiment", "7721010509")
-                        }
+                        },
                     }
                 },
                 {
@@ -495,7 +495,7 @@ namespace OptimizelySDK.Tests
                         {
                             "122234",
                             Config.GetVariationFromId("test_experiment_multivariate", "122234")
-                        }
+                        },
                     }
                 },
                 {
@@ -510,7 +510,7 @@ namespace OptimizelySDK.Tests
                             "122237", Config.GetVariationFromId(
                                 "test_experiment_with_feature_rollout",
                                 "122237")
-                        }
+                        },
                     }
                 },
                 {
@@ -523,7 +523,7 @@ namespace OptimizelySDK.Tests
                         {
                             "122240",
                             Config.GetVariationFromId("test_experiment_double_feature", "122240")
-                        }
+                        },
                     }
                 },
                 {
@@ -536,7 +536,7 @@ namespace OptimizelySDK.Tests
                         {
                             "122243",
                             Config.GetVariationFromId("test_experiment_integer_feature", "122243")
-                        }
+                        },
                     }
                 },
                 {
@@ -549,7 +549,7 @@ namespace OptimizelySDK.Tests
                         {
                             "7722360022",
                             Config.GetVariationFromId("group_experiment_1", "7722360022")
-                        }
+                        },
                     }
                 },
                 {
@@ -562,7 +562,7 @@ namespace OptimizelySDK.Tests
                         {
                             "7725250007",
                             Config.GetVariationFromId("group_experiment_2", "7725250007")
-                        }
+                        },
                     }
                 },
                 {
@@ -570,7 +570,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177771", Config.GetVariationFromId("177770", "177771")
-                        }
+                        },
                     }
                 },
                 {
@@ -578,7 +578,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177773", Config.GetVariationFromId("177772", "177773")
-                        }
+                        },
                     }
                 },
                 {
@@ -586,7 +586,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177778", Config.GetVariationFromId("177776", "177778")
-                        }
+                        },
                     }
                 },
                 {
@@ -594,7 +594,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177775", Config.GetVariationFromId("177774", "177775")
-                        }
+                        },
                     }
                 },
                 {
@@ -602,7 +602,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177780", Config.GetVariationFromId("177779", "177780")
-                        }
+                        },
                     }
                 },
                 {
@@ -610,7 +610,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177782", Config.GetVariationFromId("177781", "177782")
-                        }
+                        },
                     }
                 },
                 {
@@ -618,7 +618,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "177784", Config.GetVariationFromId("177783", "177784")
-                        }
+                        },
                     }
                 },
                 {
@@ -626,7 +626,7 @@ namespace OptimizelySDK.Tests
                     {
                         {
                             "188881", Config.GetVariationFromId("188880", "188881")
-                        }
+                        },
                     }
                 },
                 {
@@ -637,7 +637,7 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "277", Config.GetVariationFromId("etag1", "277")
-                        }
+                        },
                     }
                 },
                 {
@@ -648,7 +648,7 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "279", Config.GetVariationFromId("etag2", "279")
-                        }
+                        },
                     }
                 },
                 {
@@ -659,7 +659,7 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "281", Config.GetVariationFromId("etag3", "281")
-                        }
+                        },
                     }
                 },
                 {
@@ -670,9 +670,9 @@ namespace OptimizelySDK.Tests
                         },
                         {
                             "283", Config.GetVariationFromId("etag4", "283")
-                        }
+                        },
                     }
-                }
+                },
             };
 
             Assert.IsTrue(TestData.CompareObjects(expectedVariationIdMap, Config.VariationIdMap));
@@ -683,12 +683,12 @@ namespace OptimizelySDK.Tests
                 new FeatureVariableUsage
                 {
                     Id = "155560",
-                    Value = "F"
+                    Value = "F",
                 },
                 new FeatureVariableUsage
                 {
                     Id = "155561",
-                    Value = "red"
+                    Value = "red",
                 },
             };
 
@@ -697,7 +697,7 @@ namespace OptimizelySDK.Tests
                 Id = "122231",
                 Key = "Fred",
                 FeatureVariableUsageInstances = featureVariableUsageInstance,
-                FeatureEnabled = true
+                FeatureEnabled = true,
             };
             var actualVariationUsage =
                 Config.GetVariationFromKey("test_experiment_multivariate", "Fred");
@@ -742,7 +742,7 @@ namespace OptimizelySDK.Tests
                 {
                     "unsupported_variabletype",
                     Config.GetFeatureFlagFromKey("unsupported_variabletype")
-                }
+                },
             };
 
             Assertions.AreEquivalent(expectedFeatureKeyMap, Config.FeatureKeyMap);
@@ -755,7 +755,7 @@ namespace OptimizelySDK.Tests
                 },
                 {
                     "166661", Config.GetRolloutFromId("166661")
-                }
+                },
             };
 
             Assert.IsTrue(TestData.CompareObjects(expectedRolloutIdMap, Config.RolloutIdMap));
@@ -779,9 +779,9 @@ namespace OptimizelySDK.Tests
                             new FeatureVariableUsage
                             {
                                 Id = "155563",
-                                Value = "groupie_1_v1"
-                            }
-                        }
+                                Value = "groupie_1_v1",
+                            },
+                        },
                     }
                 },
                 {
@@ -795,9 +795,9 @@ namespace OptimizelySDK.Tests
                             new FeatureVariableUsage
                             {
                                 Id = "155563",
-                                Value = "groupie_1_v2"
-                            }
-                        }
+                                Value = "groupie_1_v2",
+                            },
+                        },
                     }
                 },
                 {
@@ -811,9 +811,9 @@ namespace OptimizelySDK.Tests
                             new FeatureVariableUsage
                             {
                                 Id = "155563",
-                                Value = "groupie_2_v1"
-                            }
-                        }
+                                Value = "groupie_2_v1",
+                            },
+                        },
                     }
                 },
                 {
@@ -827,11 +827,11 @@ namespace OptimizelySDK.Tests
                             new FeatureVariableUsage
                             {
                                 Id = "155563",
-                                Value = "groupie_2_v2"
-                            }
-                        }
+                                Value = "groupie_2_v2",
+                            },
+                        },
                     }
-                }
+                },
             };
             var filteredActualFlagVariations = allVariations["boolean_feature"];
             TestData.CompareObjects(expectedVariationDict, filteredActualFlagVariations);
@@ -880,7 +880,7 @@ namespace OptimizelySDK.Tests
                         ex.Message == "Provided group is not in datafile.")),
                 Times.Once, "Failed");
 
-            Assert.IsTrue(TestData.CompareObjects(group, new Entity.Group()));
+            Assert.IsTrue(TestData.CompareObjects(group, new Group()));
         }
 
         [Test]
@@ -904,7 +904,7 @@ namespace OptimizelySDK.Tests
                 e.HandleError(It.Is<InvalidExperimentException>(ex =>
                     ex.Message == "Provided experiment is not in datafile.")));
 
-            Assert.IsTrue(TestData.CompareObjects(new Entity.Experiment(), experiment));
+            Assert.IsTrue(TestData.CompareObjects(new Experiment(), experiment));
         }
 
         [Test]
@@ -928,7 +928,7 @@ namespace OptimizelySDK.Tests
                 e.HandleError(It.Is<InvalidExperimentException>(ex =>
                     ex.Message == "Provided experiment is not in datafile.")));
 
-            Assert.IsTrue(TestData.CompareObjects(new Entity.Experiment(), experiment));
+            Assert.IsTrue(TestData.CompareObjects(new Experiment(), experiment));
         }
 
         [Test]
@@ -940,7 +940,7 @@ namespace OptimizelySDK.Tests
 
             Assert.IsTrue(TestData.CompareObjects(new object[]
             {
-                "7716830082", "7723330021", "7718750065", "7716830585"
+                "7716830082", "7723330021", "7718750065", "7716830585",
             }, ev.ExperimentIds));
         }
 
@@ -981,7 +981,7 @@ namespace OptimizelySDK.Tests
             ErrorHandlerMock.Verify(e =>
                 e.HandleError(It.Is<InvalidAudienceException>(ex =>
                     ex.Message == "Provided audience is not in datafile.")));
-            Assert.IsTrue(TestData.CompareObjects(new Entity.Audience(), audience));
+            Assert.IsTrue(TestData.CompareObjects(new Audience(), audience));
         }
 
         [Test]
@@ -1038,7 +1038,7 @@ namespace OptimizelySDK.Tests
                 e.HandleError(It.Is<InvalidVariationException>(ex =>
                     ex.Message == "Provided variation is not in datafile.")));
 
-            Assert.AreEqual(new Entity.Variation(), variation);
+            Assert.AreEqual(new Variation(), variation);
         }
 
         [Test]
@@ -1053,7 +1053,7 @@ namespace OptimizelySDK.Tests
             ErrorHandlerMock.Verify(e =>
                 e.HandleError(It.Is<InvalidVariationException>(ex =>
                     ex.Message == "Provided variation is not in datafile.")));
-            Assert.AreEqual(new Entity.Variation(), variation);
+            Assert.AreEqual(new Variation(), variation);
         }
 
         [Test]
@@ -1076,7 +1076,7 @@ namespace OptimizelySDK.Tests
             ErrorHandlerMock.Verify(e =>
                 e.HandleError(It.Is<InvalidVariationException>(ex =>
                     ex.Message == "Provided variation is not in datafile.")));
-            Assert.AreEqual(new Entity.Variation(), variation);
+            Assert.AreEqual(new Variation(), variation);
         }
 
         [Test]
@@ -1091,13 +1091,13 @@ namespace OptimizelySDK.Tests
             ErrorHandlerMock.Verify(e =>
                 e.HandleError(It.Is<InvalidVariationException>(ex =>
                     ex.Message == "Provided variation is not in datafile.")));
-            Assert.AreEqual(new Entity.Variation(), variation);
+            Assert.AreEqual(new Variation(), variation);
         }
 
         [Test]
         public void TempProjectConfigTest()
         {
-            ProjectConfig config = DatafileProjectConfig.Create(TestData.Datafile,
+            var config = DatafileProjectConfig.Create(TestData.Datafile,
                 new Mock<ILogger>().Object, new DefaultErrorHandler());
             Assert.IsNotNull(config);
             Assert.AreEqual("1592310167", config.AccountId);
@@ -1107,7 +1107,7 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestProjectConfigDatafileIsSame()
         {
-            ProjectConfig config = DatafileProjectConfig.Create(TestData.Datafile,
+            var config = DatafileProjectConfig.Create(TestData.Datafile,
                 new Mock<ILogger>().Object, new DefaultErrorHandler());
             Assert.AreEqual(config.ToDatafile(), TestData.Datafile);
         }
@@ -1132,8 +1132,8 @@ namespace OptimizelySDK.Tests
             Assert.True(Config.BotFiltering.GetValueOrDefault());
 
             // Remove botFilering node and verify returned value in null.
-            JObject projConfig = JObject.Parse(TestData.Datafile);
-            if (projConfig.TryGetValue("botFiltering", out JToken token))
+            var projConfig = JObject.Parse(TestData.Datafile);
+            if (projConfig.TryGetValue("botFiltering", out var token))
             {
                 projConfig.Property("botFiltering").Remove();
                 var configWithoutBotFilter = DatafileProjectConfig.Create(
@@ -1157,14 +1157,14 @@ namespace OptimizelySDK.Tests
                 "$opt_reserved_prefix_attribute");
 
             // Create config file copy with additional resered prefix attribute.
-            string reservedPrefixAttrKey = "$opt_user_defined_attribute";
-            JObject projConfig = JObject.Parse(TestData.Datafile);
+            var reservedPrefixAttrKey = "$opt_user_defined_attribute";
+            var projConfig = JObject.Parse(TestData.Datafile);
             var attributes = (JArray)projConfig["attributes"];
 
             var reservedAttr = new Entity.Attribute
             {
                 Id = "7723348204",
-                Key = reservedPrefixAttrKey
+                Key = reservedPrefixAttrKey,
             };
             attributes.Add((JObject)JToken.FromObject(reservedAttr));
 
@@ -1233,7 +1233,7 @@ namespace OptimizelySDK.Tests
             var expectedAudienceIds = new string[]
             {
                 "3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644",
-                "3468206643"
+                "3468206643",
             };
             Assert.That(expectedAudienceIds, Is.EquivalentTo(experiment.AudienceIds));
         }
@@ -1313,7 +1313,7 @@ namespace OptimizelySDK.Tests
         {
             var datafileProjectConfig = DatafileProjectConfig.Create(
                 TestData.OdpIntegrationDatafile, new NoOpLogger(),
-                new ErrorHandler.NoOpErrorHandler());
+                new NoOpErrorHandler());
 
             Assert.AreEqual(ZAIUS_HOST, datafileProjectConfig.HostForOdp);
             Assert.AreEqual(ZAIUS_PUBLIC_KEY, datafileProjectConfig.PublicKeyForOdp);
@@ -1324,7 +1324,7 @@ namespace OptimizelySDK.Tests
         {
             var datafileProjectConfig = DatafileProjectConfig.Create(
                 TestData.OdpIntegrationWithOtherFieldsDatafile, new NoOpLogger(),
-                new ErrorHandler.NoOpErrorHandler());
+                new NoOpErrorHandler());
 
             Assert.AreEqual(ZAIUS_HOST, datafileProjectConfig.HostForOdp);
             Assert.AreEqual(ZAIUS_PUBLIC_KEY, datafileProjectConfig.PublicKeyForOdp);
@@ -1335,7 +1335,7 @@ namespace OptimizelySDK.Tests
         {
             var datafileProjectConfig = DatafileProjectConfig.Create(
                 TestData.EmptyIntegrationDatafile, new NoOpLogger(),
-                new ErrorHandler.NoOpErrorHandler());
+                new NoOpErrorHandler());
 
             Assert.IsNull(datafileProjectConfig.HostForOdp);
             Assert.IsNull(datafileProjectConfig.PublicKeyForOdp);
@@ -1346,7 +1346,7 @@ namespace OptimizelySDK.Tests
         {
             var datafileProjectConfig = DatafileProjectConfig.Create(
                 TestData.NonOdpIntegrationDatafile, new NoOpLogger(),
-                new ErrorHandler.NoOpErrorHandler());
+                new NoOpErrorHandler());
 
             Assert.IsNull(datafileProjectConfig.HostForOdp);
             Assert.IsNull(datafileProjectConfig.PublicKeyForOdp);

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -24,9 +27,6 @@ using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Exceptions;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Utils;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace OptimizelySDK.Tests
 {

--- a/OptimizelySDK.Tests/TestBucketer.cs
+++ b/OptimizelySDK.Tests/TestBucketer.cs
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
- namespace OptimizelySDK.Tests
+namespace OptimizelySDK.Tests
 {
     internal class TestBucketer : Bucketing.Bucketer
     {
         public TestBucketer(Logger.ILogger logger)
-            : base(logger)
-        {
-        }
+            : base(logger) { }
 
         public void SetBucketValues(int[] bucketValues)
         {
@@ -36,7 +34,10 @@
         public override int GenerateBucketValue(string bucketingId)
         {
             if (BucketValues == null || BucketValues.Length == 0)
+            {
                 return 0;
+            }
+
             Ndx %= BucketValues.Length;
             return BucketValues[Ndx++];
         }

--- a/OptimizelySDK.Tests/TestData.json
+++ b/OptimizelySDK.Tests/TestData.json
@@ -1,947 +1,975 @@
 ﻿{
-	"tempproperty": "This is to test additional properties",
-	"experiments": [
-		{
-			"status": "Running",
-			"key": "test_experiment",
-			"layerId": "7719770039",
-			"trafficAllocation": [
-				{
-					"entityId": "7722370027",
-					"endOfRange": 4000
-				},
-				{
-					"entityId": "7721010009",
-					"endOfRange": 8000
-				}
-			],
-			"audienceIds": [ "7718080042" ],
-			"variations": [
-				{
-					"id": "7722370027",
-					"key": "control"
-				},
-				{
-					"id": "7721010009",
-					"key": "variation"
-				}
-			],
-			"forcedVariations": {
-				"user1": "control"
-			},
-			"id": "7716830082"
-		},
-		{
-			"status": "Paused",
-			"key": "paused_experiment",
-			"layerId": "7719779139",
-			"trafficAllocation": [
-				{
-					"entityId": "7722370427",
-					"endOfRange": 5000
-				},
-				{
-					"entityId": "7721010509",
-					"endOfRange": 8000
-				}
-			],
-			"audienceIds": [],
-			"variations": [
-				{
-					"id": "7722370427",
-					"key": "control"
-				},
-				{
-					"id": "7721010509",
-					"key": "variation"
-				}
-			],
-			"forcedVariations": {},
-			"id": "7716830585"
-		},
-		{
-			"key": "test_experiment_multivariate",
-			"status": "Running",
-			"layerId": "4",
-			"audienceIds": [ "11154" ],
-			"id": "122230",
-			"forcedVariations": {},
-			"trafficAllocation": [
-				{
-					"entityId": "122231",
-					"endOfRange": 2500
-				},
-				{
-					"entityId": "122232",
-					"endOfRange": 5000
-				},
-				{
-					"entityId": "122233",
-					"endOfRange": 7500
-				},
-				{
-					"entityId": "122234",
-					"endOfRange": 10000
-				}
-			],
-			"variations": [
-				{
-					"id": "122231",
-					"key": "Fred",
-					"variables": [
-						{
-							"id": "155560",
-							"value": "F"
-						},
-						{
-							"id": "155561",
-							"value": "red"
-						}
-					],
-					"featureEnabled": true
-				},
-				{
-					"id": "122232",
-					"key": "Feorge",
-					"variables": [
-						{
-							"id": "155560",
-							"value": "F"
-						},
-						{
-							"id": "155561",
-							"value": "eorge"
-						}
-					],
-					"featureEnabled": false
-				},
-				{
-					"id": "122233",
-					"key": "Gred",
-					"variables": [
-						{
-							"id": "155560",
-							"value": "G"
-						},
-						{
-							"id": "155561",
-							"value": "red"
-						}
-					]
-				},
-				{
-					"id": "122234",
-					"key": "George",
-					"variables": [
-						{
-							"id": "155560",
-							"value": "G"
-						},
-						{
-							"id": "155561",
-							"value": "eorge"
-						}
-					],
-					"featureEnabled": true
-				}
-			]
-		},
-		{
-			"key": "test_experiment_with_feature_rollout",
-			"status": "Running",
-			"layerId": "5",
-			"audienceIds": [],
-			"id": "122235",
-			"forcedVariations": {},
-			"trafficAllocation": [
-				{
-					"entityId": "122236",
-					"endOfRange": 5000
-				},
-				{
-					"entityId": "122237",
-					"endOfRange": 10000
-				}
-			],
-			"variations": [
-				{
-					"id": "122236",
-					"key": "control",
-					"variables": [
-						{
-							"id": "155558",
-							"value": "cta_1"
-						},
-						{
-							"id": "17014990011",
-							"value": "{\"int_var\": 1, \"boolean_key\": false}"
-						}
-					],
-					"featureEnabled": true
-				},
-				{
-					"id": "122237",
-					"key": "variation",
-					"variables": [
-						{
-							"id": "155558",
-							"value": "cta_2"
-						}
-					],
-					"featureEnabled": true
-				}
-			]
-		},
-		{
-			"key": "test_experiment_double_feature",
-			"status": "Running",
-			"layerId": "5",
-			"audienceIds": [],
-			"id": "122238",
-			"forcedVariations": {},
-			"trafficAllocation": [
-				{
-					"entityId": "122239",
-					"endOfRange": 5000
-				},
-				{
-					"entityId": "122240",
-					"endOfRange": 10000
-				}
-			],
-			"variations": [
-				{
-					"id": "122239",
-					"key": "control",
-					"variables": [
-						{
-							"id": "155551",
-							"value": "42.42"
-						}
-					],
-					"featureEnabled": true
-				},
-				{
-					"id": "122240",
-					"key": "variation",
-					"variables": [
-						{
-							"id": "155551",
-							"value": "13.37"
-						}
-					],
-					"featureEnabled": false
-				}
-			]
-		},
-		{
-			"key": "test_experiment_integer_feature",
-			"status": "Running",
-			"layerId": "6",
-			"audienceIds": [],
-			"id": "122241",
-			"forcedVariations": {},
-			"trafficAllocation": [
-				{
-					"entityId": "122242",
-					"endOfRange": 5000
-				},
-				{
-					"entityId": "122243",
-					"endOfRange": 10000
-				}
-			],
-			"variations": [
-				{
-					"id": "122242",
-					"key": "control",
-					"variables": [
-						{
-							"id": "155553",
-							"value": "42"
-						}
-					],
-					"featureEnabled": false
-				},
-				{
-					"id": "122243",
-					"key": "variation",
-					"variables": [
-						{
-							"id": "155553",
-							"value": "13"
-						}
-					],
-					"featureEnabled": true
-				}
-			]
-		},
-		{
-			"id": "223",
-			"key": "etag1",
-			"status": "Running",
-			"layerId": "1",
-			"percentageIncluded": 9000,
-			"audienceIds": [],
-			"variations": [
-				{
-					"id": "276",
-					"key": "vtag1",
-					"variables": []
-				},
-				{
-					"id": "277",
-					"key": "vtag2",
-					"variables": []
-				}
-			],
-			"forcedVariations": {
-				"testUser1": "vtag1",
-				"testUser2": "vtag2"
-			},
-			"trafficAllocation": [
-				{
-					"entityId": "276",
-					"endOfRange": 3500
-				},
-				{
-					"entityId": "277",
-					"endOfRange": 9000
-				}
-			]
-		},
-		{
-			"id": "118",
-			"key": "etag2",
-			"status": "Not started",
-			"layerId": "2",
-			"audienceIds": [],
-			"variations": [
-				{
-					"id": "278",
-					"key": "vtag3",
-					"variables": []
-				},
-				{
-					"id": "279",
-					"key": "vtag4",
-					"variables": []
-				}
-			],
-			"forcedVariations": {},
-			"trafficAllocation": [
-				{
-					"entityId": "278",
-					"endOfRange": 4500
-				},
-				{
-					"entityId": "279",
-					"endOfRange": 9000
-				}
-			]
-		},
-		{
-			"id": "224",
-			"key": "etag3",
-			"status": "Running",
-			"layerId": "1",
-			"percentageIncluded": 9000,
-			"audienceIds": [
-				"100"
-			],
-			"variations": [
-				{
-					"id": "280",
-					"key": "vtag5",
-					"variables": []
-				},
-				{
-					"id": "281",
-					"key": "vtag6",
-					"variables": []
-				}
-			],
-			"forcedVariations": {
-				"testUser1": "vtag5"
-			},
-			"trafficAllocation": [
-				{
-					"entityId": "280",
-					"endOfRange": 3500
-				},
-				{
-					"entityId": "281",
-					"endOfRange": 9000
-				}
-			]
-		},
-		{
-			"id": "119",
-			"key": "etag4",
-			"status": "Not started",
-			"layerId": "2",
-			"audienceIds": [
-				"100"
-			],
-			"variations": [
-				{
-					"id": "282",
-					"key": "vtag7",
-					"variables": []
-				},
-				{
-					"id": "283",
-					"key": "vtag8",
-					"variables": []
-				}
-			],
-			"forcedVariations": {
-				"testUser3": "vtag7"
-			},
-			"trafficAllocation": [
-				{
-					"entityId": "282",
-					"endOfRange": 4500
-				},
-				{
-					"entityId": "283",
-					"endOfRange": 9000
-				}
-			]
-		}
-	],
-	"version": "4",
-	"audiences": [
-		{
-			"conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"device_type\", \"type\": \"custom_attribute\", \"value\": \"iPhone\"}]], [\"or\", [\"or\", {\"name\": \"location\", \"type\": \"custom_attribute\", \"value\": \"San Francisco\"}]]]",
-			"id": "7718080042",
-			"name": "iPhone users in San Francisco"
-		},
-		{
-			"name": "Chrome users",
-			"conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"chrome\"}]]]",
-			"id": "11154"
-		},
-		{
-			"id": "100",
-			"name": "not_firefox_users",
-			"conditions": "[\"and\", [\"or\", [\"not\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_dimension\", \"value\":\"firefox\"}]]]]"
-		}
-	],
-	"groups": [
-		{
-			"policy": "random",
-			"trafficAllocation": [
-				{
-					"entityId": "7723330021",
-					"endOfRange": 2000
-				},
-				{
-					"entityId": "7718750065",
-					"endOfRange": 6000
-				}
-			],
-			"experiments": [
-				{
-					"status": "Running",
-					"key": "group_experiment_1",
-					"layerId": "7721010011",
-					"trafficAllocation": [
-						{
-							"entityId": "7722260071",
-							"endOfRange": 5000
-						},
-						{
-							"entityId": "7722360022",
-							"endOfRange": 10000
-						}
-					],
-					"audienceIds": [],
-					"variations": [
-						{
-							"id": "7722260071",
-							"key": "group_exp_1_var_1",
-							"variables": [
-								{
-									"id": "155563",
-									"value": "groupie_1_v1"
-								}
-							],
-							"featureEnabled": true
-						},
-						{
-							"id": "7722360022",
-							"key": "group_exp_1_var_2",
-							"variables": [
-								{
-									"id": "155563",
-									"value": "groupie_1_v2"
-								}
-							],
-							"featureEnabled": true
-						}
-					],
-					"forcedVariations": {
-						"user1": "group_exp_1_var_1"
-					},
-					"id": "7723330021"
-				},
-				{
-					"status": "Running",
-					"key": "group_experiment_2",
-					"layerId": "7721020020",
-					"trafficAllocation": [
-						{
-							"entityId": "7713030086",
-							"endOfRange": 5000
-						},
-						{
-							"entityId": "7725250007",
-							"endOfRange": 10000
-						}
-					],
-					"audienceIds": [],
-					"variations": [
-						{
-							"id": "7713030086",
-							"key": "group_exp_2_var_1",
-							"variables": [
-								{
-									"id": "155563",
-									"value": "groupie_2_v1"
-								}
-							],
-							"featureEnabled": false
-						},
-						{
-							"id": "7725250007",
-							"key": "group_exp_2_var_2",
-							"variables": [
-								{
-									"id": "155563",
-									"value": "groupie_2_v2"
-								}
-							],
-							"featureEnabled": false
-						}
-					],
-					"forcedVariations": {},
-					"id": "7718750065"
-				}
-			],
-			"id": "7722400015"
-		}
-	],
-	"featureFlags": [
-		{
-			"id": "155549",
-			"key": "boolean_feature",
-			"rolloutId": "",
-			"experimentIds": [ "7723330021", "7718750065" ],
-			"variables": []
-		},
-		{
-			"id": "155550",
-			"key": "double_single_variable_feature",
-			"rolloutId": "",
-			"experimentIds": [ "122238" ],
-			"variables": [
-				{
-					"id": "155551",
-					"key": "double_variable",
-					"type": "double",
-					"defaultValue": "14.99"
-				}
-			]
-		},
-		{
-			"id": "155552",
-			"key": "integer_single_variable_feature",
-			"rolloutId": "",
-			"experimentIds": [ "122241" ],
-			"variables": [
-				{
-					"id": "155553",
-					"key": "integer_variable",
-					"type": "integer",
-					"defaultValue": "7"
-				}					
-			]
-		},
-		{
-			"id": "155554",
-			"key": "boolean_single_variable_feature",
-			"rolloutId": "166660",
-			"experimentIds": [],
-			"variables": [
-				{
-					"id": "155556",
-					"key": "boolean_variable",
-					"type": "boolean",
-					"defaultValue": "true"
-				}
-			]
-		},
-		{
-			"id": "155557",
-			"key": "string_single_variable_feature",
-			"rolloutId": "166661",
-			"experimentIds": [ "122235" ],
-			"variables": [
-				{
-					"id": "155558",
-					"key": "string_variable",
-					"type": "string",
-					"defaultValue": "wingardium leviosa"
-				},
-				{
-					"defaultValue": "{\"int_var\": 5212, \"boolean_key\": true}",
-					"type": "string",
-					"subType": "json",
-					"id": "17014990011",
-					"key": "json_var"
-				},
-				{
-					"defaultValue": "{\"int_var\": 123, \"boolean_key\": true}",
-					"type": "json",
-					"id": "170149900112",
-					"key": "true_json_var"
-				}
-			]
-		},
-		{
-			"id": "155559",
-			"key": "multi_variate_feature",
-			"rolloutId": "",
-			"experimentIds": [ "122230" ],
-			"variables": [
-				{
-					"id": "155560",
-					"key": "first_letter",
-					"type": "string",
-					"defaultValue": "H"
-				},
-				{
-					"id": "155561",
-					"key": "rest_of_name",
-					"type": "string",
-					"defaultValue": "arry"
-				}
-			]
-		},
-		{
-			"id": "155562",
-			"key": "mutex_group_feature",
-			"rolloutId": "",
-			"experimentIds": [ "7723330021", "7718750065" ],
-			"variables": [
-				{
-					"id": "155563",
-					"key": "correlating_variation_name",
-					"type": "string",
-					"defaultValue": "null"
-				}
-			]
-		},
-		{
-			"id": "155564",
-			"key": "empty_feature",
-			"rolloutId": "",
-			"experimentIds": [],
-			"variables": []
-		},
-		{
-			"id": "155565",
-			"key": "no_rollout_experiment_feature",
-			"rolloutId": "166662",
-			"experimentIds": [],
-			"variables": []
-		},
-		{
-			"id": "155566",
-			"key": "unsupported_variabletype",
-			"rolloutId": "166662",
-			"experimentIds": [],
-			"variables": [
-				{
-					"id": "255554",
-					"key": "any_key",
-					"type": "random",
-					"defaultValue": "{}"
-				},
-				{
-					"id": "255555",
-					"key": "string_regex_key",
-					"type": "string",
-					"defaultValue": "^\\d+(\\.\\d+)?",
-					"subType": "regex"
-				}
-			]
-
-		}
-	],
-	"rollouts": [
-		{
-			"id": "166660",
-			"experiments": [
-				{
-					"id": "177770",
-					"key": "177770",
-					"status": "Running",
-					"layerId": "166660",
-					"audienceIds": [ "11154" ],
-					"variations": [
-						{
-							"id": "177771",
-							"key": "177771",
-							"variables": [
-								{
-									"id": "155556",
-									"value": "true"
-								}
-							],
-							"featureEnabled": true
-						}
-					],
-					"trafficAllocation": [
-						{
-							"entityId": "177771",
-							"endOfRange": 1000
-						}
-					]
-				},
-				{
-					"id": "177772",
-					"key": "177772",
-					"status": "Running",
-					"layerId": "166660",
-					"audienceIds": [ "7718080042" ],
-					"variations": [
-						{
-							"id": "177773",
-							"key": "177773",
-							"variables": [
-								{
-									"id": "155556",
-									"value": "false"
-								}
-							],
-							"featureEnabled": true
-						}
-					],
-					"trafficAllocation": [
-						{
-							"entityId": "177773",
-							"endOfRange": 10000
-						}
-					]
-				},
-				{
-					"id": "177776",
-					"key": "177776",
-					"status": "Running",
-					"layerId": "166660",
-					"audienceIds": [],
-					"variations": [
-						{
-							"id": "177778",
-							"key": "177778",
-							"variables": [
-								{
-									"id": "155556",
-									"value": "false"
-								}
-							],
-							"featureEnabled": true
-						}
-					],
-					"trafficAllocation": [
-						{
-							"entityId": "177778",
-							"endOfRange": 9000
-						}
-					]
-				},
-				{
-					"id": "177781",
-					"key": "177781",
-					"status": "Running",
-					"layerId": "166660",
-					"audienceIds": [],
-					"variations": [
-						{
-							"id": "177782",
-							"key": "177782",
-							"variables": [
-								{
-									"id": "155556",
-									"value": "false"
-								}
-							],
-							"featureEnabled": false
-						}
-					],
-					"trafficAllocation": [
-						{
-							"entityId": "177778",
-							"endOfRange": 9000
-						}
-					]
-				},
-				{
-					"id": "188880",
-					"key": "188880",
-					"status": "Running",
-					"layerId": "166660",
-					"audienceIds": [],
-					"variations": [
-						{
-							"id": "188881",
-							"key": "188881",
-							"variables": [
-								{
-									"id": "155556",
-									"value": "false"
-								}
-							],
-							"featureEnabled": false
-						}
-					],
-					"trafficAllocation": [
-						{
-							"entityId": "188881",
-							"endOfRange": 9200
-						}
-					]
-				}
-			]
-		},
-		{
-			"id": "166661",
-			"experiments": [
-				{
-					"id": "177774",
-					"key": "177774",
-					"status": "Running",
-					"layerId": "166661",
-					"audienceIds": [ "11154" ],
-					"variations": [
-						{
-							"id": "177775",
-							"key": "177775",
-							"variables": [
-								{
-									"id": "155558",
-									"value": "cta_4"
-								},
-								{
-									"id": "17014990011",
-									"value": "{\"int_var\": 4 , \"string_var\": \"cta_4\"}"
-								},
-								{
-									"id": "170149900112",
-									"value": "{\"int_var\": 5 , \"string_var\": \"cta_5\"}"
-								}
-							],
-							"featureEnabled": true
-						}
-					],
-					"trafficAllocation": [
-						{
-							"entityId": "177775",
-							"endOfRange": 1500
-						}
-					]
-				},
-				{
-					"id": "177779",
-					"key": "177779",
-					"status": "Running",
-					"layerId": "166661",
-					"audienceIds": [],
-					"variations": [
-						{
-							"id": "177780",
-							"key": "177780",
-							"variables": [],
-							"featureEnabled": true
-						}
-					],
-					"trafficAllocation": [
-						{
-							"entityId": "177780",
-							"endOfRange": 1500
-						}
-					]
-				},
-				{
-					"id": "177783",
-					"key": "177783",
-					"status": "Running",
-					"layerId": "166661",
-					"audienceIds": [],
-					"variations": [
-						{
-							"id": "177784",
-							"key": "177784",
-							"variables": [
-								{
-									"id": "155558",
-									"value": "cta_5"
-								}
-							],
-							"featureEnabled": false
-						}
-					],
-					"trafficAllocation": [
-						{
-							"entityId": "177780",
-							"endOfRange": 1500
-						}
-					]
-				}
-			]
-		}
-	],
-	"attributes": [
-		{
-			"id": "7723280020",
-			"key": "device_type"
-		},
-		{
-			"id": "7723340004",
-			"key": "location"
-		},
-		{
-			"id": "134",
-			"key": "browser_type"
-		},
-		{
-			"id": "323434545",
-			"key": "boolean_key"
-		},
-		{
-			"id": "616727838",
-			"key": "integer_key"
-		},
-		{
-			"id": "808797686",
-			"key": "double_key"
-		}
-	],
-	"projectId": "7720880029",
-	"accountId": "1592310167",
-	"events": [
-		{
-			"experimentIds": [ "7716830082", "7723330021", "7718750065", "7716830585" ],
-			"id": "7718020063",
-			"key": "purchase"
-		}
-	],
-	"revision": "15",
-	"sdkKey": "TestData",
-	"environmentKey": "Production",
-	"anonymizeIP": false,
-	"sendFlagDecisions": true,
-	"botFiltering": true
+  "tempproperty": "This is to test additional properties",
+  "experiments": [
+    {
+      "status": "Running",
+      "key": "test_experiment",
+      "layerId": "7719770039",
+      "trafficAllocation": [
+        {
+          "entityId": "7722370027",
+          "endOfRange": 4000
+        },
+        {
+          "entityId": "7721010009",
+          "endOfRange": 8000
+        }
+      ],
+      "audienceIds": [
+        "7718080042"
+      ],
+      "variations": [
+        {
+          "id": "7722370027",
+          "key": "control"
+        },
+        {
+          "id": "7721010009",
+          "key": "variation"
+        }
+      ],
+      "forcedVariations": {
+        "user1": "control"
+      },
+      "id": "7716830082"
+    },
+    {
+      "status": "Paused",
+      "key": "paused_experiment",
+      "layerId": "7719779139",
+      "trafficAllocation": [
+        {
+          "entityId": "7722370427",
+          "endOfRange": 5000
+        },
+        {
+          "entityId": "7721010509",
+          "endOfRange": 8000
+        }
+      ],
+      "audienceIds": [],
+      "variations": [
+        {
+          "id": "7722370427",
+          "key": "control"
+        },
+        {
+          "id": "7721010509",
+          "key": "variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "7716830585"
+    },
+    {
+      "key": "test_experiment_multivariate",
+      "status": "Running",
+      "layerId": "4",
+      "audienceIds": [
+        "11154"
+      ],
+      "id": "122230",
+      "forcedVariations": {},
+      "trafficAllocation": [
+        {
+          "entityId": "122231",
+          "endOfRange": 2500
+        },
+        {
+          "entityId": "122232",
+          "endOfRange": 5000
+        },
+        {
+          "entityId": "122233",
+          "endOfRange": 7500
+        },
+        {
+          "entityId": "122234",
+          "endOfRange": 10000
+        }
+      ],
+      "variations": [
+        {
+          "id": "122231",
+          "key": "Fred",
+          "variables": [
+            {
+              "id": "155560",
+              "value": "F"
+            },
+            {
+              "id": "155561",
+              "value": "red"
+            }
+          ],
+          "featureEnabled": true
+        },
+        {
+          "id": "122232",
+          "key": "Feorge",
+          "variables": [
+            {
+              "id": "155560",
+              "value": "F"
+            },
+            {
+              "id": "155561",
+              "value": "eorge"
+            }
+          ],
+          "featureEnabled": false
+        },
+        {
+          "id": "122233",
+          "key": "Gred",
+          "variables": [
+            {
+              "id": "155560",
+              "value": "G"
+            },
+            {
+              "id": "155561",
+              "value": "red"
+            }
+          ]
+        },
+        {
+          "id": "122234",
+          "key": "George",
+          "variables": [
+            {
+              "id": "155560",
+              "value": "G"
+            },
+            {
+              "id": "155561",
+              "value": "eorge"
+            }
+          ],
+          "featureEnabled": true
+        }
+      ]
+    },
+    {
+      "key": "test_experiment_with_feature_rollout",
+      "status": "Running",
+      "layerId": "5",
+      "audienceIds": [],
+      "id": "122235",
+      "forcedVariations": {},
+      "trafficAllocation": [
+        {
+          "entityId": "122236",
+          "endOfRange": 5000
+        },
+        {
+          "entityId": "122237",
+          "endOfRange": 10000
+        }
+      ],
+      "variations": [
+        {
+          "id": "122236",
+          "key": "control",
+          "variables": [
+            {
+              "id": "155558",
+              "value": "cta_1"
+            },
+            {
+              "id": "17014990011",
+              "value": "{\"int_var\": 1, \"boolean_key\": false}"
+            }
+          ],
+          "featureEnabled": true
+        },
+        {
+          "id": "122237",
+          "key": "variation",
+          "variables": [
+            {
+              "id": "155558",
+              "value": "cta_2"
+            }
+          ],
+          "featureEnabled": true
+        }
+      ]
+    },
+    {
+      "key": "test_experiment_double_feature",
+      "status": "Running",
+      "layerId": "5",
+      "audienceIds": [],
+      "id": "122238",
+      "forcedVariations": {},
+      "trafficAllocation": [
+        {
+          "entityId": "122239",
+          "endOfRange": 5000
+        },
+        {
+          "entityId": "122240",
+          "endOfRange": 10000
+        }
+      ],
+      "variations": [
+        {
+          "id": "122239",
+          "key": "control",
+          "variables": [
+            {
+              "id": "155551",
+              "value": "42.42"
+            }
+          ],
+          "featureEnabled": true
+        },
+        {
+          "id": "122240",
+          "key": "variation",
+          "variables": [
+            {
+              "id": "155551",
+              "value": "13.37"
+            }
+          ],
+          "featureEnabled": false
+        }
+      ]
+    },
+    {
+      "key": "test_experiment_integer_feature",
+      "status": "Running",
+      "layerId": "6",
+      "audienceIds": [],
+      "id": "122241",
+      "forcedVariations": {},
+      "trafficAllocation": [
+        {
+          "entityId": "122242",
+          "endOfRange": 5000
+        },
+        {
+          "entityId": "122243",
+          "endOfRange": 10000
+        }
+      ],
+      "variations": [
+        {
+          "id": "122242",
+          "key": "control",
+          "variables": [
+            {
+              "id": "155553",
+              "value": "42"
+            }
+          ],
+          "featureEnabled": false
+        },
+        {
+          "id": "122243",
+          "key": "variation",
+          "variables": [
+            {
+              "id": "155553",
+              "value": "13"
+            }
+          ],
+          "featureEnabled": true
+        }
+      ]
+    },
+    {
+      "id": "223",
+      "key": "etag1",
+      "status": "Running",
+      "layerId": "1",
+      "percentageIncluded": 9000,
+      "audienceIds": [],
+      "variations": [
+        {
+          "id": "276",
+          "key": "vtag1",
+          "variables": []
+        },
+        {
+          "id": "277",
+          "key": "vtag2",
+          "variables": []
+        }
+      ],
+      "forcedVariations": {
+        "testUser1": "vtag1",
+        "testUser2": "vtag2"
+      },
+      "trafficAllocation": [
+        {
+          "entityId": "276",
+          "endOfRange": 3500
+        },
+        {
+          "entityId": "277",
+          "endOfRange": 9000
+        }
+      ]
+    },
+    {
+      "id": "118",
+      "key": "etag2",
+      "status": "Not started",
+      "layerId": "2",
+      "audienceIds": [],
+      "variations": [
+        {
+          "id": "278",
+          "key": "vtag3",
+          "variables": []
+        },
+        {
+          "id": "279",
+          "key": "vtag4",
+          "variables": []
+        }
+      ],
+      "forcedVariations": {},
+      "trafficAllocation": [
+        {
+          "entityId": "278",
+          "endOfRange": 4500
+        },
+        {
+          "entityId": "279",
+          "endOfRange": 9000
+        }
+      ]
+    },
+    {
+      "id": "224",
+      "key": "etag3",
+      "status": "Running",
+      "layerId": "1",
+      "percentageIncluded": 9000,
+      "audienceIds": [
+        "100"
+      ],
+      "variations": [
+        {
+          "id": "280",
+          "key": "vtag5",
+          "variables": []
+        },
+        {
+          "id": "281",
+          "key": "vtag6",
+          "variables": []
+        }
+      ],
+      "forcedVariations": {
+        "testUser1": "vtag5"
+      },
+      "trafficAllocation": [
+        {
+          "entityId": "280",
+          "endOfRange": 3500
+        },
+        {
+          "entityId": "281",
+          "endOfRange": 9000
+        }
+      ]
+    },
+    {
+      "id": "119",
+      "key": "etag4",
+      "status": "Not started",
+      "layerId": "2",
+      "audienceIds": [
+        "100"
+      ],
+      "variations": [
+        {
+          "id": "282",
+          "key": "vtag7",
+          "variables": []
+        },
+        {
+          "id": "283",
+          "key": "vtag8",
+          "variables": []
+        }
+      ],
+      "forcedVariations": {
+        "testUser3": "vtag7"
+      },
+      "trafficAllocation": [
+        {
+          "entityId": "282",
+          "endOfRange": 4500
+        },
+        {
+          "entityId": "283",
+          "endOfRange": 9000
+        }
+      ]
+    }
+  ],
+  "version": "4",
+  "audiences": [
+    {
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"device_type\", \"type\": \"custom_attribute\", \"value\": \"iPhone\"}]], [\"or\", [\"or\", {\"name\": \"location\", \"type\": \"custom_attribute\", \"value\": \"San Francisco\"}]]]",
+      "id": "7718080042",
+      "name": "iPhone users in San Francisco"
+    },
+    {
+      "name": "Chrome users",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\": \"chrome\"}]]]",
+      "id": "11154"
+    },
+    {
+      "id": "100",
+      "name": "not_firefox_users",
+      "conditions": "[\"and\", [\"or\", [\"not\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_dimension\", \"value\":\"firefox\"}]]]]"
+    }
+  ],
+  "groups": [
+    {
+      "policy": "random",
+      "trafficAllocation": [
+        {
+          "entityId": "7723330021",
+          "endOfRange": 2000
+        },
+        {
+          "entityId": "7718750065",
+          "endOfRange": 6000
+        }
+      ],
+      "experiments": [
+        {
+          "status": "Running",
+          "key": "group_experiment_1",
+          "layerId": "7721010011",
+          "trafficAllocation": [
+            {
+              "entityId": "7722260071",
+              "endOfRange": 5000
+            },
+            {
+              "entityId": "7722360022",
+              "endOfRange": 10000
+            }
+          ],
+          "audienceIds": [],
+          "variations": [
+            {
+              "id": "7722260071",
+              "key": "group_exp_1_var_1",
+              "variables": [
+                {
+                  "id": "155563",
+                  "value": "groupie_1_v1"
+                }
+              ],
+              "featureEnabled": true
+            },
+            {
+              "id": "7722360022",
+              "key": "group_exp_1_var_2",
+              "variables": [
+                {
+                  "id": "155563",
+                  "value": "groupie_1_v2"
+                }
+              ],
+              "featureEnabled": true
+            }
+          ],
+          "forcedVariations": {
+            "user1": "group_exp_1_var_1"
+          },
+          "id": "7723330021"
+        },
+        {
+          "status": "Running",
+          "key": "group_experiment_2",
+          "layerId": "7721020020",
+          "trafficAllocation": [
+            {
+              "entityId": "7713030086",
+              "endOfRange": 5000
+            },
+            {
+              "entityId": "7725250007",
+              "endOfRange": 10000
+            }
+          ],
+          "audienceIds": [],
+          "variations": [
+            {
+              "id": "7713030086",
+              "key": "group_exp_2_var_1",
+              "variables": [
+                {
+                  "id": "155563",
+                  "value": "groupie_2_v1"
+                }
+              ],
+              "featureEnabled": false
+            },
+            {
+              "id": "7725250007",
+              "key": "group_exp_2_var_2",
+              "variables": [
+                {
+                  "id": "155563",
+                  "value": "groupie_2_v2"
+                }
+              ],
+              "featureEnabled": false
+            }
+          ],
+          "forcedVariations": {},
+          "id": "7718750065"
+        }
+      ],
+      "id": "7722400015"
+    }
+  ],
+  "featureFlags": [
+    {
+      "id": "155549",
+      "key": "boolean_feature",
+      "rolloutId": "",
+      "experimentIds": [
+        "7723330021",
+        "7718750065"
+      ],
+      "variables": []
+    },
+    {
+      "id": "155550",
+      "key": "double_single_variable_feature",
+      "rolloutId": "",
+      "experimentIds": [
+        "122238"
+      ],
+      "variables": [
+        {
+          "id": "155551",
+          "key": "double_variable",
+          "type": "double",
+          "defaultValue": "14.99"
+        }
+      ]
+    },
+    {
+      "id": "155552",
+      "key": "integer_single_variable_feature",
+      "rolloutId": "",
+      "experimentIds": [
+        "122241"
+      ],
+      "variables": [
+        {
+          "id": "155553",
+          "key": "integer_variable",
+          "type": "integer",
+          "defaultValue": "7"
+        }
+      ]
+    },
+    {
+      "id": "155554",
+      "key": "boolean_single_variable_feature",
+      "rolloutId": "166660",
+      "experimentIds": [],
+      "variables": [
+        {
+          "id": "155556",
+          "key": "boolean_variable",
+          "type": "boolean",
+          "defaultValue": "true"
+        }
+      ]
+    },
+    {
+      "id": "155557",
+      "key": "string_single_variable_feature",
+      "rolloutId": "166661",
+      "experimentIds": [
+        "122235"
+      ],
+      "variables": [
+        {
+          "id": "155558",
+          "key": "string_variable",
+          "type": "string",
+          "defaultValue": "wingardium leviosa"
+        },
+        {
+          "defaultValue": "{\"int_var\": 5212, \"boolean_key\": true}",
+          "type": "string",
+          "subType": "json",
+          "id": "17014990011",
+          "key": "json_var"
+        },
+        {
+          "defaultValue": "{\"int_var\": 123, \"boolean_key\": true}",
+          "type": "json",
+          "id": "170149900112",
+          "key": "true_json_var"
+        }
+      ]
+    },
+    {
+      "id": "155559",
+      "key": "multi_variate_feature",
+      "rolloutId": "",
+      "experimentIds": [
+        "122230"
+      ],
+      "variables": [
+        {
+          "id": "155560",
+          "key": "first_letter",
+          "type": "string",
+          "defaultValue": "H"
+        },
+        {
+          "id": "155561",
+          "key": "rest_of_name",
+          "type": "string",
+          "defaultValue": "arry"
+        }
+      ]
+    },
+    {
+      "id": "155562",
+      "key": "mutex_group_feature",
+      "rolloutId": "",
+      "experimentIds": [
+        "7723330021",
+        "7718750065"
+      ],
+      "variables": [
+        {
+          "id": "155563",
+          "key": "correlating_variation_name",
+          "type": "string",
+          "defaultValue": "null"
+        }
+      ]
+    },
+    {
+      "id": "155564",
+      "key": "empty_feature",
+      "rolloutId": "",
+      "experimentIds": [],
+      "variables": []
+    },
+    {
+      "id": "155565",
+      "key": "no_rollout_experiment_feature",
+      "rolloutId": "166662",
+      "experimentIds": [],
+      "variables": []
+    },
+    {
+      "id": "155566",
+      "key": "unsupported_variabletype",
+      "rolloutId": "166662",
+      "experimentIds": [],
+      "variables": [
+        {
+          "id": "255554",
+          "key": "any_key",
+          "type": "random",
+          "defaultValue": "{}"
+        },
+        {
+          "id": "255555",
+          "key": "string_regex_key",
+          "type": "string",
+          "defaultValue": "^\\d+(\\.\\d+)?",
+          "subType": "regex"
+        }
+      ]
+    }
+  ],
+  "rollouts": [
+    {
+      "id": "166660",
+      "experiments": [
+        {
+          "id": "177770",
+          "key": "177770",
+          "status": "Running",
+          "layerId": "166660",
+          "audienceIds": [
+            "11154"
+          ],
+          "variations": [
+            {
+              "id": "177771",
+              "key": "177771",
+              "variables": [
+                {
+                  "id": "155556",
+                  "value": "true"
+                }
+              ],
+              "featureEnabled": true
+            }
+          ],
+          "trafficAllocation": [
+            {
+              "entityId": "177771",
+              "endOfRange": 1000
+            }
+          ]
+        },
+        {
+          "id": "177772",
+          "key": "177772",
+          "status": "Running",
+          "layerId": "166660",
+          "audienceIds": [
+            "7718080042"
+          ],
+          "variations": [
+            {
+              "id": "177773",
+              "key": "177773",
+              "variables": [
+                {
+                  "id": "155556",
+                  "value": "false"
+                }
+              ],
+              "featureEnabled": true
+            }
+          ],
+          "trafficAllocation": [
+            {
+              "entityId": "177773",
+              "endOfRange": 10000
+            }
+          ]
+        },
+        {
+          "id": "177776",
+          "key": "177776",
+          "status": "Running",
+          "layerId": "166660",
+          "audienceIds": [],
+          "variations": [
+            {
+              "id": "177778",
+              "key": "177778",
+              "variables": [
+                {
+                  "id": "155556",
+                  "value": "false"
+                }
+              ],
+              "featureEnabled": true
+            }
+          ],
+          "trafficAllocation": [
+            {
+              "entityId": "177778",
+              "endOfRange": 9000
+            }
+          ]
+        },
+        {
+          "id": "177781",
+          "key": "177781",
+          "status": "Running",
+          "layerId": "166660",
+          "audienceIds": [],
+          "variations": [
+            {
+              "id": "177782",
+              "key": "177782",
+              "variables": [
+                {
+                  "id": "155556",
+                  "value": "false"
+                }
+              ],
+              "featureEnabled": false
+            }
+          ],
+          "trafficAllocation": [
+            {
+              "entityId": "177778",
+              "endOfRange": 9000
+            }
+          ]
+        },
+        {
+          "id": "188880",
+          "key": "188880",
+          "status": "Running",
+          "layerId": "166660",
+          "audienceIds": [],
+          "variations": [
+            {
+              "id": "188881",
+              "key": "188881",
+              "variables": [
+                {
+                  "id": "155556",
+                  "value": "false"
+                }
+              ],
+              "featureEnabled": false
+            }
+          ],
+          "trafficAllocation": [
+            {
+              "entityId": "188881",
+              "endOfRange": 9200
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "id": "166661",
+      "experiments": [
+        {
+          "id": "177774",
+          "key": "177774",
+          "status": "Running",
+          "layerId": "166661",
+          "audienceIds": [
+            "11154"
+          ],
+          "variations": [
+            {
+              "id": "177775",
+              "key": "177775",
+              "variables": [
+                {
+                  "id": "155558",
+                  "value": "cta_4"
+                },
+                {
+                  "id": "17014990011",
+                  "value": "{\"int_var\": 4 , \"string_var\": \"cta_4\"}"
+                },
+                {
+                  "id": "170149900112",
+                  "value": "{\"int_var\": 5 , \"string_var\": \"cta_5\"}"
+                }
+              ],
+              "featureEnabled": true
+            }
+          ],
+          "trafficAllocation": [
+            {
+              "entityId": "177775",
+              "endOfRange": 1500
+            }
+          ]
+        },
+        {
+          "id": "177779",
+          "key": "177779",
+          "status": "Running",
+          "layerId": "166661",
+          "audienceIds": [],
+          "variations": [
+            {
+              "id": "177780",
+              "key": "177780",
+              "variables": [],
+              "featureEnabled": true
+            }
+          ],
+          "trafficAllocation": [
+            {
+              "entityId": "177780",
+              "endOfRange": 1500
+            }
+          ]
+        },
+        {
+          "id": "177783",
+          "key": "177783",
+          "status": "Running",
+          "layerId": "166661",
+          "audienceIds": [],
+          "variations": [
+            {
+              "id": "177784",
+              "key": "177784",
+              "variables": [
+                {
+                  "id": "155558",
+                  "value": "cta_5"
+                }
+              ],
+              "featureEnabled": false
+            }
+          ],
+          "trafficAllocation": [
+            {
+              "entityId": "177780",
+              "endOfRange": 1500
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "attributes": [
+    {
+      "id": "7723280020",
+      "key": "device_type"
+    },
+    {
+      "id": "7723340004",
+      "key": "location"
+    },
+    {
+      "id": "134",
+      "key": "browser_type"
+    },
+    {
+      "id": "323434545",
+      "key": "boolean_key"
+    },
+    {
+      "id": "616727838",
+      "key": "integer_key"
+    },
+    {
+      "id": "808797686",
+      "key": "double_key"
+    }
+  ],
+  "projectId": "7720880029",
+  "accountId": "1592310167",
+  "events": [
+    {
+      "experimentIds": [
+        "7716830082",
+        "7723330021",
+        "7718750065",
+        "7716830585"
+      ],
+      "id": "7718020063",
+      "key": "purchase"
+    }
+  ],
+  "revision": "15",
+  "sdkKey": "TestData",
+  "environmentKey": "Production",
+  "anonymizeIP": false,
+  "sendFlagDecisions": true,
+  "botFiltering": true
 }

--- a/OptimizelySDK.Tests/TestSetup.cs
+++ b/OptimizelySDK.Tests/TestSetup.cs
@@ -1,6 +1,6 @@
-﻿using NUnit.Framework;
-using System.Globalization;
+﻿using System.Globalization;
 using System.Threading;
+using NUnit.Framework;
 
 namespace OptimizelySDK.Tests
 {

--- a/OptimizelySDK.Tests/Utils/Reflection.cs
+++ b/OptimizelySDK.Tests/Utils/Reflection.cs
@@ -24,7 +24,8 @@ namespace OptimizelySDK.Tests.Utils
                     return (T)fieldInfo.GetValue(obj);
                 }
             }
-            return (T)default(T);
+
+            return (T)default;
         }
 
         /// <summary>
@@ -34,7 +35,9 @@ namespace OptimizelySDK.Tests.Utils
         /// <param name="obj">Object from which you want to get variable</param>
         /// <param name="fieldName">Name of the field</param>
         /// <returns></returns>
-        public static T GetFieldValue<T, U>(U obj, string fieldName, IEnumerable<FieldInfo> fieldsInfo)
+        public static T GetFieldValue<T, U>(U obj, string fieldName,
+            IEnumerable<FieldInfo> fieldsInfo
+        )
         {
             foreach (var fieldInfo in fieldsInfo)
             {
@@ -43,7 +46,8 @@ namespace OptimizelySDK.Tests.Utils
                     return (T)fieldInfo.GetValue(obj);
                 }
             }
-            return (T)default(T);
+
+            return (T)default;
         }
 
 
@@ -64,7 +68,8 @@ namespace OptimizelySDK.Tests.Utils
                     return (T)popertyInfo.GetValue(obj);
                 }
             }
-            return (T)default(T);
+
+            return (T)default;
         }
 
         /// <summary>
@@ -75,10 +80,13 @@ namespace OptimizelySDK.Tests.Utils
         public static IEnumerable<PropertyInfo> GetAllProperties(Type type)
         {
             if (type == null)
+            {
                 return Enumerable.Empty<PropertyInfo>();
+            }
+
             var flags = BindingFlags.Public | BindingFlags.NonPublic |
-                                 BindingFlags.Static | BindingFlags.Instance |
-                                 BindingFlags.DeclaredOnly;
+                        BindingFlags.Static | BindingFlags.Instance |
+                        BindingFlags.DeclaredOnly;
             return type.GetProperties(flags).Concat(GetAllProperties(type.BaseType));
         }
 
@@ -90,10 +98,13 @@ namespace OptimizelySDK.Tests.Utils
         public static IEnumerable<FieldInfo> GetAllFields(Type t)
         {
             if (t == null)
+            {
                 return Enumerable.Empty<FieldInfo>();
+            }
+
             var flags = BindingFlags.Public | BindingFlags.NonPublic |
-                                 BindingFlags.Static | BindingFlags.Instance |
-                                 BindingFlags.DeclaredOnly;
+                        BindingFlags.Static | BindingFlags.Instance |
+                        BindingFlags.DeclaredOnly;
             return t.GetFields(flags).Concat(GetAllFields(t.BaseType));
         }
     }

--- a/OptimizelySDK.Tests/Utils/TestConversionExtensions.cs
+++ b/OptimizelySDK.Tests/Utils/TestConversionExtensions.cs
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using Moq;
 using OptimizelySDK.Config;
 using OptimizelySDK.Entity;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
-using System.Collections.Generic;
 
 namespace OptimizelySDK.Tests.Utils
 {

--- a/OptimizelySDK.Tests/Utils/TestConversionExtensions.cs
+++ b/OptimizelySDK.Tests/Utils/TestConversionExtensions.cs
@@ -29,15 +29,15 @@ namespace OptimizelySDK.Tests.Utils
         {
             var mockLogger = new Mock<ILogger>();
             mockLogger.Setup(i => i.Log(It.IsAny<LogLevel>(), It.IsAny<string>()));
-            
+
             var errorHandler = new NoOpErrorHandler();
             var config = DatafileProjectConfig.Create(
-                content: TestData.Datafile,
-                logger: mockLogger.Object,
-                errorHandler: errorHandler);
+                TestData.Datafile,
+                mockLogger.Object,
+                errorHandler);
             var configManager = new FallbackProjectConfigManager(config);
             var optimizely = new Optimizely(configManager);
-            
+
             return new OptimizelyUserContext(optimizely, "any-user", attributes, errorHandler,
                 mockLogger.Object);
         }
@@ -46,16 +46,17 @@ namespace OptimizelySDK.Tests.Utils
         {
             var mockLogger = new Mock<ILogger>();
             mockLogger.Setup(i => i.Log(It.IsAny<LogLevel>(), It.IsAny<string>()));
-            
+
             var errorHandler = new NoOpErrorHandler();
             var config = DatafileProjectConfig.Create(
-                content: TestData.Datafile,
-                logger: mockLogger.Object,
-                errorHandler: errorHandler);
+                TestData.Datafile,
+                mockLogger.Object,
+                errorHandler);
             var configManager = new FallbackProjectConfigManager(config);
             var optimizely = new Optimizely(configManager);
-            
-            return new OptimizelyUserContext(optimizely, "any-user", new UserAttributes(), null, qualifiedSegments, errorHandler,
+
+            return new OptimizelyUserContext(optimizely, "any-user", new UserAttributes(), null,
+                qualifiedSegments, errorHandler,
                 mockLogger.Object);
         }
     }

--- a/OptimizelySDK.Tests/Utils/TestData.cs
+++ b/OptimizelySDK.Tests/Utils/TestData.cs
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
+using Newtonsoft.Json.Linq;
 
 namespace OptimizelySDK.Tests
 {

--- a/OptimizelySDK.Tests/Utils/TestData.cs
+++ b/OptimizelySDK.Tests/Utils/TestData.cs
@@ -39,130 +39,66 @@ namespace OptimizelySDK.Tests
         private static string odpIntegrationDatafile = null;
         private static string odpIntegrationWithOtherFieldsDatafile = null;
 
-        public static string Datafile
-        {
-            get
-            {
-                return cachedDataFile ?? (cachedDataFile = LoadJsonData());
-            }
-        }
+        public static string Datafile => cachedDataFile ?? (cachedDataFile = LoadJsonData());
 
-        public static string DuplicateExpKeysDatafile
-        {
-            get
-            {
-                return duplicateExpKeysDatafile ??
-                       (duplicateExpKeysDatafile = LoadJsonData("similar_exp_keys.json"));
-            }
-        }
+        public static string DuplicateExpKeysDatafile =>
+            duplicateExpKeysDatafile ??
+            (duplicateExpKeysDatafile = LoadJsonData("similar_exp_keys.json"));
 
-        public static string DuplicateRuleKeysDatafile
-        {
-            get
-            {
-                return duplicateRuleKeysDatafile ?? (duplicateRuleKeysDatafile =
-                    LoadJsonData("similar_rule_keys_bucketing.json"));
-            }
-        }
+        public static string DuplicateRuleKeysDatafile =>
+            duplicateRuleKeysDatafile ?? (duplicateRuleKeysDatafile =
+                LoadJsonData("similar_rule_keys_bucketing.json"));
 
-        public static string SimpleABExperimentsDatafile
-        {
-            get
-            {
-                return simpleABExperimentsDatafile ?? (simpleABExperimentsDatafile =
-                    LoadJsonData("simple_ab_experiments.json"));
-            }
-        }
+        public static string SimpleABExperimentsDatafile =>
+            simpleABExperimentsDatafile ?? (simpleABExperimentsDatafile =
+                LoadJsonData("simple_ab_experiments.json"));
 
-        public static string UnsupportedVersionDatafile
-        {
-            get
-            {
-                return unsupportedVersionDatafile ?? (unsupportedVersionDatafile =
-                    LoadJsonData("unsupported_version_datafile.json"));
-            }
-        }
+        public static string UnsupportedVersionDatafile =>
+            unsupportedVersionDatafile ?? (unsupportedVersionDatafile =
+                LoadJsonData("unsupported_version_datafile.json"));
 
-        public static string EmptyRolloutDatafile
-        {
-            get
-            {
-                return emptyRolloutDatafile ??
-                       (emptyRolloutDatafile = LoadJsonData("EmptyRolloutRule.json"));
-            }
-        }
+        public static string EmptyRolloutDatafile =>
+            emptyRolloutDatafile ??
+            (emptyRolloutDatafile = LoadJsonData("EmptyRolloutRule.json"));
 
-        public static string EmptyDatafile
-        {
-            get
-            {
-                return emptyDatafile ?? (emptyDatafile = LoadJsonData("emptydatafile.json"));
-            }
-        }
+        public static string EmptyDatafile =>
+            emptyDatafile ?? (emptyDatafile = LoadJsonData("emptydatafile.json"));
 
-        public static string EmptyIntegrationDatafile
-        {
-            get
-            {
-                return emptyIntegrationDatafile ?? (emptyIntegrationDatafile =
-                    LoadJsonData("IntegrationEmptyDatafile.json"));
-            }
-        }
+        public static string EmptyIntegrationDatafile =>
+            emptyIntegrationDatafile ?? (emptyIntegrationDatafile =
+                LoadJsonData("IntegrationEmptyDatafile.json"));
 
-        public static string NonOdpIntegrationDatafile
-        {
-            get
-            {
-                return nonOdpIntegrationDatafile ?? (nonOdpIntegrationDatafile =
-                    LoadJsonData("IntegrationNonOdpDatafile.json"));
-            }
-        }
+        public static string NonOdpIntegrationDatafile =>
+            nonOdpIntegrationDatafile ?? (nonOdpIntegrationDatafile =
+                LoadJsonData("IntegrationNonOdpDatafile.json"));
 
-        public static string OdpIntegrationDatafile
-        {
-            get
-            {
-                return odpIntegrationDatafile ?? (odpIntegrationDatafile =
-                    LoadJsonData("IntegrationOdpDatafile.json"));
-            }
-        }
+        public static string OdpIntegrationDatafile =>
+            odpIntegrationDatafile ?? (odpIntegrationDatafile =
+                LoadJsonData("IntegrationOdpDatafile.json"));
 
-        public static string OdpIntegrationWithOtherFieldsDatafile
-        {
-            get
-            {
-                return odpIntegrationWithOtherFieldsDatafile ??
-                       (odpIntegrationWithOtherFieldsDatafile =
-                           LoadJsonData("IntegrationOdpWithOtherFieldsDatafile.json"));
-            }
-        }
+        public static string OdpIntegrationWithOtherFieldsDatafile =>
+            odpIntegrationWithOtherFieldsDatafile ??
+            (odpIntegrationWithOtherFieldsDatafile =
+                LoadJsonData("IntegrationOdpWithOtherFieldsDatafile.json"));
 
-        public static string TypedAudienceDatafile
-        {
-            get
-            {
-                return typedAudienceDatafile ?? (typedAudienceDatafile =
-                    LoadJsonData("typed_audience_datafile.json"));
-            }
-        }
+        public static string TypedAudienceDatafile =>
+            typedAudienceDatafile ?? (typedAudienceDatafile =
+                LoadJsonData("typed_audience_datafile.json"));
 
-        public static string OdpSegmentsDatafile
-        {
-            get
-            {
-                return odpSegmentsDatafile ??
-                       (odpSegmentsDatafile = LoadJsonData("OdpSegmentsDatafile.json"));
-            }
-        }
+        public static string OdpSegmentsDatafile =>
+            odpSegmentsDatafile ??
+            (odpSegmentsDatafile = LoadJsonData("OdpSegmentsDatafile.json"));
 
         private static string LoadJsonData(string fileName = "TestData.json")
         {
             var assembly = Assembly.GetExecutingAssembly();
             var resourceName = string.Format("OptimizelySDK.Tests.{0}", fileName);
 
-            using (Stream stream = assembly.GetManifestResourceStream(resourceName))
-            using (StreamReader reader = new StreamReader(stream))
+            using (var stream = assembly.GetManifestResourceStream(resourceName))
+            using (var reader = new StreamReader(stream))
+            {
                 return reader.ReadToEnd();
+            }
         }
 
         public static bool CompareObjects(object o1, object o2)

--- a/OptimizelySDK.Tests/Utils/TestHttpProjectConfigManagerUtil.cs
+++ b/OptimizelySDK.Tests/Utils/TestHttpProjectConfigManagerUtil.cs
@@ -1,5 +1,4 @@
-﻿
-/*
+﻿/*
  * Copyright 2019-2020, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,21 +28,31 @@ namespace OptimizelySDK.Tests.Utils
     /// </summary>
     public static class TestHttpProjectConfigManagerUtil
     {
-        public static Task MockSendAsync(Mock<HttpProjectConfigManager.HttpClient> HttpClientMock, string datafile = null, TimeSpan? delay=null, HttpStatusCode statusCode = HttpStatusCode.OK)
+        public static Task MockSendAsync(Mock<HttpProjectConfigManager.HttpClient> HttpClientMock,
+            string datafile = null, TimeSpan? delay = null,
+            HttpStatusCode statusCode = HttpStatusCode.OK
+        )
         {
-            var t = new System.Threading.Tasks.TaskCompletionSource<bool>();
+            var t = new TaskCompletionSource<bool>();
 
-            HttpClientMock.Setup(_ => _.SendAsync(It.IsAny<System.Net.Http.HttpRequestMessage>()))
-                .Returns(() => {
-                    if (delay != null) {
+            HttpClientMock.Setup(_ => _.SendAsync(It.IsAny<HttpRequestMessage>())).
+                Returns(() =>
+                {
+                    if (delay != null)
+                    {
                         // This delay mocks the networking delay. And help to see the behavior when get a datafile with some delay.
                         Task.Delay(delay.Value).Wait();
                     }
-                    
-                    return System.Threading.Tasks.Task.FromResult<HttpResponseMessage>(new HttpResponseMessage { StatusCode = statusCode, Content = new StringContent(datafile ?? string.Empty) });
-                })
-                .Callback(()
-                => {
+
+                    return Task.FromResult<HttpResponseMessage>(new HttpResponseMessage
+                    {
+                        StatusCode = statusCode,
+                        Content = new StringContent(datafile ?? string.Empty),
+                    });
+                }).
+                Callback(()
+                    =>
+                {
                     t.SetResult(true);
                 });
 
@@ -61,6 +70,6 @@ namespace OptimizelySDK.Tests.Utils
                 System.Reflection.BindingFlags.Static |
                 System.Reflection.BindingFlags.NonPublic);
             field.SetValue(new object(), value);
-        }        
+        }
     }
 }

--- a/OptimizelySDK.Tests/UtilsTests/ConditionParserTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/ConditionParserTest.cs
@@ -24,18 +24,21 @@ namespace OptimizelySDK.Tests.UtilsTests
     [TestFixture]
     public class ConditionParserTest
     {
-        JToken Conditions;
-        JToken BaseCondition;
-        JToken AudienceConditions;
-        JToken NoOpAudienceConditions;
+        private JToken Conditions;
+        private JToken BaseCondition;
+        private JToken AudienceConditions;
+        private JToken NoOpAudienceConditions;
 
         [TestFixtureSetUp]
         public void Initialize()
         {
-            string conditionStr = @"[""and"", [""or"", [""or"", {""name"": ""device_type"", ""type"": ""custom_attribute"", ""value"": ""iPhone"", ""match"": ""substring""}]]]";
-            string baseConditionStr = @"{""name"": ""browser_type"", ""type"": ""custom_attribute"", ""value"": ""Chrome"", ""match"": ""exact""}";
-            string audienceConditionStr = @"[""or"", [""or"", ""3468206642"", ""3988293898""], [""or"", ""3988293899"", ""3468206646"", ""3468206647""]]";
-            string noOpAudienceConditionStr = @"[""3468206642"", ""3988293898""]";
+            var conditionStr =
+                @"[""and"", [""or"", [""or"", {""name"": ""device_type"", ""type"": ""custom_attribute"", ""value"": ""iPhone"", ""match"": ""substring""}]]]";
+            var baseConditionStr =
+                @"{""name"": ""browser_type"", ""type"": ""custom_attribute"", ""value"": ""Chrome"", ""match"": ""exact""}";
+            var audienceConditionStr =
+                @"[""or"", [""or"", ""3468206642"", ""3988293898""], [""or"", ""3988293899"", ""3468206646"", ""3468206647""]]";
+            var noOpAudienceConditionStr = @"[""3468206642"", ""3988293898""]";
 
             Conditions = JToken.Parse(conditionStr);
             BaseCondition = JToken.Parse(baseConditionStr);
@@ -80,7 +83,7 @@ namespace OptimizelySDK.Tests.UtilsTests
         [Test]
         public void TestParseConditionsAssignsNullConditionIfNoConditionIsProvidedInNotOperator()
         {
-            JToken emptyNotCondition = JToken.Parse(@"[""not""]");
+            var emptyNotCondition = JToken.Parse(@"[""not""]");
             var condition = ConditionParser.ParseConditions(emptyNotCondition);
             Assert.NotNull(condition);
             Assert.IsInstanceOf(typeof(NotCondition), condition);

--- a/OptimizelySDK.Tests/UtilsTests/EventTagUtilsTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/EventTagUtilsTest.cs
@@ -23,7 +23,7 @@ using System.Collections.Generic;
 namespace OptimizelySDK.Tests.UtilsTests
 {
     [TestFixture]
-    class EventTagUtilsTest
+    internal class EventTagUtilsTest
     {
         private Mock<ILogger> LoggerMock;
         private ILogger Logger;
@@ -43,28 +43,34 @@ namespace OptimizelySDK.Tests.UtilsTests
             var expectedValue = 42;
             var expectedValue2 = 100;
             var expectedValueString = 123;
-            var validTag = new Dictionary<string, object>() {
-                { "revenue", 42 }
+            var validTag = new Dictionary<string, object>()
+            {
+                { "revenue", 42 },
             };
-            var validTag2 = new Dictionary<string, object>() {
-                { "revenue", 100 }
+            var validTag2 = new Dictionary<string, object>()
+            {
+                { "revenue", 100 },
             };
-            var validTagStringValue = new Dictionary<string, object>() {
-                { "revenue", "123" }
+            var validTagStringValue = new Dictionary<string, object>()
+            {
+                { "revenue", "123" },
             };
 
-            var invalidTag = new Dictionary<string, object>() {
-                { "abc", 42 }
+            var invalidTag = new Dictionary<string, object>()
+            {
+                { "abc", 42 },
             };
-            var nullValue = new Dictionary<string, object>() {
-                { "revenue", null }
+            var nullValue = new Dictionary<string, object>()
+            {
+                { "revenue", null },
             };
-            var invalidValue = new Dictionary<string, object>() {
-                { "revenue", 42.5 }
+            var invalidValue = new Dictionary<string, object>()
+            {
+                { "revenue", 42.5 },
             };
             var invalidTagNonRevenue = new Dictionary<string, object>()
             {
-                {"non-revenue", 123 }
+                { "non-revenue", 123 },
             };
 
             // Invalid data.
@@ -75,50 +81,72 @@ namespace OptimizelySDK.Tests.UtilsTests
             Assert.Null(EventTagUtils.GetRevenueValue(invalidTagNonRevenue, Logger));
 
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Event tags is undefined."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "The revenue key is not defined in the event tags."), Times.Exactly(2));
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "The revenue key value is not defined in event tags."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Revenue value is not an integer or couldn't be parsed as an integer."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, "The revenue key is not defined in the event tags."),
+                Times.Exactly(2));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, "The revenue key value is not defined in event tags."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.ERROR,
+                    "Revenue value is not an integer or couldn't be parsed as an integer."),
+                Times.Once);
 
             // Valid data.
             Assert.AreEqual(EventTagUtils.GetRevenueValue(validTag, Logger), expectedValue);
             Assert.AreEqual(EventTagUtils.GetRevenueValue(validTag2, Logger), expectedValue2);
-            Assert.AreEqual(EventTagUtils.GetRevenueValue(validTagStringValue, Logger), expectedValueString);
+            Assert.AreEqual(EventTagUtils.GetRevenueValue(validTagStringValue, Logger),
+                expectedValueString);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, $"The revenue value {expectedValue} will be sent to results."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, $"The revenue value {expectedValue2} will be sent to results."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, $"The revenue value {expectedValueString} will be sent to results."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    $"The revenue value {expectedValue} will be sent to results."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    $"The revenue value {expectedValue2} will be sent to results."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    $"The revenue value {expectedValueString} will be sent to results."),
+                Times.Once);
         }
 
         [Test]
         public void TestGetEventValue()
         {
-            int expectedValue = 42;
-            float expectedValue2 = 42.5F;
-            double expectedValue3 = 42.52;
+            var expectedValue = 42;
+            var expectedValue2 = 42.5F;
+            var expectedValue3 = 42.52;
 
-            var validTag = new Dictionary<string, object>() {
-                { "value", 42 }
-            };
-
-            var validTag2 = new Dictionary<string, object>() {
-                { "value", 42.5 }
+            var validTag = new Dictionary<string, object>()
+            {
+                { "value", 42 },
             };
 
-            var validTag3 = new Dictionary<string, object>() {
-                { "value", 42.52 }
+            var validTag2 = new Dictionary<string, object>()
+            {
+                { "value", 42.5 },
             };
 
-            var invalidTag = new Dictionary<string, object>() {
-                { "abc", 42 }
+            var validTag3 = new Dictionary<string, object>()
+            {
+                { "value", 42.52 },
             };
-            var nullValue = new Dictionary<string, object>() {
-                { "value", null }
+
+            var invalidTag = new Dictionary<string, object>()
+            {
+                { "abc", 42 },
             };
-            var validTagStr = new Dictionary<string, object>() {
-                { "value", "42" }
+            var nullValue = new Dictionary<string, object>()
+            {
+                { "value", null },
             };
-            var validTagStr1 = new Dictionary<string, object>() {
-                { "value", "42.3" }
+            var validTagStr = new Dictionary<string, object>()
+            {
+                { "value", "42" },
+            };
+            var validTagStr1 = new Dictionary<string, object>()
+            {
+                { "value", "42.3" },
             };
 
             // Invalid data.
@@ -127,20 +155,36 @@ namespace OptimizelySDK.Tests.UtilsTests
             Assert.Null(EventTagUtils.GetNumericValue(nullValue, Logger));
 
             LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "Event tags is undefined."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "The numeric metric key is not in event tags."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "The numeric metric key value is not defined in event tags."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, "The numeric metric key is not in event tags."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    "The numeric metric key value is not defined in event tags."), Times.Once);
 
             // Valid data.
             Assert.AreEqual(42, EventTagUtils.GetNumericValue(validTagStr, Logger));
             Assert.AreEqual("42.3", EventTagUtils.GetNumericValue(validTagStr1, Logger).ToString());
             Assert.AreEqual(EventTagUtils.GetNumericValue(validTag, Logger), expectedValue);
             Assert.AreEqual(EventTagUtils.GetNumericValue(validTag2, Logger), expectedValue2);
-            Assert.AreEqual(EventTagUtils.GetNumericValue(validTag3, Logger).ToString(), expectedValue3.ToString());
-            
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The numeric metric value 42.3 will be sent to results."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, $"The numeric metric value {expectedValue} will be sent to results."), Times.Exactly(2));
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, $"The numeric metric value {expectedValue2} will be sent to results."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, $"The numeric metric value {expectedValue3} will be sent to results."), Times.Once);
+            Assert.AreEqual(EventTagUtils.GetNumericValue(validTag3, Logger).ToString(),
+                expectedValue3.ToString());
+
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO, "The numeric metric value 42.3 will be sent to results."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    $"The numeric metric value {expectedValue} will be sent to results."),
+                Times.Exactly(2));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    $"The numeric metric value {expectedValue2} will be sent to results."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    $"The numeric metric value {expectedValue3} will be sent to results."),
+                Times.Once);
         }
 
         [Test]
@@ -159,15 +203,20 @@ namespace OptimizelySDK.Tests.UtilsTests
             //Assert.IsNull(EventTagUtils.GetEventValue(False));
         }
 
-        
+
         [Test]
         public void TestGetNumericMetricNoValueTag()
         {
             // Test that numeric value is not returned when there's no numeric event tag.
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { }, Logger));
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "non-value", 42 } }, Logger));
+            Assert.IsNull(
+                EventTagUtils.GetNumericValue(new Dictionary<string, object> { }, Logger));
+            Assert.IsNull(
+                EventTagUtils.GetNumericValue(
+                    new Dictionary<string, object> { { "non-value", 42 } }, Logger));
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "The numeric metric key is not in event tags."), Times.Exactly(2));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, "The numeric metric key is not in event tags."),
+                Times.Exactly(2));
 
             //Errors for all, because it accepts only dictionary// 
             //Assert.IsNull(EventTagUtils.GetEventValue(new object[] { }));
@@ -176,71 +225,126 @@ namespace OptimizelySDK.Tests.UtilsTests
         [Test]
         public void TestGetNumericMetricInvalidValueTag()
         {
-            
             // Test that numeric value is not returned when revenue event tag has invalid data type.
 
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "non-value", null } }, Logger));
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "non-value",  0.5} }, Logger));
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "non-value",  12345} }, Logger));
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "non-value", "65536" } }, Logger));
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "non-value", true } }, Logger));
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "non-value", false } }, Logger));
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "non-value", new object[] { 1, 2, 3 } } }, Logger));
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "non-value", new object[] { 'a', 'b', 'c' } } }, Logger));
+            Assert.IsNull(
+                EventTagUtils.GetNumericValue(
+                    new Dictionary<string, object> { { "non-value", null } }, Logger));
+            Assert.IsNull(
+                EventTagUtils.GetNumericValue(
+                    new Dictionary<string, object> { { "non-value", 0.5 } }, Logger));
+            Assert.IsNull(EventTagUtils.GetNumericValue(
+                new Dictionary<string, object> { { "non-value", 12345 } }, Logger));
+            Assert.IsNull(EventTagUtils.GetNumericValue(
+                new Dictionary<string, object> { { "non-value", "65536" } }, Logger));
+            Assert.IsNull(
+                EventTagUtils.GetNumericValue(
+                    new Dictionary<string, object> { { "non-value", true } }, Logger));
+            Assert.IsNull(EventTagUtils.GetNumericValue(
+                new Dictionary<string, object> { { "non-value", false } }, Logger));
+            Assert.IsNull(EventTagUtils.GetNumericValue(
+                new Dictionary<string, object> { { "non-value", new object[] { 1, 2, 3 } } },
+                Logger));
+            Assert.IsNull(EventTagUtils.GetNumericValue(
+                new Dictionary<string, object> { { "non-value", new object[] { 'a', 'b', 'c' } } },
+                Logger));
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, "The numeric metric key is not in event tags."), Times.Exactly(8));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, "The numeric metric key is not in event tags."),
+                Times.Exactly(8));
         }
 
         [Test]
-
         public void TestGetNumericMetricValueTag()
         {
-
             // An integer should be cast to a float
-            Assert.AreEqual(12345.0, EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", 12345 } }, Logger));
+            Assert.AreEqual(12345.0,
+                EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", 12345 } },
+                    Logger));
 
             // A string should be cast to a float
-            Assert.AreEqual(12345.0, EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", "12345" } }, Logger));
-            
+            Assert.AreEqual(12345.0,
+                EventTagUtils.GetNumericValue(
+                    new Dictionary<string, object> { { "value", "12345" } }, Logger));
+
             // Valid float values
-            float someFloat = 1.2345F;
+            var someFloat = 1.2345F;
 
-            Assert.AreEqual(someFloat, EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", someFloat } }, Logger));
+            Assert.AreEqual(someFloat,
+                EventTagUtils.GetNumericValue(
+                    new Dictionary<string, object> { { "value", someFloat } }, Logger));
 
-            float maxFloat = float.MaxValue;
-            Assert.AreEqual(maxFloat, EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", maxFloat } }, Logger));
+            var maxFloat = float.MaxValue;
+            Assert.AreEqual(maxFloat,
+                EventTagUtils.GetNumericValue(
+                    new Dictionary<string, object> { { "value", maxFloat } }, Logger));
 
 
-            float minFloat = float.MinValue;
-            Assert.AreEqual(minFloat, EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", minFloat } }, Logger));
+            var minFloat = float.MinValue;
+            Assert.AreEqual(minFloat,
+                EventTagUtils.GetNumericValue(
+                    new Dictionary<string, object> { { "value", minFloat } }, Logger));
 
             // Invalid values
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", false } }, Logger));
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", null } }, Logger));
+            Assert.IsNull(
+                EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", false } },
+                    Logger));
+            Assert.IsNull(
+                EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", null } },
+                    Logger));
 
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", true } }, Logger));
-            Assert.IsNull(EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", new int[] { } } }, Logger));
+            Assert.IsNull(
+                EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", true } },
+                    Logger));
+            Assert.IsNull(EventTagUtils.GetNumericValue(
+                new Dictionary<string, object> { { "value", new int[] { } } }, Logger));
 
-            var numericValueArray = EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", new object[] { }} }, Logger);
-            Assert.IsNull(numericValueArray, string.Format("Array numeric value is {0}", numericValueArray));
+            var numericValueArray = EventTagUtils.GetNumericValue(
+                new Dictionary<string, object> { { "value", new object[] { } } }, Logger);
+            Assert.IsNull(numericValueArray,
+                string.Format("Array numeric value is {0}", numericValueArray));
 
 
-            var numericValueNone = EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", null } }, Logger);
-            Assert.IsNull(numericValueNone, string.Format("None numeric value is {0}", numericValueNone));
+            var numericValueNone =
+                EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", null } },
+                    Logger);
+            Assert.IsNull(numericValueNone,
+                string.Format("None numeric value is {0}", numericValueNone));
 
 
-            var numericValueOverflow = EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", float.MaxValue * 10 } }, Logger);
-            Assert.IsNull(numericValueOverflow, string.Format("Max numeric value is {0}", float.MaxValue * 10 ));
+            var numericValueOverflow = EventTagUtils.GetNumericValue(
+                new Dictionary<string, object> { { "value", float.MaxValue * 10 } }, Logger);
+            Assert.IsNull(numericValueOverflow,
+                string.Format("Max numeric value is {0}", float.MaxValue * 10));
 
-            Assert.AreEqual(0.0, EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", 0.0 } }, Logger));
+            Assert.AreEqual(0.0,
+                EventTagUtils.GetNumericValue(new Dictionary<string, object> { { "value", 0.0 } },
+                    Logger));
 
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The numeric metric value 12345 will be sent to results."), Times.Exactly(2));
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, $"The numeric metric value {maxFloat} will be sent to results."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, $"The numeric metric value {minFloat} will be sent to results."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, $"Provided numeric value {float.PositiveInfinity} is in an invalid format."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, "The numeric metric value 0 will be sent to results."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Provided numeric value is boolean which is an invalid format."), Times.Exactly(2));
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Numeric metric value is not in integer, float, or string form."), Times.Exactly(2));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    "The numeric metric value 12345 will be sent to results."), Times.Exactly(2));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    $"The numeric metric value {maxFloat} will be sent to results."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    $"The numeric metric value {minFloat} will be sent to results."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.ERROR,
+                    $"Provided numeric value {float.PositiveInfinity} is in an invalid format."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO, "The numeric metric value 0 will be sent to results."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.ERROR,
+                    "Provided numeric value is boolean which is an invalid format."),
+                Times.Exactly(2));
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.ERROR,
+                    "Numeric metric value is not in integer, float, or string form."),
+                Times.Exactly(2));
 
             /* Value is converted into 1234F */
             //var numericValueInvalidLiteral = EventTagUtils.GetEventValue(new Dictionary<string, object> { { "value", "1,234" } });
@@ -250,6 +354,5 @@ namespace OptimizelySDK.Tests.UtilsTests
             // float - inf is not possible.
             // float -inf is not possible.
         }
-
     }
 }

--- a/OptimizelySDK.Tests/UtilsTests/EventTagUtilsTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/EventTagUtilsTest.cs
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using Moq;
 using NUnit.Framework;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Utils;
-using System.Collections.Generic;
 
 namespace OptimizelySDK.Tests.UtilsTests
 {

--- a/OptimizelySDK.Tests/UtilsTests/ExceptionExtensionsTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/ExceptionExtensionsTest.cs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+using System;
 using NUnit.Framework;
 using OptimizelySDK.Utils;
-using System;
 
 namespace OptimizelySDK.Tests.UtilsTests
 {

--- a/OptimizelySDK.Tests/UtilsTests/ExceptionExtensionsTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/ExceptionExtensionsTest.cs
@@ -25,9 +25,11 @@ namespace OptimizelySDK.Tests.UtilsTests
         [Test]
         public void TestGetAllMessagesReturnsAllInnerExceptionMessages()
         {
-            var exception = new Exception("Outer exception.", new Exception("Inner exception.", new Exception("Second level inner exception.")));
-            var expectedMessage = "Outer exception.\nInner exception.\nSecond level inner exception.";
-            
+            var exception = new Exception("Outer exception.",
+                new Exception("Inner exception.", new Exception("Second level inner exception.")));
+            var expectedMessage =
+                "Outer exception.\nInner exception.\nSecond level inner exception.";
+
             Assert.AreEqual(expectedMessage, exception.GetAllMessages());
         }
     }

--- a/OptimizelySDK.Tests/UtilsTests/ExperimentUtilsTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/ExperimentUtilsTest.cs
@@ -49,25 +49,44 @@ namespace OptimizelySDK.Tests.UtilsTests
             experiment.AudienceIds = new string[] { };
             experiment.AudienceConditions = null;
 
-            Assert.True(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment, new UserAttributes().ToUserContext(), "experiment", experiment.Key, Logger).ResultObject);
+            Assert.True(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment,
+                    new UserAttributes().ToUserContext(), "experiment", experiment.Key, Logger).
+                ResultObject);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Evaluating audiences for experiment ""feat_with_var_test"": []."), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Evaluating audiences for experiment ""feat_with_var_test"": []."),
+                Times.Once);
         }
 
         [Test]
-        public void TestDoesUserMeetAudienceConditionsReturnsTrueWhenAudienceUsedInExperimentNoAttributesProvided()
+        public void
+            TestDoesUserMeetAudienceConditionsReturnsTrueWhenAudienceUsedInExperimentNoAttributesProvided()
         {
             var experiment = Config.GetExperimentFromKey("feat_with_var_test");
             experiment.AudienceIds = new string[] { "3468206648" };
-            
-            var boolResult = ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment, new UserAttributes { }.ToUserContext(), "experiment", experiment.Key, Logger);
+
+            var boolResult = ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment,
+                new UserAttributes { }.ToUserContext(), "experiment", experiment.Key, Logger);
             Assert.True(boolResult.ResultObject);
 
-            Assert.AreEqual(boolResult.DecisionReasons.ToReport(true)[0], "Audiences for experiment \"feat_with_var_test\" collectively evaluated to TRUE");
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Evaluating audiences for experiment ""feat_with_var_test"": [""3468206648""]."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3468206648"" with conditions: [""not"",{""name"":""input_value"",""type"":""custom_attribute"",""match"":""exists""}]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, $@"Audience ""3468206648"" evaluated to TRUE"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, @"Audiences for experiment ""feat_with_var_test"" collectively evaluated to TRUE"), Times.Once);
+            Assert.AreEqual(boolResult.DecisionReasons.ToReport(true)[0],
+                "Audiences for experiment \"feat_with_var_test\" collectively evaluated to TRUE");
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Evaluating audiences for experiment ""feat_with_var_test"": [""3468206648""]."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3468206648"" with conditions: [""not"",{""name"":""input_value"",""type"":""custom_attribute"",""match"":""exists""}]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, $@"Audience ""3468206648"" evaluated to TRUE"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    @"Audiences for experiment ""feat_with_var_test"" collectively evaluated to TRUE"),
+                Times.Once);
         }
 
         [Test]
@@ -78,25 +97,63 @@ namespace OptimizelySDK.Tests.UtilsTests
             {
                 { "house", "Ravenclaw" },
                 { "lasers", 50 },
-                { "should_do_it", false }
+                { "should_do_it", false },
             };
 
-            Assert.False(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment, userAttributes.ToUserContext(), "experiment", experiment.Key, Logger).ResultObject);
+            Assert.False(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment,
+                    userAttributes.ToUserContext(), "experiment", experiment.Key, Logger).
+                ResultObject);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Evaluating audiences for experiment ""feat_with_var_test"": [""3468206642"",""3988293898"",""3988293899"",""3468206646"",""3468206647"",""3468206644"",""3468206643""]."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3468206642"" with conditions: [""and"", [""or"", [""or"", {""name"": ""house"", ""type"": ""custom_attribute"", ""value"": ""Gryffindor""}]]]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience ""3468206642"" evaluated to FALSE"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3988293899"" with conditions: [""and"",[""or"",[""or"",{""name"":""favorite_ice_cream"",""type"":""custom_attribute"",""match"":""exists""}]]]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience ""3988293899"" evaluated to FALSE"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3468206646"" with conditions: [""and"",[""or"",[""or"",{""name"":""lasers"",""type"":""custom_attribute"",""match"":""exact"",""value"":45.5}]]]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience ""3468206646"" evaluated to FALSE"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3468206647"" with conditions: [""and"",[""or"",[""or"",{""name"":""lasers"",""type"":""custom_attribute"",""match"":""gt"",""value"":70}]]]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience ""3468206647"" evaluated to FALSE"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3468206644"" with conditions: [""and"",[""or"",[""or"",{""name"":""lasers"",""type"":""custom_attribute"",""match"":""lt"",""value"":1.0}]]]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience ""3468206644"" evaluated to FALSE"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3468206643"" with conditions: [""and"",[""or"",[""or"",{""name"":""should_do_it"",""type"":""custom_attribute"",""match"":""exact"",""value"":true}]]]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience ""3468206643"" evaluated to FALSE"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, @"Audiences for experiment ""feat_with_var_test"" collectively evaluated to FALSE"), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Evaluating audiences for experiment ""feat_with_var_test"": [""3468206642"",""3988293898"",""3988293899"",""3468206646"",""3468206647"",""3468206644"",""3468206643""]."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3468206642"" with conditions: [""and"", [""or"", [""or"", {""name"": ""house"", ""type"": ""custom_attribute"", ""value"": ""Gryffindor""}]]]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, @"Audience ""3468206642"" evaluated to FALSE"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3988293899"" with conditions: [""and"",[""or"",[""or"",{""name"":""favorite_ice_cream"",""type"":""custom_attribute"",""match"":""exists""}]]]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, @"Audience ""3988293899"" evaluated to FALSE"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3468206646"" with conditions: [""and"",[""or"",[""or"",{""name"":""lasers"",""type"":""custom_attribute"",""match"":""exact"",""value"":45.5}]]]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, @"Audience ""3468206646"" evaluated to FALSE"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3468206647"" with conditions: [""and"",[""or"",[""or"",{""name"":""lasers"",""type"":""custom_attribute"",""match"":""gt"",""value"":70}]]]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, @"Audience ""3468206647"" evaluated to FALSE"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3468206644"" with conditions: [""and"",[""or"",[""or"",{""name"":""lasers"",""type"":""custom_attribute"",""match"":""lt"",""value"":1.0}]]]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, @"Audience ""3468206644"" evaluated to FALSE"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3468206643"" with conditions: [""and"",[""or"",[""or"",{""name"":""should_do_it"",""type"":""custom_attribute"",""match"":""exact"",""value"":true}]]]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, @"Audience ""3468206643"" evaluated to FALSE"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    @"Audiences for experiment ""feat_with_var_test"" collectively evaluated to FALSE"),
+                Times.Once);
         }
 
         [Test]
@@ -107,15 +164,28 @@ namespace OptimizelySDK.Tests.UtilsTests
             {
                 { "house", "Gryffindor" },
                 { "lasers", 50 },
-                { "should_do_it", false }
+                { "should_do_it", false },
             };
 
-            Assert.True(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment, userAttributes.ToUserContext(), "experiment", experiment.Key, Logger).ResultObject);
+            Assert.True(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment,
+                    userAttributes.ToUserContext(), "experiment", experiment.Key, Logger).
+                ResultObject);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Evaluating audiences for experiment ""feat_with_var_test"": [""3468206642"",""3988293898"",""3988293899"",""3468206646"",""3468206647"",""3468206644"",""3468206643""]."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3468206642"" with conditions: [""and"", [""or"", [""or"", {""name"": ""house"", ""type"": ""custom_attribute"", ""value"": ""Gryffindor""}]]]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience ""3468206642"" evaluated to TRUE"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, @"Audiences for experiment ""feat_with_var_test"" collectively evaluated to TRUE"), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Evaluating audiences for experiment ""feat_with_var_test"": [""3468206642"",""3988293898"",""3988293899"",""3468206646"",""3468206647"",""3468206644"",""3468206643""]."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3468206642"" with conditions: [""and"", [""or"", [""or"", {""name"": ""house"", ""type"": ""custom_attribute"", ""value"": ""Gryffindor""}]]]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, @"Audience ""3468206642"" evaluated to TRUE"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    @"Audiences for experiment ""feat_with_var_test"" collectively evaluated to TRUE"),
+                Times.Once);
         }
 
         [Test]
@@ -125,65 +195,115 @@ namespace OptimizelySDK.Tests.UtilsTests
             var userAttributes = new UserAttributes
             {
                 { "house", "Gryffindor" },
-                { "favorite_ice_cream", "walls" }
+                { "favorite_ice_cream", "walls" },
             };
 
-            Assert.True(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment, userAttributes.ToUserContext(), "experiment", experiment.Key, Logger).ResultObject);
+            Assert.True(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment,
+                    userAttributes.ToUserContext(), "experiment", experiment.Key, Logger).
+                ResultObject);
         }
 
         [Test]
-        public void TestDoesUserMeetAudienceConditionsReturnsFalseIfAnyAudienceInANDConditionDoesNotPass()
+        public void
+            TestDoesUserMeetAudienceConditionsReturnsFalseIfAnyAudienceInANDConditionDoesNotPass()
         {
             var experiment = Config.GetExperimentFromKey("audience_combinations_experiment");
             var userAttributes = new UserAttributes
             {
                 { "house", "Gryffindor" },
-                { "lasers", 50 }
+                { "lasers", 50 },
             };
 
-            Assert.False(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment, userAttributes.ToUserContext(), "experiment", experiment.Key, Logger).ResultObject);
+            Assert.False(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment,
+                    userAttributes.ToUserContext(), "experiment", experiment.Key, Logger).
+                ResultObject);
 
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Evaluating audiences for experiment ""audience_combinations_experiment"": [""and"",[""or"",""3468206642"",""3988293898""],[""or"",""3988293899"",""3468206646"",""3468206647"",""3468206644"",""3468206643""]]."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3468206642"" with conditions: [""and"", [""or"", [""or"", {""name"": ""house"", ""type"": ""custom_attribute"", ""value"": ""Gryffindor""}]]]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience ""3468206642"" evaluated to TRUE"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3988293899"" with conditions: [""and"",[""or"",[""or"",{""name"":""favorite_ice_cream"",""type"":""custom_attribute"",""match"":""exists""}]]]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience ""3988293899"" evaluated to FALSE"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3468206646"" with conditions: [""and"",[""or"",[""or"",{""name"":""lasers"",""type"":""custom_attribute"",""match"":""exact"",""value"":45.5}]]]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience ""3468206646"" evaluated to FALSE"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3468206647"" with conditions: [""and"",[""or"",[""or"",{""name"":""lasers"",""type"":""custom_attribute"",""match"":""gt"",""value"":70}]]]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience ""3468206647"" evaluated to FALSE"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3468206644"" with conditions: [""and"",[""or"",[""or"",{""name"":""lasers"",""type"":""custom_attribute"",""match"":""lt"",""value"":1.0}]]]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience ""3468206644"" evaluated to FALSE"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Starting to evaluate audience ""3468206643"" with conditions: [""and"",[""or"",[""or"",{""name"":""should_do_it"",""type"":""custom_attribute"",""match"":""exact"",""value"":true}]]]"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""should_do_it"",""value"":true} evaluated to UNKNOWN because no value was passed for user attribute ""should_do_it""."), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.DEBUG, @"Audience ""3468206643"" evaluated to UNKNOWN"), Times.Once);
-            LoggerMock.Verify(l => l.Log(LogLevel.INFO, @"Audiences for experiment ""audience_combinations_experiment"" collectively evaluated to FALSE"), Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Evaluating audiences for experiment ""audience_combinations_experiment"": [""and"",[""or"",""3468206642"",""3988293898""],[""or"",""3988293899"",""3468206646"",""3468206647"",""3468206644"",""3468206643""]]."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3468206642"" with conditions: [""and"", [""or"", [""or"", {""name"": ""house"", ""type"": ""custom_attribute"", ""value"": ""Gryffindor""}]]]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, @"Audience ""3468206642"" evaluated to TRUE"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3988293899"" with conditions: [""and"",[""or"",[""or"",{""name"":""favorite_ice_cream"",""type"":""custom_attribute"",""match"":""exists""}]]]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, @"Audience ""3988293899"" evaluated to FALSE"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3468206646"" with conditions: [""and"",[""or"",[""or"",{""name"":""lasers"",""type"":""custom_attribute"",""match"":""exact"",""value"":45.5}]]]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, @"Audience ""3468206646"" evaluated to FALSE"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3468206647"" with conditions: [""and"",[""or"",[""or"",{""name"":""lasers"",""type"":""custom_attribute"",""match"":""gt"",""value"":70}]]]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, @"Audience ""3468206647"" evaluated to FALSE"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3468206644"" with conditions: [""and"",[""or"",[""or"",{""name"":""lasers"",""type"":""custom_attribute"",""match"":""lt"",""value"":1.0}]]]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, @"Audience ""3468206644"" evaluated to FALSE"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Starting to evaluate audience ""3468206643"" with conditions: [""and"",[""or"",[""or"",{""name"":""should_do_it"",""type"":""custom_attribute"",""match"":""exact"",""value"":true}]]]"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    @"Audience condition {""type"":""custom_attribute"",""match"":""exact"",""name"":""should_do_it"",""value"":true} evaluated to UNKNOWN because no value was passed for user attribute ""should_do_it""."),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.DEBUG, @"Audience ""3468206643"" evaluated to UNKNOWN"),
+                Times.Once);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.INFO,
+                    @"Audiences for experiment ""audience_combinations_experiment"" collectively evaluated to FALSE"),
+                Times.Once);
         }
 
         [Test]
-        public void TestDoesUserMeetAudienceConditionsReturnsTrueIfAudienceInNOTConditionDoesNotPass()
+        public void
+            TestDoesUserMeetAudienceConditionsReturnsTrueIfAudienceInNOTConditionDoesNotPass()
         {
             var experiment = Config.GetExperimentFromKey("feat_with_var_test");
             experiment.AudienceIds = new string[] { "3468206645" };
             var userAttributes = new UserAttributes
             {
-                { "browser_type", "Safari" }
+                { "browser_type", "Safari" },
             };
 
-            Assert.True(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment, userAttributes.ToUserContext(), "experiment", experiment.Key, Logger).ResultObject);
+            Assert.True(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment,
+                    userAttributes.ToUserContext(), "experiment", experiment.Key, Logger).
+                ResultObject);
         }
 
         [Test]
-        public void TestDoesUserMeetAudienceConditionsReturnsFalseIfAudienceInNOTConditionGetsPassed()
+        public void
+            TestDoesUserMeetAudienceConditionsReturnsFalseIfAudienceInNOTConditionGetsPassed()
         {
             var experiment = Config.GetExperimentFromKey("feat_with_var_test");
             experiment.AudienceIds = new string[] { "3468206645" };
             var userAttributes = new UserAttributes
             {
-                { "browser_type", "Chrome" }
+                { "browser_type", "Chrome" },
             };
 
-            Assert.False(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment, userAttributes.ToUserContext(), "experiment", experiment.Key, Logger).ResultObject);
+            Assert.False(ExperimentUtils.DoesUserMeetAudienceConditions(Config, experiment,
+                    userAttributes.ToUserContext(), "experiment", experiment.Key, Logger).
+                ResultObject);
         }
 
         #endregion // DoesUserMeetAudienceConditions Tests

--- a/OptimizelySDK.Tests/UtilsTests/PrivateObject.cs
+++ b/OptimizelySDK.Tests/UtilsTests/PrivateObject.cs
@@ -29,6 +29,7 @@ namespace OptimizelySDK.Tests.UtilsTests
             instanceType = privateObject;
             createdInstance = Activator.CreateInstance(instanceType, parameterValues);
         }
+
         private PrivateObject(Type privateObject, object[] parameterValues)
         {
             instanceType = privateObject;
@@ -37,26 +38,34 @@ namespace OptimizelySDK.Tests.UtilsTests
 
         public void SetFieldOrProperty(string propertyName, object value)
         {
-            instanceType.InvokeMember(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.SetProperty | BindingFlags.NonPublic | BindingFlags.SetField,
+            instanceType.InvokeMember(propertyName,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.SetProperty |
+                BindingFlags.NonPublic | BindingFlags.SetField,
                 Type.DefaultBinder, createdInstance, new object[] { value });
         }
 
         public Type GetFieldOrProperyType(string propertyName)
         {
-            return instanceType.GetField(propertyName, BindingFlags.NonPublic | BindingFlags.Instance).FieldType;
+            return instanceType.
+                GetField(propertyName, BindingFlags.NonPublic | BindingFlags.Instance).
+                FieldType;
         }
 
         public object Invoke(string name, params object[] args)
         {
-            return instanceType.InvokeMember(name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.InvokeMethod | BindingFlags.NonPublic,
+            return instanceType.InvokeMember(name,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.InvokeMethod |
+                BindingFlags.NonPublic,
                 Type.DefaultBinder, createdInstance, args);
         }
 
         public object InvokeGeneric(string name, Type[] genericTypes, params object[] args)
         {
-            MethodInfo method = instanceType.GetMethod(name);
-            MethodInfo genericMethod = method.MakeGenericMethod(genericTypes);
-            return genericMethod.Invoke(createdInstance, BindingFlags.Instance | BindingFlags.Public | BindingFlags.InvokeMethod | BindingFlags.NonPublic,
+            var method = instanceType.GetMethod(name);
+            var genericMethod = method.MakeGenericMethod(genericTypes);
+            return genericMethod.Invoke(createdInstance,
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.InvokeMethod |
+                BindingFlags.NonPublic,
                 Type.DefaultBinder, args, null);
         }
 

--- a/OptimizelySDK.Tests/UtilsTests/ValidatorTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/ValidatorTest.cs
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.ErrorHandler;
-using OptimizelySDK.Logger;
-using OptimizelySDK.Utils;
-using OptimizelySDK.Entity;
 using NUnit.Framework;
 using OptimizelySDK.Config;
+using OptimizelySDK.Entity;
+using OptimizelySDK.ErrorHandler;
+using OptimizelySDK.Logger;
 using OptimizelySDK.Tests.Utils;
+using OptimizelySDK.Utils;
 
 namespace OptimizelySDK.Tests.UtilsTests
 {

--- a/OptimizelySDK.Tests/UtilsTests/ValidatorTest.cs
+++ b/OptimizelySDK.Tests/UtilsTests/ValidatorTest.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Utils;
@@ -44,7 +45,10 @@ namespace OptimizelySDK.Tests.UtilsTests
         {
             Assert.IsTrue(Validator.ValidateJSONSchema(TestData.Datafile));
 
-            var testDataJSON = Newtonsoft.Json.JsonConvert.DeserializeObject<System.Collections.Generic.Dictionary<string, object>>(TestData.Datafile);
+            var testDataJSON =
+                Newtonsoft.Json.JsonConvert.
+                    DeserializeObject<System.Collections.Generic.Dictionary<string, object>>(
+                        TestData.Datafile);
             Assert.IsTrue(testDataJSON.ContainsKey("tempproperty"));
         }
 
@@ -82,15 +86,25 @@ namespace OptimizelySDK.Tests.UtilsTests
         [Test]
         public void TestDoesUserMeetAudienceConditionsNoAudienceUsedInExperiment()
         {
-            Assert.IsTrue(ExperimentUtils.DoesUserMeetAudienceConditions(Config, Config.GetExperimentFromKey("paused_experiment"), new UserAttributes().ToUserContext(), "experiment", "paused_experiment", Logger).ResultObject);
+            Assert.IsTrue(ExperimentUtils.DoesUserMeetAudienceConditions(Config,
+                    Config.GetExperimentFromKey("paused_experiment"),
+                    new UserAttributes().ToUserContext(), "experiment", "paused_experiment",
+                    Logger).
+                ResultObject);
         }
 
         [Test]
         public void TestDoesUserMeetAudienceConditionsAudienceUsedInExperimentNoAttributesProvided()
         {
-            Assert.IsFalse(ExperimentUtils.DoesUserMeetAudienceConditions(Config, Config.GetExperimentFromKey("test_experiment"), new UserAttributes().ToUserContext(), "experiment", "test_experiment", Logger).ResultObject);
+            Assert.IsFalse(ExperimentUtils.DoesUserMeetAudienceConditions(Config,
+                    Config.GetExperimentFromKey("test_experiment"),
+                    new UserAttributes().ToUserContext(), "experiment", "test_experiment", Logger).
+                ResultObject);
 
-            Assert.IsFalse(ExperimentUtils.DoesUserMeetAudienceConditions(Config, Config.GetExperimentFromKey("test_experiment"), null, "experiment", "test_experiment", Logger).ResultObject);
+            Assert.IsFalse(ExperimentUtils.DoesUserMeetAudienceConditions(Config,
+                    Config.GetExperimentFromKey("test_experiment"), null, "experiment",
+                    "test_experiment", Logger).
+                ResultObject);
         }
 
         [Test]
@@ -98,28 +112,37 @@ namespace OptimizelySDK.Tests.UtilsTests
         {
             var userAttributes = new UserAttributes
             {
-                {"device_type", "iPhone" },
-                {"location", "San Francisco" }
+                { "device_type", "iPhone" },
+                { "location", "San Francisco" },
             };
-            Assert.IsTrue(ExperimentUtils.DoesUserMeetAudienceConditions(Config, Config.GetExperimentFromKey("test_experiment"), userAttributes.ToUserContext(), "experiment", "test_experiment", Logger).ResultObject);
+            Assert.IsTrue(ExperimentUtils.DoesUserMeetAudienceConditions(Config,
+                    Config.GetExperimentFromKey("test_experiment"), userAttributes.ToUserContext(),
+                    "experiment", "test_experiment", Logger).
+                ResultObject);
         }
 
         [Test]
         public void TestDoesUserMeetAudienceConditionsAudienceNoMatch()
         {
-            Assert.IsFalse(ExperimentUtils.DoesUserMeetAudienceConditions(Config, Config.GetExperimentFromKey("test_experiment"), new UserAttributes().ToUserContext(), "experiment", "test_experiment", Logger).ResultObject);
+            Assert.IsFalse(ExperimentUtils.DoesUserMeetAudienceConditions(Config,
+                    Config.GetExperimentFromKey("test_experiment"),
+                    new UserAttributes().ToUserContext(), "experiment", "test_experiment", Logger).
+                ResultObject);
         }
 
         [Test]
         public void TestAreEventTagsValidValidEventTags()
         {
-            Assert.IsTrue(Validator.AreEventTagsValid(new System.Collections.Generic.Dictionary<string, object>()));
-            Assert.IsTrue(Validator.AreEventTagsValid(new System.Collections.Generic.Dictionary<string, object>
-            {
-                {"location", "San Francisco" },
-                {"browser", "Firefox" },
-                {"revenue", 0 }
-            }));
+            Assert.IsTrue(
+                Validator.AreEventTagsValid(
+                    new System.Collections.Generic.Dictionary<string, object>()));
+            Assert.IsTrue(Validator.AreEventTagsValid(
+                new System.Collections.Generic.Dictionary<string, object>
+                {
+                    { "location", "San Francisco" },
+                    { "browser", "Firefox" },
+                    { "revenue", 0 },
+                }));
         }
 
         [Test]
@@ -127,10 +150,11 @@ namespace OptimizelySDK.Tests.UtilsTests
         {
             // Some of the tests cases are not applicable because C# is strongly typed.
 
-            Assert.IsFalse(Validator.AreEventTagsValid(new System.Collections.Generic.Dictionary<string, object>
-            {
-                {"43",  "23"}
-            }));
+            Assert.IsFalse(Validator.AreEventTagsValid(
+                new System.Collections.Generic.Dictionary<string, object>
+                {
+                    { "43", "23" },
+                }));
         }
 
         [Test]
@@ -141,11 +165,13 @@ namespace OptimizelySDK.Tests.UtilsTests
                 { "device_type", "Android" },
                 { "is_firefox", true },
                 { "num_users", 15 },
-                { "pi_value", 3.14 }
+                { "pi_value", 3.14 },
             };
 
             foreach (var attribute in userAttributes)
+            {
                 Assert.True(Validator.IsUserAttributeValid(attribute));
+            }
         }
 
         [Test]
@@ -154,11 +180,13 @@ namespace OptimizelySDK.Tests.UtilsTests
             var invalidUserAttributes = new UserAttributes
             {
                 { "objects", new object() },
-                { "arrays", new string[] { "a", "b", "c" } }
+                { "arrays", new string[] { "a", "b", "c" } },
             };
 
             foreach (var attribute in invalidUserAttributes)
+            {
                 Assert.False(Validator.IsUserAttributeValid(attribute));
+            }
         }
 
         [Test]
@@ -168,11 +196,13 @@ namespace OptimizelySDK.Tests.UtilsTests
             {
                 { "", "Android" },
                 { "integer", 0 },
-                { "string", string.Empty }
+                { "string", string.Empty },
             };
 
             foreach (var attribute in validUserAttributes)
-                Assert.True(Validator.IsUserAttributeValid(attribute));    
+            {
+                Assert.True(Validator.IsUserAttributeValid(attribute));
+            }
         }
     }
 }

--- a/OptimizelySDK.Tests/ValidEventDispatcher.cs
+++ b/OptimizelySDK.Tests/ValidEventDispatcher.cs
@@ -13,16 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using OptimizelySDK.Event.Dispatcher;
 using OptimizelySDK.Logger;
 
 namespace OptimizelySDK.Tests
 {
-    class ValidEventDispatcher : IEventDispatcher
+    internal class ValidEventDispatcher : IEventDispatcher
     {
         public ILogger Logger { get; set; }
-        public void DispatchEvent(Event.LogEvent logEvent)
-        {
-        }
+        public void DispatchEvent(Event.LogEvent logEvent) { }
     }
 }

--- a/OptimizelySDK.Tests/packages.config
+++ b/OptimizelySDK.Tests/packages.config
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.0.0" targetFramework="net45" />
-  <package id="Moq" version="4.7.1" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45" />
-  <package id="OpenCover" version="4.6.519" targetFramework="net45" />
-  <package id="ReportGenerator" version="2.5.6" targetFramework="net45" />
+  <package id="Castle.Core" version="4.0.0" targetFramework="net45"/>
+  <package id="Moq" version="4.7.1" targetFramework="net45"/>
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45"/>
+  <package id="NUnit" version="2.6.4" targetFramework="net45"/>
+  <package id="NUnitTestAdapter" version="2.1.1" targetFramework="net45"/>
+  <package id="OpenCover" version="4.6.519" targetFramework="net45"/>
+  <package id="ReportGenerator" version="2.5.6" targetFramework="net45"/>
 </packages>

--- a/OptimizelySDK.Tests/similar_exp_keys.json
+++ b/OptimizelySDK.Tests/similar_exp_keys.json
@@ -46,14 +46,18 @@
   "variables": [],
   "featureFlags": [
     {
-      "experimentIds": ["9300000007569"],
+      "experimentIds": [
+        "9300000007569"
+      ],
       "rolloutId": "",
       "variables": [],
       "id": "3045",
       "key": "flag1"
     },
     {
-      "experimentIds": ["9300000007573"],
+      "experimentIds": [
+        "9300000007573"
+      ],
       "rolloutId": "",
       "variables": [],
       "id": "3046",
@@ -63,8 +67,13 @@
   "experiments": [
     {
       "status": "Running",
-      "audienceConditions": ["or", "20415611520"],
-      "audienceIds": ["20415611520"],
+      "audienceConditions": [
+        "or",
+        "20415611520"
+      ],
+      "audienceIds": [
+        "20415611520"
+      ],
       "variations": [
         {
           "variables": [],
@@ -76,13 +85,23 @@
       "forcedVariations": {},
       "key": "targeted_delivery",
       "layerId": "9300000007569",
-      "trafficAllocation": [{ "entityId": "8045", "endOfRange": 10000 }],
+      "trafficAllocation": [
+        {
+          "entityId": "8045",
+          "endOfRange": 10000
+        }
+      ],
       "id": "9300000007569"
     },
     {
       "status": "Running",
-      "audienceConditions": ["or", "20406066925"],
-      "audienceIds": ["20406066925"],
+      "audienceConditions": [
+        "or",
+        "20406066925"
+      ],
+      "audienceIds": [
+        "20406066925"
+      ],
       "variations": [
         {
           "variables": [],
@@ -94,7 +113,12 @@
       "forcedVariations": {},
       "key": "targeted_delivery",
       "layerId": "9300000007573",
-      "trafficAllocation": [{ "entityId": "8048", "endOfRange": 10000 }],
+      "trafficAllocation": [
+        {
+          "entityId": "8048",
+          "endOfRange": 10000
+        }
+      ],
       "id": "9300000007573"
     }
   ],
@@ -116,7 +140,12 @@
     }
   ],
   "groups": [],
-  "attributes": [{ "id": "20408641883", "key": "hiddenLiveEnabled" }],
+  "attributes": [
+    {
+      "id": "20408641883",
+      "key": "hiddenLiveEnabled"
+    }
+  ],
   "botFiltering": false,
   "accountId": "17882702980",
   "events": [],

--- a/OptimizelySDK.Tests/similar_rule_keys_bucketing.json
+++ b/OptimizelySDK.Tests/similar_rule_keys_bucketing.json
@@ -18,7 +18,12 @@
           "forcedVariations": {},
           "key": "targeted_delivery",
           "layerId": "9300000004981",
-          "trafficAllocation": [{ "entityId": "5452", "endOfRange": 10000 }],
+          "trafficAllocation": [
+            {
+              "entityId": "5452",
+              "endOfRange": 10000
+            }
+          ],
           "id": "9300000004981"
         },
         {
@@ -36,7 +41,12 @@
           "forcedVariations": {},
           "key": "default-rollout-2029-20301771717",
           "layerId": "default-layer-rollout-2029-20301771717",
-          "trafficAllocation": [{ "entityId": "5451", "endOfRange": 10000 }],
+          "trafficAllocation": [
+            {
+              "entityId": "5451",
+              "endOfRange": 10000
+            }
+          ],
           "id": "default-rollout-2029-20301771717"
         }
       ],
@@ -59,7 +69,12 @@
           "forcedVariations": {},
           "key": "targeted_delivery",
           "layerId": "9300000004979",
-          "trafficAllocation": [{ "entityId": "5450", "endOfRange": 10000 }],
+          "trafficAllocation": [
+            {
+              "entityId": "5450",
+              "endOfRange": 10000
+            }
+          ],
           "id": "9300000004979"
         },
         {
@@ -77,7 +92,12 @@
           "forcedVariations": {},
           "key": "default-rollout-2028-20301771717",
           "layerId": "default-layer-rollout-2028-20301771717",
-          "trafficAllocation": [{ "entityId": "5449", "endOfRange": 10000 }],
+          "trafficAllocation": [
+            {
+              "entityId": "5449",
+              "endOfRange": 10000
+            }
+          ],
           "id": "default-rollout-2028-20301771717"
         }
       ],
@@ -100,7 +120,12 @@
           "forcedVariations": {},
           "key": "targeted_delivery",
           "layerId": "9300000004977",
-          "trafficAllocation": [{ "entityId": "5448", "endOfRange": 10000 }],
+          "trafficAllocation": [
+            {
+              "entityId": "5448",
+              "endOfRange": 10000
+            }
+          ],
           "id": "9300000004977"
         },
         {
@@ -118,7 +143,12 @@
           "forcedVariations": {},
           "key": "default-rollout-2027-20301771717",
           "layerId": "default-layer-rollout-2027-20301771717",
-          "trafficAllocation": [{ "entityId": "5447", "endOfRange": 10000 }],
+          "trafficAllocation": [
+            {
+              "entityId": "5447",
+              "endOfRange": 10000
+            }
+          ],
           "id": "default-rollout-2027-20301771717"
         }
       ],

--- a/OptimizelySDK.Tests/typed_audience_datafile.json
+++ b/OptimizelySDK.Tests/typed_audience_datafile.json
@@ -1,379 +1,561 @@
 {
-	"version": "4",
-	"rollouts": [{
-			"experiments": [{
-				"status": "Running",
-				"key": "feat_no_vars_rule",
-				"layerId": "11551226731",
-				"trafficAllocation": [{
-					"entityId": "11557362669",
-					"endOfRange": 10000
-				}],
-				"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
-				"variations": [{
-					"variables": [],
-					"id": "11557362669",
-					"key": "11557362669",
-					"featureEnabled": true
-				}],
-				"forcedVariations": {},
-				"id": "11488548027"
-			}],
-			"id": "11551226731"
-		},
-		{
-			"experiments": [{
-				"status": "Paused",
-				"key": "feat_with_var_rule",
-				"layerId": "11638870867",
-				"trafficAllocation": [{
-					"entityId": "11475708558",
-					"endOfRange": 0
-				}],
-				"audienceIds": [],
-				"variations": [{
-					"variables": [],
-					"id": "11475708558",
-					"key": "11475708558",
-					"featureEnabled": false
-				}],
-				"forcedVariations": {},
-				"id": "11630490911"
-			}],
-			"id": "11638870867"
-		},
-		{
-			"experiments": [{
-				"status": "Running",
-				"key": "11488548028",
-				"layerId": "11551226732",
-				"trafficAllocation": [{
-					"entityId": "11557362670",
-					"endOfRange": 10000
-				}],
-				"audienceIds": ["0"],
-				"audienceConditions": ["and", ["or", "3468206642", "3988293898"],
-					["or", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"]
-				],
-				"variations": [{
-					"variables": [],
-					"id": "11557362670",
-					"key": "11557362670",
-					"featureEnabled": true
-				}],
-				"forcedVariations": {},
-				"id": "11488548028"
-			}],
-			"id": "11551226732"
-		},
-		{
-			"experiments": [{
-				"status": "Paused",
-				"key": "11630490912",
-				"layerId": "11638870868",
-				"trafficAllocation": [{
-					"entityId": "11475708559",
-					"endOfRange": 0
-				}],
-				"audienceIds": [],
-				"variations": [{
-					"variables": [],
-					"id": "11475708559",
-					"key": "11475708559",
-					"featureEnabled": false
-				}],
-				"forcedVariations": {},
-				"id": "11630490912"
-			}],
-			"id": "11638870868"
-		}
-	],
-	"anonymizeIP": false,
-	"projectId": "11624721371",
-	"variables": [],
-	"featureFlags": [{
-			"experimentIds": [],
-			"rolloutId": "11551226731",
-			"variables": [],
-			"id": "11477755619",
-			"key": "feat_no_vars"
-		},
-		{
-			"experimentIds": [
-				"11564051718"
-			],
-			"rolloutId": "11638870867",
-			"variables": [{
-				"defaultValue": "x",
-				"type": "string",
-				"id": "11535264366",
-				"key": "x"
-			}],
-			"id": "11567102051",
-			"key": "feat_with_var"
-		},
-		{
-			"experimentIds": [],
-			"rolloutId": "11551226732",
-			"variables": [],
-			"id": "11567102052",
-			"key": "feat2"
-		},
-		{
-			"experimentIds": ["1323241599"],
-			"rolloutId": "11638870868",
-			"variables": [{
-				"defaultValue": "10",
-				"type": "integer",
-				"id": "11535264367",
-				"key": "z"
-			}],
-			"id": "11567102053",
-			"key": "feat2_with_var"
-		}
-	],
-	"experiments": [{
-			"status": "Running",
-			"key": "feat_with_var_test",
-			"layerId": "11504144555",
-			"trafficAllocation": [{
-				"entityId": "11617170975",
-				"endOfRange": 10000
-			}],
-			"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
-			"variations": [{
-				"variables": [{
-					"id": "11535264366",
-					"value": "xyz"
-				}],
-				"id": "11617170975",
-				"key": "variation_2",
-				"featureEnabled": true
-			}],
-			"forcedVariations": {},
-			"id": "11564051718"
-		},
-		{
-			"id": "1323241597",
-			"key": "typed_audience_experiment",
-			"layerId": "1630555627",
-			"status": "Running",
-			"variations": [{
-				"id": "1423767503",
-				"key": "A",
-				"variables": []
-			}],
-			"trafficAllocation": [{
-				"entityId": "1423767503",
-				"endOfRange": 10000
-			}],
-			"audienceIds": ["3468206642", "3988293898", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"],
-			"forcedVariations": {}
-		},
-		{
-			"id": "1323241598",
-			"key": "audience_combinations_experiment",
-			"layerId": "1323241598",
-			"status": "Running",
-			"variations": [{
-				"id": "1423767504",
-				"key": "A",
-				"variables": []
-			}],
-			"trafficAllocation": [{
-				"entityId": "1423767504",
-				"endOfRange": 10000
-			}],
-			"audienceIds": ["0"],
-			"audienceConditions": ["and", ["or", "3468206642", "3988293898"],
-				["or", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"]
-			],
-			"forcedVariations": {}
-		},
-		{
-			"id": "1323241599",
-			"key": "feat2_with_var_test",
-			"layerId": "1323241600",
-			"status": "Running",
-			"variations": [{
-				"variables": [{
-					"id": "11535264367",
-					"value": "150"
-				}],
-				"id": "1423767505",
-				"key": "variation_2",
-				"featureEnabled": true
-			}],
-			"trafficAllocation": [{
-				"entityId": "1423767505",
-				"endOfRange": 10000
-			}],
-			"audienceIds": ["0"],
-			"audienceConditions": ["and", ["or", "3468206642", "3988293898"],
-				["or", "3988293899", "3468206646", "3468206647", "3468206644", "3468206643"]
-			],
-			"forcedVariations": {}
-		}
-	],
-	"audiences": [
-		{
-			"id": "3468206642",
-			"name": "exactString",
-			"conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"house\", \"type\": \"custom_attribute\", \"value\": \"Gryffindor\"}]]]"
-		},
-		{
-			"id": "3468206645",
-			"name": "notChrome",
-			"conditions": "[\"and\", [\"or\", [\"not\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\":\"Chrome\"}]]]]"
-		},
-		{
-			"id": "3988293898",
-			"name": "$$dummySubstringString",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3988293899",
-			"name": "$$dummyExists",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3468206646",
-			"name": "$$dummyExactNumber",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3468206647",
-			"name": "$$dummyGtNumber",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3468206644",
-			"name": "$$dummyLtNumber",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "3468206643",
-			"name": "$$dummyExactBoolean",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "0",
-			"name": "$$dummy",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		},
-		{
-			"id": "$opt_dummy_audience",
-			"name": "dummy_audience",
-			"conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
-		}
-	],
-	"typedAudiences": [{
-			"id": "3988293898",
-			"name": "substringString",
-			"conditions": ["and", ["or", ["or", {
-				"name": "house",
-				"type": "custom_attribute",
-				"match": "substring",
-				"value": "Slytherin"
-			}]]]
-		},
-		{
-			"id": "3988293899",
-			"name": "exists",
-			"conditions": ["and", ["or", ["or", {
-				"name": "favorite_ice_cream",
-				"type": "custom_attribute",
-				"match": "exists"
-			}]]]
-		},
-		{
-			"id": "3468206646",
-			"name": "exactNumber",
-			"conditions": ["and", ["or", ["or", {
-				"name": "lasers",
-				"type": "custom_attribute",
-				"match": "exact",
-				"value": 45.5
-			}]]]
-		},
-		{
-			"id": "3468206647",
-			"name": "gtNumber",
-			"conditions": ["and", ["or", ["or", {
-				"name": "lasers",
-				"type": "custom_attribute",
-				"match": "gt",
-				"value": 70
-			}]]]
-		},
-		{
-			"id": "3468206644",
-			"name": "ltNumber",
-			"conditions": ["and", ["or", ["or", {
-				"name": "lasers",
-				"type": "custom_attribute",
-				"match": "lt",
-				"value": 1.0
-			}]]]
-		},
-		{
-			"id": "3468206643",
-			"name": "exactBoolean",
-			"conditions": ["and", ["or", ["or", {
-				"name": "should_do_it",
-				"type": "custom_attribute",
-				"match": "exact",
-				"value": true
-			}]]]
-		},
-		{
-			"id": "3468206648",
-			"name": "notExist",
-			"conditions": ["not", {
-				"name": "input_value",
-				"type": "custom_attribute",
-				"match": "exists"
-			}]
-		}
-	],
-	"groups": [],
-	"attributes": [{
-			"key": "house",
-			"id": "594015"
-		},
-		{
-			"key": "lasers",
-			"id": "594016"
-		},
-		{
-			"key": "should_do_it",
-			"id": "594017"
-		},
-		{
-			"key": "favorite_ice_cream",
-			"id": "594018"
-		}
-	],
-	"botFiltering": false,
-	"accountId": "4879520872",
-	"events": [{
-			"key": "item_bought",
-			"id": "594089",
-			"experimentIds": [
-				"11564051718",
-				"1323241597"
-			]
-		},
-		{
-			"key": "user_signed_up",
-			"id": "594090",
-			"experimentIds": [
-				"1323241598",
-				"1323241599"
-			]
-		}
-	],
-	"revision": "3",
-	"sdkKey": "typedAudienceDatafile",
-	"environmentKey": "Production"
+  "version": "4",
+  "rollouts": [
+    {
+      "experiments": [
+        {
+          "status": "Running",
+          "key": "feat_no_vars_rule",
+          "layerId": "11551226731",
+          "trafficAllocation": [
+            {
+              "entityId": "11557362669",
+              "endOfRange": 10000
+            }
+          ],
+          "audienceIds": [
+            "3468206642",
+            "3988293898",
+            "3988293899",
+            "3468206646",
+            "3468206647",
+            "3468206644",
+            "3468206643"
+          ],
+          "variations": [
+            {
+              "variables": [],
+              "id": "11557362669",
+              "key": "11557362669",
+              "featureEnabled": true
+            }
+          ],
+          "forcedVariations": {},
+          "id": "11488548027"
+        }
+      ],
+      "id": "11551226731"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Paused",
+          "key": "feat_with_var_rule",
+          "layerId": "11638870867",
+          "trafficAllocation": [
+            {
+              "entityId": "11475708558",
+              "endOfRange": 0
+            }
+          ],
+          "audienceIds": [],
+          "variations": [
+            {
+              "variables": [],
+              "id": "11475708558",
+              "key": "11475708558",
+              "featureEnabled": false
+            }
+          ],
+          "forcedVariations": {},
+          "id": "11630490911"
+        }
+      ],
+      "id": "11638870867"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Running",
+          "key": "11488548028",
+          "layerId": "11551226732",
+          "trafficAllocation": [
+            {
+              "entityId": "11557362670",
+              "endOfRange": 10000
+            }
+          ],
+          "audienceIds": [
+            "0"
+          ],
+          "audienceConditions": [
+            "and",
+            [
+              "or",
+              "3468206642",
+              "3988293898"
+            ],
+            [
+              "or",
+              "3988293899",
+              "3468206646",
+              "3468206647",
+              "3468206644",
+              "3468206643"
+            ]
+          ],
+          "variations": [
+            {
+              "variables": [],
+              "id": "11557362670",
+              "key": "11557362670",
+              "featureEnabled": true
+            }
+          ],
+          "forcedVariations": {},
+          "id": "11488548028"
+        }
+      ],
+      "id": "11551226732"
+    },
+    {
+      "experiments": [
+        {
+          "status": "Paused",
+          "key": "11630490912",
+          "layerId": "11638870868",
+          "trafficAllocation": [
+            {
+              "entityId": "11475708559",
+              "endOfRange": 0
+            }
+          ],
+          "audienceIds": [],
+          "variations": [
+            {
+              "variables": [],
+              "id": "11475708559",
+              "key": "11475708559",
+              "featureEnabled": false
+            }
+          ],
+          "forcedVariations": {},
+          "id": "11630490912"
+        }
+      ],
+      "id": "11638870868"
+    }
+  ],
+  "anonymizeIP": false,
+  "projectId": "11624721371",
+  "variables": [],
+  "featureFlags": [
+    {
+      "experimentIds": [],
+      "rolloutId": "11551226731",
+      "variables": [],
+      "id": "11477755619",
+      "key": "feat_no_vars"
+    },
+    {
+      "experimentIds": [
+        "11564051718"
+      ],
+      "rolloutId": "11638870867",
+      "variables": [
+        {
+          "defaultValue": "x",
+          "type": "string",
+          "id": "11535264366",
+          "key": "x"
+        }
+      ],
+      "id": "11567102051",
+      "key": "feat_with_var"
+    },
+    {
+      "experimentIds": [],
+      "rolloutId": "11551226732",
+      "variables": [],
+      "id": "11567102052",
+      "key": "feat2"
+    },
+    {
+      "experimentIds": [
+        "1323241599"
+      ],
+      "rolloutId": "11638870868",
+      "variables": [
+        {
+          "defaultValue": "10",
+          "type": "integer",
+          "id": "11535264367",
+          "key": "z"
+        }
+      ],
+      "id": "11567102053",
+      "key": "feat2_with_var"
+    }
+  ],
+  "experiments": [
+    {
+      "status": "Running",
+      "key": "feat_with_var_test",
+      "layerId": "11504144555",
+      "trafficAllocation": [
+        {
+          "entityId": "11617170975",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [
+        "3468206642",
+        "3988293898",
+        "3988293899",
+        "3468206646",
+        "3468206647",
+        "3468206644",
+        "3468206643"
+      ],
+      "variations": [
+        {
+          "variables": [
+            {
+              "id": "11535264366",
+              "value": "xyz"
+            }
+          ],
+          "id": "11617170975",
+          "key": "variation_2",
+          "featureEnabled": true
+        }
+      ],
+      "forcedVariations": {},
+      "id": "11564051718"
+    },
+    {
+      "id": "1323241597",
+      "key": "typed_audience_experiment",
+      "layerId": "1630555627",
+      "status": "Running",
+      "variations": [
+        {
+          "id": "1423767503",
+          "key": "A",
+          "variables": []
+        }
+      ],
+      "trafficAllocation": [
+        {
+          "entityId": "1423767503",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [
+        "3468206642",
+        "3988293898",
+        "3988293899",
+        "3468206646",
+        "3468206647",
+        "3468206644",
+        "3468206643"
+      ],
+      "forcedVariations": {}
+    },
+    {
+      "id": "1323241598",
+      "key": "audience_combinations_experiment",
+      "layerId": "1323241598",
+      "status": "Running",
+      "variations": [
+        {
+          "id": "1423767504",
+          "key": "A",
+          "variables": []
+        }
+      ],
+      "trafficAllocation": [
+        {
+          "entityId": "1423767504",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [
+        "0"
+      ],
+      "audienceConditions": [
+        "and",
+        [
+          "or",
+          "3468206642",
+          "3988293898"
+        ],
+        [
+          "or",
+          "3988293899",
+          "3468206646",
+          "3468206647",
+          "3468206644",
+          "3468206643"
+        ]
+      ],
+      "forcedVariations": {}
+    },
+    {
+      "id": "1323241599",
+      "key": "feat2_with_var_test",
+      "layerId": "1323241600",
+      "status": "Running",
+      "variations": [
+        {
+          "variables": [
+            {
+              "id": "11535264367",
+              "value": "150"
+            }
+          ],
+          "id": "1423767505",
+          "key": "variation_2",
+          "featureEnabled": true
+        }
+      ],
+      "trafficAllocation": [
+        {
+          "entityId": "1423767505",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [
+        "0"
+      ],
+      "audienceConditions": [
+        "and",
+        [
+          "or",
+          "3468206642",
+          "3988293898"
+        ],
+        [
+          "or",
+          "3988293899",
+          "3468206646",
+          "3468206647",
+          "3468206644",
+          "3468206643"
+        ]
+      ],
+      "forcedVariations": {}
+    }
+  ],
+  "audiences": [
+    {
+      "id": "3468206642",
+      "name": "exactString",
+      "conditions": "[\"and\", [\"or\", [\"or\", {\"name\": \"house\", \"type\": \"custom_attribute\", \"value\": \"Gryffindor\"}]]]"
+    },
+    {
+      "id": "3468206645",
+      "name": "notChrome",
+      "conditions": "[\"and\", [\"or\", [\"not\", [\"or\", {\"name\": \"browser_type\", \"type\": \"custom_attribute\", \"value\":\"Chrome\"}]]]]"
+    },
+    {
+      "id": "3988293898",
+      "name": "$$dummySubstringString",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3988293899",
+      "name": "$$dummyExists",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3468206646",
+      "name": "$$dummyExactNumber",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3468206647",
+      "name": "$$dummyGtNumber",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3468206644",
+      "name": "$$dummyLtNumber",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "3468206643",
+      "name": "$$dummyExactBoolean",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "0",
+      "name": "$$dummy",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    },
+    {
+      "id": "$opt_dummy_audience",
+      "name": "dummy_audience",
+      "conditions": "{\"type\": \"custom_attribute\", \"name\": \"$opt_dummy_attribute\", \"value\": \"impossible_value\"}"
+    }
+  ],
+  "typedAudiences": [
+    {
+      "id": "3988293898",
+      "name": "substringString",
+      "conditions": [
+        "and",
+        [
+          "or",
+          [
+            "or",
+            {
+              "name": "house",
+              "type": "custom_attribute",
+              "match": "substring",
+              "value": "Slytherin"
+            }
+          ]
+        ]
+      ]
+    },
+    {
+      "id": "3988293899",
+      "name": "exists",
+      "conditions": [
+        "and",
+        [
+          "or",
+          [
+            "or",
+            {
+              "name": "favorite_ice_cream",
+              "type": "custom_attribute",
+              "match": "exists"
+            }
+          ]
+        ]
+      ]
+    },
+    {
+      "id": "3468206646",
+      "name": "exactNumber",
+      "conditions": [
+        "and",
+        [
+          "or",
+          [
+            "or",
+            {
+              "name": "lasers",
+              "type": "custom_attribute",
+              "match": "exact",
+              "value": 45.5
+            }
+          ]
+        ]
+      ]
+    },
+    {
+      "id": "3468206647",
+      "name": "gtNumber",
+      "conditions": [
+        "and",
+        [
+          "or",
+          [
+            "or",
+            {
+              "name": "lasers",
+              "type": "custom_attribute",
+              "match": "gt",
+              "value": 70
+            }
+          ]
+        ]
+      ]
+    },
+    {
+      "id": "3468206644",
+      "name": "ltNumber",
+      "conditions": [
+        "and",
+        [
+          "or",
+          [
+            "or",
+            {
+              "name": "lasers",
+              "type": "custom_attribute",
+              "match": "lt",
+              "value": 1.0
+            }
+          ]
+        ]
+      ]
+    },
+    {
+      "id": "3468206643",
+      "name": "exactBoolean",
+      "conditions": [
+        "and",
+        [
+          "or",
+          [
+            "or",
+            {
+              "name": "should_do_it",
+              "type": "custom_attribute",
+              "match": "exact",
+              "value": true
+            }
+          ]
+        ]
+      ]
+    },
+    {
+      "id": "3468206648",
+      "name": "notExist",
+      "conditions": [
+        "not",
+        {
+          "name": "input_value",
+          "type": "custom_attribute",
+          "match": "exists"
+        }
+      ]
+    }
+  ],
+  "groups": [],
+  "attributes": [
+    {
+      "key": "house",
+      "id": "594015"
+    },
+    {
+      "key": "lasers",
+      "id": "594016"
+    },
+    {
+      "key": "should_do_it",
+      "id": "594017"
+    },
+    {
+      "key": "favorite_ice_cream",
+      "id": "594018"
+    }
+  ],
+  "botFiltering": false,
+  "accountId": "4879520872",
+  "events": [
+    {
+      "key": "item_bought",
+      "id": "594089",
+      "experimentIds": [
+        "11564051718",
+        "1323241597"
+      ]
+    },
+    {
+      "key": "user_signed_up",
+      "id": "594090",
+      "experimentIds": [
+        "1323241598",
+        "1323241599"
+      ]
+    }
+  ],
+  "revision": "3",
+  "sdkKey": "typedAudienceDatafile",
+  "environmentKey": "Production"
 }

--- a/OptimizelySDK.Tests/unsupported_version_datafile.json
+++ b/OptimizelySDK.Tests/unsupported_version_datafile.json
@@ -1,42 +1,49 @@
 {
-	"version": "5",
-	"rollouts": [],
-	"projectId": "10431130345",
-	"variables": [],
-	"featureFlags": [],
-	"experiments": [{
-		"status": "Running",
-		"key": "ab_running_exp_untargeted",
-		"layerId": "10417730432",
-		"trafficAllocation": [{
-			"entityId": "10418551353",
-			"endOfRange": 10000
-		}],
-		"audienceIds": [],
-		"variations": [{
-				"variables": [],
-				"id": "10418551353",
-				"key": "all_traffic_variation"
-			},
-			{
-				"variables": [],
-				"id": "10418510624",
-				"key": "no_traffic_variation"
-			}
-		],
-		"forcedVariations": {},
-		"id": "10420810910"
-	}],
-	"audiences": [],
-	"groups": [],
-	"attributes": [],
-	"accountId": "10367498574",
-	"events": [{
-		"experimentIds": [
-			"10420810910"
-		],
-		"id": "10404198134",
-		"key": "winning"
-	}],
-	"revision": "1337"
+  "version": "5",
+  "rollouts": [],
+  "projectId": "10431130345",
+  "variables": [],
+  "featureFlags": [],
+  "experiments": [
+    {
+      "status": "Running",
+      "key": "ab_running_exp_untargeted",
+      "layerId": "10417730432",
+      "trafficAllocation": [
+        {
+          "entityId": "10418551353",
+          "endOfRange": 10000
+        }
+      ],
+      "audienceIds": [],
+      "variations": [
+        {
+          "variables": [],
+          "id": "10418551353",
+          "key": "all_traffic_variation"
+        },
+        {
+          "variables": [],
+          "id": "10418510624",
+          "key": "no_traffic_variation"
+        }
+      ],
+      "forcedVariations": {},
+      "id": "10420810910"
+    }
+  ],
+  "audiences": [],
+  "groups": [],
+  "attributes": [],
+  "accountId": "10367498574",
+  "events": [
+    {
+      "experimentIds": [
+        "10420810910"
+      ],
+      "id": "10404198134",
+      "key": "winning"
+    }
+  ],
+  "revision": "1337"
 }

--- a/OptimizelySDK/AudienceConditions/AndCondition.cs
+++ b/OptimizelySDK/AudienceConditions/AndCondition.cs
@@ -26,7 +26,9 @@ namespace OptimizelySDK.AudienceConditions
     {
         public ICondition[] Conditions { get; set; }
 
-        public bool? Evaluate(ProjectConfig config, OptimizelyUserContext userContext, ILogger logger)
+        public bool? Evaluate(ProjectConfig config, OptimizelyUserContext userContext,
+            ILogger logger
+        )
         {
             // According to the matrix:
             // false and true is false
@@ -40,13 +42,19 @@ namespace OptimizelySDK.AudienceConditions
             {
                 var result = condition.Evaluate(config, userContext, logger);
                 if (result == null)
+                {
                     foundNull = true;
+                }
                 else if (result == false)
+                {
                     return false;
+                }
             }
 
             if (foundNull)
+            {
                 return null;
+            }
 
             return true;
         }

--- a/OptimizelySDK/AudienceConditions/AudienceIdCondition.cs
+++ b/OptimizelySDK/AudienceConditions/AudienceIdCondition.cs
@@ -24,14 +24,20 @@ namespace OptimizelySDK.AudienceConditions
     public class AudienceIdCondition : ICondition
     {
         public string AudienceId { get; set; }
-        
-        public bool? Evaluate(ProjectConfig config, OptimizelyUserContext userContext, ILogger logger)
+
+        public bool? Evaluate(ProjectConfig config, OptimizelyUserContext userContext,
+            ILogger logger
+        )
         {
             var audience = config?.GetAudience(AudienceId);
             if (audience == null || string.IsNullOrEmpty(audience.Id))
+            {
                 return null;
+            }
 
-            logger.Log(LogLevel.DEBUG, $@"Starting to evaluate audience ""{AudienceId}"" with conditions: {audience.ConditionsString}");
+            logger.Log(LogLevel.DEBUG,
+                $@"Starting to evaluate audience ""{AudienceId}"" with conditions: {
+                    audience.ConditionsString}");
             var result = audience.ConditionList.Evaluate(config, userContext, logger);
             var resultText = result?.ToString().ToUpper() ?? "UNKNOWN";
             logger.Log(LogLevel.DEBUG, $@"Audience ""{AudienceId}"" evaluated to {resultText}");

--- a/OptimizelySDK/AudienceConditions/BaseCondition.cs
+++ b/OptimizelySDK/AudienceConditions/BaseCondition.cs
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+using System;
+using System.Linq;
 using Newtonsoft.Json;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Utils;
-using System;
-using System.Linq;
 
 namespace OptimizelySDK.AudienceConditions
 {

--- a/OptimizelySDK/AudienceConditions/BaseCondition.cs
+++ b/OptimizelySDK/AudienceConditions/BaseCondition.cs
@@ -31,7 +31,7 @@ namespace OptimizelySDK.AudienceConditions
         /// String constant representing custom attribute condition type.
         /// </summary>
         public const string CUSTOM_ATTRIBUTE = "custom_attribute";
-        
+
         /// <summary>
         /// String constant representing a third-party condition type.
         /// </summary>
@@ -45,7 +45,8 @@ namespace OptimizelySDK.AudienceConditions
         /// <summary>
         /// Valid types allowed for validation
         /// </summary>
-        public static readonly string[] ValidTypes = {
+        public static readonly string[] ValidTypes =
+        {
             CUSTOM_ATTRIBUTE, THIRD_PARTY_DIMENSION,
         };
 
@@ -61,11 +62,15 @@ namespace OptimizelySDK.AudienceConditions
         [JsonProperty("value")]
         public object Value { get; set; }
 
-        public bool? Evaluate(ProjectConfig config, OptimizelyUserContext userContext, ILogger logger)
+        public bool? Evaluate(ProjectConfig config, OptimizelyUserContext userContext,
+            ILogger logger
+        )
         {
             if (!ValidTypes.Contains(Type))
             {
-                logger.Log(LogLevel.WARN, $@"Audience condition ""{this}"" uses an unknown condition type. You may need to upgrade to a newer release of the Optimizely SDK.");
+                logger.Log(LogLevel.WARN,
+                    $@"Audience condition ""{this
+                    }"" uses an unknown condition type. You may need to upgrade to a newer release of the Optimizely SDK.");
                 return null;
             }
 
@@ -75,29 +80,36 @@ namespace OptimizelySDK.AudienceConditions
                 {
                     return userContext.IsQualifiedFor(Value.ToString());
                 }
-                
-                logger.Log(LogLevel.WARN, $@"Audience condition ""{this}"" has a qualified match but invalid value.");
+
+                logger.Log(LogLevel.WARN,
+                    $@"Audience condition ""{this}"" has a qualified match but invalid value.");
                 return null;
             }
-            
+
             var userAttributes = userContext.GetAttributes();
             object attributeValue = null;
-            if (userAttributes.TryGetValue(Name, out attributeValue) == false && Match != AttributeMatchTypes.EXIST)
+            if (userAttributes.TryGetValue(Name, out attributeValue) == false &&
+                Match != AttributeMatchTypes.EXIST)
             {
-                logger.Log(LogLevel.DEBUG, $@"Audience condition {this} evaluated to UNKNOWN because no value was passed for user attribute ""{Name}"".");
+                logger.Log(LogLevel.DEBUG,
+                    $@"Audience condition {this
+                    } evaluated to UNKNOWN because no value was passed for user attribute ""{Name
+                    }"".");
                 return null;
             }
 
             var evaluator = GetEvaluator();
             if (evaluator == null)
             {
-                logger.Log(LogLevel.WARN, $@"Audience condition ""{this}"" uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK.");
+                logger.Log(LogLevel.WARN,
+                    $@"Audience condition ""{this
+                    }"" uses an unknown match type. You may need to upgrade to a newer release of the Optimizely SDK.");
                 return null;
             }
 
             return evaluator(attributeValue, logger);
         }
-        
+
         public Func<object, ILogger, bool?> GetEvaluator()
         {
             switch (Match)
@@ -135,32 +147,49 @@ namespace OptimizelySDK.AudienceConditions
 
         public bool? ExactEvaluator(object attributeValue, ILogger logger)
         {
-            if (!IsValueTypeValidForExactConditions(Value) || (Validator.IsNumericType(Value) && !Validator.IsValidNumericValue(Value)))
+            if (!IsValueTypeValidForExactConditions(Value) || (Validator.IsNumericType(Value) &&
+                                                               !Validator.
+                                                                   IsValidNumericValue(Value)))
             {
-                logger.Log(LogLevel.WARN, $@"Audience condition {this} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
+                logger.Log(LogLevel.WARN,
+                    $@"Audience condition {this
+                    } has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
                 return null;
             }
 
             if (attributeValue == null)
             {
-                logger.Log(LogLevel.DEBUG, $@"Audience condition {this} evaluated to UNKNOWN because a null value was passed for user attribute ""{Name}"".");
+                logger.Log(LogLevel.DEBUG,
+                    $@"Audience condition {this
+                    } evaluated to UNKNOWN because a null value was passed for user attribute ""{
+                        Name}"".");
                 return null;
             }
 
-            if (!IsValueTypeValidForExactConditions(attributeValue) || !AreValuesSameType(Value, attributeValue))
+            if (!IsValueTypeValidForExactConditions(attributeValue) ||
+                !AreValuesSameType(Value, attributeValue))
             {
-                logger.Log(LogLevel.WARN, $@"Audience condition {this} evaluated to UNKNOWN because a value of type ""{attributeValue.GetType().Name}"" was passed for user attribute ""{Name}"".");
+                logger.Log(LogLevel.WARN,
+                    $@"Audience condition {this} evaluated to UNKNOWN because a value of type ""{
+                        attributeValue.GetType().Name}"" was passed for user attribute ""{Name
+                        }"".");
                 return null;
             }
 
-            if (Validator.IsNumericType(attributeValue) && !Validator.IsValidNumericValue(attributeValue))
+            if (Validator.IsNumericType(attributeValue) &&
+                !Validator.IsValidNumericValue(attributeValue))
             {
-                logger.Log(LogLevel.WARN, $@"Audience condition {this} evaluated to UNKNOWN because the number value for user attribute ""{Name}"" is not in the range [-2^53, +2^53].");
+                logger.Log(LogLevel.WARN,
+                    $@"Audience condition {this
+                    } evaluated to UNKNOWN because the number value for user attribute ""{Name
+                    }"" is not in the range [-2^53, +2^53].");
                 return null;
             }
 
             if (Validator.IsNumericType(Value) && Validator.IsNumericType(attributeValue))
+            {
                 return Convert.ToDouble(Value).Equals(Convert.ToDouble(attributeValue));
+            }
 
             return Value.Equals(attributeValue);
         }
@@ -172,25 +201,25 @@ namespace OptimizelySDK.AudienceConditions
 
         public bool? GreaterThanEvaluator(object attributeValue, ILogger logger)
         {
-            int? result = NumberEvaluator(attributeValue, logger);
+            var result = NumberEvaluator(attributeValue, logger);
             return result == null ? null : (bool?)(result > 0);
         }
 
         public bool? GreaterOrEqualThanEvaluator(object attributeValue, ILogger logger)
         {
-            int? result = NumberEvaluator(attributeValue, logger);
+            var result = NumberEvaluator(attributeValue, logger);
             return result == null ? null : (bool?)(result >= 0);
         }
 
         public bool? LessThanEvaluator(object attributeValue, ILogger logger)
         {
-            int? result = NumberEvaluator(attributeValue, logger);
+            var result = NumberEvaluator(attributeValue, logger);
             return result == null ? null : (bool?)(result < 0);
         }
 
         public bool? LessOrEqualThanEvaluator(object attributeValue, ILogger logger)
         {
-            int? result = NumberEvaluator(attributeValue, logger);
+            var result = NumberEvaluator(attributeValue, logger);
             return result == null ? null : (bool?)(result <= 0);
         }
 
@@ -198,26 +227,34 @@ namespace OptimizelySDK.AudienceConditions
         {
             if (!(Value is string))
             {
-                logger.Log(LogLevel.WARN, $@"Audience condition {this} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
+                logger.Log(LogLevel.WARN,
+                    $@"Audience condition {this
+                    } has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
                 return null;
             }
 
             if (attributeValue == null)
             {
-                logger.Log(LogLevel.DEBUG, $@"Audience condition {this} evaluated to UNKNOWN because a null value was passed for user attribute ""{Name}"".");
+                logger.Log(LogLevel.DEBUG,
+                    $@"Audience condition {this
+                    } evaluated to UNKNOWN because a null value was passed for user attribute ""{
+                        Name}"".");
                 return null;
             }
 
             if (!(attributeValue is string))
             {
-                logger.Log(LogLevel.WARN, $@"Audience condition {this} evaluated to UNKNOWN because a value of type ""{attributeValue.GetType().Name}"" was passed for user attribute ""{Name}"".");
+                logger.Log(LogLevel.WARN,
+                    $@"Audience condition {this} evaluated to UNKNOWN because a value of type ""{
+                        attributeValue.GetType().Name}"" was passed for user attribute ""{Name
+                        }"".");
                 return null;
             }
 
             var attrValue = (string)attributeValue;
             return attrValue != null && attrValue.Contains((string)Value);
         }
-        
+
         /// <summary>
         /// Validates the value for exact conditions.
         /// </summary>
@@ -230,31 +267,31 @@ namespace OptimizelySDK.AudienceConditions
 
         public bool? SemanticVersionEqualEvaluator(object attributeValue, ILogger logger)
         {
-            int? result = SemanticVersionEvaluator(attributeValue, logger);
+            var result = SemanticVersionEvaluator(attributeValue, logger);
             return result == null ? null : (bool?)(result == 0);
         }
 
         public bool? SemanticVersionGreaterEvaluator(object attributeValue, ILogger logger)
         {
-            int? result = SemanticVersionEvaluator(attributeValue, logger);
+            var result = SemanticVersionEvaluator(attributeValue, logger);
             return result == null ? null : (bool?)(result > 0);
         }
 
         public bool? SemanticVersionGreaterOrEqualEvaluator(object attributeValue, ILogger logger)
         {
-            int? result = SemanticVersionEvaluator(attributeValue, logger);
+            var result = SemanticVersionEvaluator(attributeValue, logger);
             return result == null ? null : (bool?)(result >= 0);
         }
 
         public bool? SemanticVersionLessEvaluator(object attributeValue, ILogger logger)
         {
-            int? result = SemanticVersionEvaluator(attributeValue, logger);
+            var result = SemanticVersionEvaluator(attributeValue, logger);
             return result == null ? null : (bool?)(result < 0);
         }
 
         public bool? SemanticVersionLessOrEqualEvaluator(object attributeValue, ILogger logger)
         {
-            int? result = SemanticVersionEvaluator(attributeValue, logger);
+            var result = SemanticVersionEvaluator(attributeValue, logger);
             return result == null ? null : (bool?)(result <= 0);
         }
 
@@ -262,19 +299,27 @@ namespace OptimizelySDK.AudienceConditions
         {
             if (!(Value is string))
             {
-                logger.Log(LogLevel.WARN, $@"Audience condition {this} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
+                logger.Log(LogLevel.WARN,
+                    $@"Audience condition {this
+                    } has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
                 return null;
             }
 
             if (attributeValue == null)
             {
-                logger.Log(LogLevel.DEBUG, $@"Audience condition {this} evaluated to UNKNOWN because a null value was passed for user attribute ""{Name}"".");
+                logger.Log(LogLevel.DEBUG,
+                    $@"Audience condition {this
+                    } evaluated to UNKNOWN because a null value was passed for user attribute ""{
+                        Name}"".");
                 return null;
             }
 
             if (!(attributeValue is string))
             {
-                logger.Log(LogLevel.WARN, $@"Audience condition {this} evaluated to UNKNOWN because a value of type ""{attributeValue.GetType().Name}"" was passed for user attribute ""{Name}"".");
+                logger.Log(LogLevel.WARN,
+                    $@"Audience condition {this} evaluated to UNKNOWN because a value of type ""{
+                        attributeValue.GetType().Name}"" was passed for user attribute ""{Name
+                        }"".");
                 return null;
             }
 
@@ -295,29 +340,41 @@ namespace OptimizelySDK.AudienceConditions
         {
             if (!Validator.IsValidNumericValue(Value))
             {
-                logger.Log(LogLevel.WARN, $@"Audience condition {this} has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
+                logger.Log(LogLevel.WARN,
+                    $@"Audience condition {this
+                    } has an unsupported condition value. You may need to upgrade to a newer release of the Optimizely SDK.");
                 return null;
             }
 
             if (attributeValue == null)
             {
-                logger.Log(LogLevel.DEBUG, $@"Audience condition {this} evaluated to UNKNOWN because a null value was passed for user attribute ""{Name}"".");
+                logger.Log(LogLevel.DEBUG,
+                    $@"Audience condition {this
+                    } evaluated to UNKNOWN because a null value was passed for user attribute ""{
+                        Name}"".");
                 return null;
             }
 
             if (!Validator.IsNumericType(attributeValue))
             {
-                logger.Log(LogLevel.WARN, $@"Audience condition {this} evaluated to UNKNOWN because a value of type ""{attributeValue.GetType().Name}"" was passed for user attribute ""{Name}"".");
+                logger.Log(LogLevel.WARN,
+                    $@"Audience condition {this} evaluated to UNKNOWN because a value of type ""{
+                        attributeValue.GetType().Name}"" was passed for user attribute ""{Name
+                        }"".");
                 return null;
             }
 
             if (!Validator.IsValidNumericValue(attributeValue))
             {
-                logger.Log(LogLevel.WARN, $@"Audience condition {this} evaluated to UNKNOWN because the number value for user attribute ""{Name}"" is not in the range [-2^53, +2^53].");
+                logger.Log(LogLevel.WARN,
+                    $@"Audience condition {this
+                    } evaluated to UNKNOWN because the number value for user attribute ""{Name
+                    }"" is not in the range [-2^53, +2^53].");
                 return null;
             }
-            double userValue = Convert.ToDouble(attributeValue);
-            double conditionalValue = Convert.ToDouble(Value);
+
+            var userValue = Convert.ToDouble(attributeValue);
+            var conditionalValue = Convert.ToDouble(Value);
 
             return userValue.CompareTo(conditionalValue);
         }
@@ -331,13 +388,19 @@ namespace OptimizelySDK.AudienceConditions
         public bool AreValuesSameType(object firstValue, object secondValue)
         {
             if (firstValue is string && secondValue is string)
+            {
                 return true;
+            }
 
             if (firstValue is bool && secondValue is bool)
+            {
                 return true;
+            }
 
             if (Validator.IsNumericType(firstValue) && Validator.IsNumericType(secondValue))
+            {
                 return true;
+            }
 
             return false;
         }

--- a/OptimizelySDK/AudienceConditions/EmptyCondition.cs
+++ b/OptimizelySDK/AudienceConditions/EmptyCondition.cs
@@ -24,7 +24,9 @@ namespace OptimizelySDK.AudienceConditions
     /// </summary>
     public class EmptyCondition : ICondition
     {
-        public bool? Evaluate(ProjectConfig config, OptimizelyUserContext userContext, ILogger logger)
+        public bool? Evaluate(ProjectConfig config, OptimizelyUserContext userContext,
+            ILogger logger
+        )
         {
             return true;
         }

--- a/OptimizelySDK/AudienceConditions/NotCondition.cs
+++ b/OptimizelySDK/AudienceConditions/NotCondition.cs
@@ -26,7 +26,9 @@ namespace OptimizelySDK.AudienceConditions
     {
         public ICondition Condition { get; set; }
 
-        public bool? Evaluate(ProjectConfig config, OptimizelyUserContext userContext, ILogger logger)
+        public bool? Evaluate(ProjectConfig config, OptimizelyUserContext userContext,
+            ILogger logger
+        )
         {
             var result = Condition?.Evaluate(config, userContext, logger);
             return result == null ? null : !result;

--- a/OptimizelySDK/AudienceConditions/OrCondition.cs
+++ b/OptimizelySDK/AudienceConditions/OrCondition.cs
@@ -26,7 +26,9 @@ namespace OptimizelySDK.AudienceConditions
     {
         public ICondition[] Conditions { get; set; }
 
-        public bool? Evaluate(ProjectConfig config, OptimizelyUserContext userContext, ILogger logger)
+        public bool? Evaluate(ProjectConfig config, OptimizelyUserContext userContext,
+            ILogger logger
+        )
         {
             // According to the matrix:
             // true returns true
@@ -38,13 +40,19 @@ namespace OptimizelySDK.AudienceConditions
             {
                 var result = condition.Evaluate(config, userContext, logger);
                 if (result == null)
+                {
                     foundNull = true;
+                }
                 else if (result == true)
+                {
                     return true;
+                }
             }
 
             if (foundNull)
+            {
                 return null;
+            }
 
             return false;
         }

--- a/OptimizelySDK/AudienceConditions/SemanticVersion.cs
+++ b/OptimizelySDK/AudienceConditions/SemanticVersion.cs
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
+
 namespace OptimizelySDK.AudienceConditions
 {
     /// <summary>
@@ -26,7 +28,10 @@ namespace OptimizelySDK.AudienceConditions
         public const char BuildSeparator = '+';
         public const char PreReleaseSeparator = '-';
         public const string NumberExpression = "[0-9]+";
-        public static readonly System.Text.RegularExpressions.Regex NumberRegex = new System.Text.RegularExpressions.Regex(NumberExpression);
+
+        public static readonly System.Text.RegularExpressions.Regex NumberRegex =
+            new System.Text.RegularExpressions.Regex(NumberExpression);
+
         /// <summary>
         /// Helper method to check if semantic version contains white spaces.
         /// </summary>
@@ -54,6 +59,7 @@ namespace OptimizelySDK.AudienceConditions
             {
                 return false;
             }
+
             return preReleaseIndex < buildIndex;
         }
 
@@ -74,6 +80,7 @@ namespace OptimizelySDK.AudienceConditions
             {
                 return false;
             }
+
             return buildIndex < preReleaseIndex;
         }
 
@@ -94,38 +101,48 @@ namespace OptimizelySDK.AudienceConditions
         /// <returns>string array conatining major.minor.patch and prerelease or beta version as last element.</returns>
         public static string[] SplitSemanticVersion(this string version)
         {
-            List<string> versionParts = new List<string>();
+            var versionParts = new List<string>();
             // pre-release or build.
-            string versionSuffix = string.Empty;
-            string versionPrefix = version;
+            var versionSuffix = string.Empty;
+            var versionPrefix = version;
             string[] preVersionParts;
             if (version.ContainsWhiteSpace())
             {
                 // log and throw error
-                throw new Exception("Semantic version contains white spaces. Invalid Semantic Version.");
+                throw new Exception(
+                    "Semantic version contains white spaces. Invalid Semantic Version.");
             }
 
             if (version.IsBuild() || version.IsPreRelease())
             {
-                var partialVersionParts = version.Split(new char [] { version.IsPreRelease() ?
-                     PreReleaseSeparator : BuildSeparator}, 2, StringSplitOptions.RemoveEmptyEntries);
+                var partialVersionParts = version.Split(new char[]
+                {
+                    version.IsPreRelease() ?
+                        PreReleaseSeparator :
+                        BuildSeparator,
+                }, 2, StringSplitOptions.RemoveEmptyEntries);
                 if (partialVersionParts.Length <= 1)
                 {
                     // throw error
                     throw new Exception("Invalid Semantic Version.");
                 }
+
                 // major.minor.patch
                 versionPrefix = partialVersionParts[0];
                 versionSuffix = partialVersionParts[1];
 
-                preVersionParts = versionPrefix.Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+                preVersionParts = versionPrefix.Split(new char[] { '.' },
+                    StringSplitOptions.RemoveEmptyEntries);
             }
             else
             {
-                preVersionParts = version.Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+                preVersionParts = version.Split(new char[] { '.' },
+                    StringSplitOptions.RemoveEmptyEntries);
             }
-            int dotCount = versionPrefix.Count(c => c == '.');
-            if (preVersionParts.Length != dotCount + 1 || dotCount > 2 || (preVersionParts.Any(part => !part.IsNumber())))
+
+            var dotCount = versionPrefix.Count(c => c == '.');
+            if (preVersionParts.Length != dotCount + 1 || dotCount > 2 ||
+                preVersionParts.Any(part => !part.IsNumber()))
             {
                 // Throw error as pre version should only contain major.minor.patch version 
                 throw new Exception("Invalid Semantic Version.");
@@ -180,27 +197,34 @@ namespace OptimizelySDK.AudienceConditions
 
             for (var index = 0; index < targetedVersionParts.Length; index++)
             {
-
                 if (userVersionParts.Length <= index)
                 {
                     return targetedVersion.Version.IsPreRelease() ? 1 : -1;
                 }
                 else
                 {
-                    if (!int.TryParse(userVersionParts[index], out int userVersionPartInt))
+                    if (!int.TryParse(userVersionParts[index], out var userVersionPartInt))
                     {
                         // Compare strings
-                        var result = string.Compare(userVersionParts[index], targetedVersionParts[index]);
+                        var result = string.Compare(userVersionParts[index],
+                            targetedVersionParts[index]);
                         if (result < 0)
                         {
-                            return targetedVersion.Version.IsPreRelease() && !Version.IsPreRelease() ? 1 : -1;
+                            return targetedVersion.Version.IsPreRelease() &&
+                                   !Version.IsPreRelease() ?
+                                1 :
+                                -1;
                         }
                         else if (result > 0)
                         {
-                            return !targetedVersion.Version.IsPreRelease() && Version.IsPreRelease() ? -1 : 1;
+                            return !targetedVersion.Version.IsPreRelease() &&
+                                   Version.IsPreRelease() ?
+                                -1 :
+                                1;
                         }
                     }
-                    else if (int.TryParse(targetedVersionParts[index], out int targetVersionPartInt))
+                    else if (int.TryParse(targetedVersionParts[index],
+                                 out var targetVersionPartInt))
                     {
                         if (userVersionPartInt != targetVersionPartInt)
                         {

--- a/OptimizelySDK/Bucketing/Bucketer.cs
+++ b/OptimizelySDK/Bucketing/Bucketer.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using OptimizelySDK.Entity;
 using OptimizelySDK.Logger;
 using OptimizelySDK.OptimizelyDecisions;
@@ -54,9 +55,9 @@ namespace OptimizelySDK.Bucketing
         /// <returns>integer Unsigned value denoting the hash value for the user</returns>
         private uint GenerateHashCode(string bucketingKey)
         {
-            var murmer32 = Murmur.MurmurHash.Create32(seed: HASH_SEED, managed: true);
-            byte[] data = Encoding.UTF8.GetBytes(bucketingKey);
-            byte[] hash = murmer32.ComputeHash(data);
+            var murmer32 = Murmur.MurmurHash.Create32(HASH_SEED, true);
+            var data = Encoding.UTF8.GetBytes(bucketingKey);
+            var hash = murmer32.ComputeHash(data);
             return BitConverter.ToUInt32(hash, 0);
         }
 
@@ -68,8 +69,8 @@ namespace OptimizelySDK.Bucketing
         /// <returns>integer Value in the closed range [0, 9999] denoting the bucket the user belongs to</returns>
         public virtual int GenerateBucketValue(string bucketingKey)
         {
-            uint hashCode = GenerateHashCode(bucketingKey);
-            double ratio = hashCode / (double)MAX_HASH_VALUE;
+            var hashCode = GenerateHashCode(bucketingKey);
+            var ratio = hashCode / (double)MAX_HASH_VALUE;
             return (int)(ratio * MAX_TRAFFIC_VALUE);
         }
 
@@ -81,17 +82,24 @@ namespace OptimizelySDK.Bucketing
         /// <param name="parentId">mixed ID representing Experiment or Group</param>
         /// <param name="trafficAllocations">array Traffic allocations for variation or experiment</param>
         /// <returns>string ID representing experiment or variation, returns null if not found</returns>
-        private string FindBucket(string bucketingId, string userId, string parentId, IEnumerable<TrafficAllocation> trafficAllocations)
+        private string FindBucket(string bucketingId, string userId, string parentId,
+            IEnumerable<TrafficAllocation> trafficAllocations
+        )
         {
             // Generate the bucketing key based on combination of user ID and experiment ID or group ID.
-            string bucketingKey = bucketingId + parentId;
-            int bucketingNumber = GenerateBucketValue(bucketingKey);
+            var bucketingKey = bucketingId + parentId;
+            var bucketingNumber = GenerateBucketValue(bucketingKey);
 
-            Logger.Log(LogLevel.DEBUG, $"Assigned bucket [{bucketingNumber}] to user [{userId}] with bucketing ID [{bucketingId}].");
+            Logger.Log(LogLevel.DEBUG,
+                $"Assigned bucket [{bucketingNumber}] to user [{userId}] with bucketing ID [{bucketingId}].");
 
             foreach (var ta in trafficAllocations)
+            {
                 if (bucketingNumber < ta.EndOfRange)
+                {
                     return ta.EntityId;
+                }
+            }
 
             return null;
         }
@@ -104,7 +112,9 @@ namespace OptimizelySDK.Bucketing
         /// <param name="bucketingId">A customer-assigned value used to create the key for the murmur hash.</param>
         /// <param name="userId">User identifier</param>
         /// <returns>Variation which will be shown to the user</returns>
-        public virtual Result<Variation> Bucket(ProjectConfig config, Experiment experiment, string bucketingId, string userId)
+        public virtual Result<Variation> Bucket(ProjectConfig config, Experiment experiment,
+            string bucketingId, string userId
+        )
         {
             string message;
             Variation variation;
@@ -112,16 +122,21 @@ namespace OptimizelySDK.Bucketing
             var reasons = new DecisionReasons();
 
             if (string.IsNullOrEmpty(experiment.Key))
+            {
                 return Result<Variation>.NewResult(new Variation(), reasons);
+            }
 
             // Determine if experiment is in a mutually exclusive group.
             if (experiment.IsInMutexGroup)
             {
-                Group group = config.GetGroup(experiment.GroupId);
+                var group = config.GetGroup(experiment.GroupId);
                 if (string.IsNullOrEmpty(group.Id))
+                {
                     return Result<Variation>.NewResult(new Variation(), reasons);
+                }
 
-                string userExperimentId = FindBucket(bucketingId, userId, group.Id, group.TrafficAllocation);
+                var userExperimentId =
+                    FindBucket(bucketingId, userId, group.Id, group.TrafficAllocation);
                 if (string.IsNullOrEmpty(userExperimentId))
                 {
                     message = $"User [{userId}] is in no experiment.";
@@ -131,27 +146,30 @@ namespace OptimizelySDK.Bucketing
 
                 if (userExperimentId != experiment.Id)
                 {
-                    message = $"User [{userId}] is not in experiment [{experiment.Key}] of group [{experiment.GroupId}].";
+                    message =
+                        $"User [{userId}] is not in experiment [{experiment.Key}] of group [{experiment.GroupId}].";
                     Logger.Log(LogLevel.INFO, reasons.AddInfo(message));
                     return Result<Variation>.NewResult(new Variation(), reasons);
                 }
 
-                message = $"User [{userId}] is in experiment [{experiment.Key}] of group [{experiment.GroupId}].";
+                message =
+                    $"User [{userId}] is in experiment [{experiment.Key}] of group [{experiment.GroupId}].";
                 Logger.Log(LogLevel.INFO, reasons.AddInfo(message));
             }
 
             // Bucket user if not in whitelist and in group (if any).
-            string variationId = FindBucket(bucketingId, userId, experiment.Id, experiment.TrafficAllocation);
+            var variationId = FindBucket(bucketingId, userId, experiment.Id,
+                experiment.TrafficAllocation);
             if (string.IsNullOrEmpty(variationId))
             {
                 Logger.Log(LogLevel.INFO, reasons.AddInfo($"User [{userId}] is in no variation."));
                 return Result<Variation>.NewResult(new Variation(), reasons);
-
             }
 
             // success!
             variation = config.GetVariationFromIdByExperimentId(experiment.Id, variationId);
-            message = $"User [{userId}] is in variation [{variation.Key}] of experiment [{experiment.Key}].";
+            message =
+                $"User [{userId}] is in variation [{variation.Key}] of experiment [{experiment.Key}].";
             Logger.Log(LogLevel.INFO, reasons.AddInfo(message));
             return Result<Variation>.NewResult(variation, reasons);
         }

--- a/OptimizelySDK/Bucketing/Bucketer.cs
+++ b/OptimizelySDK/Bucketing/Bucketer.cs
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Entity;
-using OptimizelySDK.Logger;
-using OptimizelySDK.OptimizelyDecisions;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using OptimizelySDK.Entity;
+using OptimizelySDK.Logger;
+using OptimizelySDK.OptimizelyDecisions;
 
 namespace OptimizelySDK.Bucketing
 {

--- a/OptimizelySDK/Bucketing/Decision.cs
+++ b/OptimizelySDK/Bucketing/Decision.cs
@@ -20,7 +20,6 @@ namespace OptimizelySDK.Bucketing
 {
     public class Decision
     {
-
         /// <summary>
         /// The ID of the Variation into which the user was bucketed.
         /// </summary>
@@ -39,7 +38,7 @@ namespace OptimizelySDK.Bucketing
         {
             return new Dictionary<string, string>
             {
-                { UserProfile.VARIATION_ID_KEY, VariationId }
+                { UserProfile.VARIATION_ID_KEY, VariationId },
             };
         }
     }

--- a/OptimizelySDK/Bucketing/UserProfile.cs
+++ b/OptimizelySDK/Bucketing/UserProfile.cs
@@ -55,7 +55,7 @@ namespace OptimizelySDK.Bucketing
             UserId = userId;
             ExperimentBucketMap = experimentBucketMap;
         }
-        
+
         /// <summary>
         /// Convert a User Profile instance to a Map.
         /// </summary>
@@ -64,9 +64,11 @@ namespace OptimizelySDK.Bucketing
         {
             return new Dictionary<string, object>
             {
-                { UserProfile.USER_ID_KEY, UserId },
-                { UserProfile.EXPERIMENT_BUCKET_MAP_KEY,
-                    ExperimentBucketMap.ToDictionary(row => row.Key, row => row.Value.ToMap()) }
+                { USER_ID_KEY, UserId },
+                {
+                    EXPERIMENT_BUCKET_MAP_KEY,
+                    ExperimentBucketMap.ToDictionary(row => row.Key, row => row.Value.ToMap())
+                },
             };
         }
     }

--- a/OptimizelySDK/Bucketing/UserProfileService.cs
+++ b/OptimizelySDK/Bucketing/UserProfileService.cs
@@ -19,14 +19,13 @@ using System.Collections.Generic;
 
 namespace OptimizelySDK.Bucketing
 {
-
     /// <summary>
     /// Class encapsulating user profile service functionality.
     /// Override with your own implementation for storing and retrieving the user profile.
     /// </summary>
     public interface UserProfileService
     {
-		Dictionary<string, object> Lookup(String userId);
+        Dictionary<string, object> Lookup(String userId);
 
         void Save(Dictionary<string, object> userProfile);
     }

--- a/OptimizelySDK/Bucketing/UserProfileUtil.cs
+++ b/OptimizelySDK/Bucketing/UserProfileUtil.cs
@@ -31,7 +31,9 @@ namespace OptimizelySDK.Bucketing
             // The Map must contain a value for the user ID and experiment bucket map
             if (!map.ContainsKey(UserProfile.USER_ID_KEY) ||
                 !map.ContainsKey(UserProfile.EXPERIMENT_BUCKET_MAP_KEY))
+            {
                 return false;
+            }
 
             // the map is good enough for us to use
             return true;
@@ -44,14 +46,16 @@ namespace OptimizelySDK.Bucketing
         /// <returns>A UserProfile instance.</returns>
         public static UserProfile ConvertMapToUserProfile(Dictionary<string, object> map)
         {
-            var experimentBucketMap = (Dictionary<string, Dictionary<string, string>>)map[UserProfile.EXPERIMENT_BUCKET_MAP_KEY];
-            Dictionary<string, Decision> decisions = experimentBucketMap.ToDictionary(
-                keySelector: kvp => kvp.Key, 
-                elementSelector: kvp => new Decision(kvp.Value[UserProfile.VARIATION_ID_KEY]));
+            var experimentBucketMap =
+                (Dictionary<string, Dictionary<string, string>>)map[
+                    UserProfile.EXPERIMENT_BUCKET_MAP_KEY];
+            var decisions = experimentBucketMap.ToDictionary(
+                kvp => kvp.Key,
+                kvp => new Decision(kvp.Value[UserProfile.VARIATION_ID_KEY]));
 
             return new UserProfile(
-                userId: (string)map[UserProfile.USER_ID_KEY], 
-                experimentBucketMap: decisions);
+                (string)map[UserProfile.USER_ID_KEY],
+                decisions);
         }
     }
 }

--- a/OptimizelySDK/ClientConfigHandler.cs
+++ b/OptimizelySDK/ClientConfigHandler.cs
@@ -21,79 +21,46 @@ namespace OptimizelySDK
     public class HttpProjectConfigElement : ConfigurationElement
     {
         [ConfigurationProperty("sdkKey", IsRequired = true, IsKey = true)]
-        public string SDKKey
-        {
-            get { return (string)base["sdkKey"]; }
-        }
+        public string SDKKey => (string)base["sdkKey"];
 
         [ConfigurationProperty("url")]
-        public string Url
-        {
-            get { return (string)base["url"]; }
-        }
+        public string Url => (string)base["url"];
 
         [ConfigurationProperty("format")]
-        public string Format
-        {
-            get { return (string)base["format"]; }
-        }
+        public string Format => (string)base["format"];
 
         [ConfigurationProperty("pollingInterval")]
-        public int PollingInterval
-        {
-            get { return base["pollingInterval"] is int ? (int)base["pollingInterval"] : 0; }
-        }
+        public int PollingInterval =>
+            base["pollingInterval"] is int ? (int)base["pollingInterval"] : 0;
 
         [ConfigurationProperty("blockingTimeOutPeriod")]
-        public int BlockingTimeOutPeriod
-        {
-            get { return base["blockingTimeOutPeriod"] is int ? (int)base["blockingTimeOutPeriod"] : 0; }
-        }
+        public int BlockingTimeOutPeriod =>
+            base["blockingTimeOutPeriod"] is int ? (int)base["blockingTimeOutPeriod"] : 0;
 
         [ConfigurationProperty("autoUpdate")]
-        public bool AutoUpdate
-        {
-            get { return (bool)base["autoUpdate"]; }
-        }
+        public bool AutoUpdate => (bool)base["autoUpdate"];
 
         [ConfigurationProperty("defaultStart")]
-        public bool DefaultStart
-        {
-            get { return (bool)base["defaultStart"]; }
-        }
+        public bool DefaultStart => (bool)base["defaultStart"];
 
         [ConfigurationProperty("datafileAccessToken")]
-        public string DatafileAccessToken
-        {
-            get { return (string)base["datafileAccessToken"]; }
-        }
+        public string DatafileAccessToken => (string)base["datafileAccessToken"];
     }
 
     public class BatchEventProcessorElement : ConfigurationElement
     {
         [ConfigurationProperty("batchSize")]
-        public int BatchSize
-        {
-            get { return (int)base["batchSize"]; }
-        }
+        public int BatchSize => (int)base["batchSize"];
 
         [ConfigurationProperty("flushInterval")]
-        public int FlushInterval
-        {
-            get { return base["flushInterval"] is int ? (int)base["flushInterval"] : 0; }
-        }
+        public int FlushInterval => base["flushInterval"] is int ? (int)base["flushInterval"] : 0;
 
         [ConfigurationProperty("timeoutInterval")]
-        public int TimeoutInterval
-        {
-            get { return base["timeoutInterval"] is int ? (int)base["timeoutInterval"] : 0; }
-        }
+        public int TimeoutInterval =>
+            base["timeoutInterval"] is int ? (int)base["timeoutInterval"] : 0;
 
         [ConfigurationProperty("defaultStart")]
-        public bool DefaultStart
-        {
-            get { return (bool)base["defaultStart"]; }
-        }
+        public bool DefaultStart => (bool)base["defaultStart"];
     }
 
     public class OptimizelySDKConfigSection : ConfigurationSection
@@ -101,14 +68,15 @@ namespace OptimizelySDK
         [ConfigurationProperty("HttpProjectConfig")]
         public HttpProjectConfigElement HttpProjectConfig
         {
-            get { return (HttpProjectConfigElement)base["HttpProjectConfig"]; }
-            set { base["HttpProjectConfig"] = value; }
+            get => (HttpProjectConfigElement)base["HttpProjectConfig"];
+            set => base["HttpProjectConfig"] = value;
         }
 
         [ConfigurationProperty("BatchEventProcessor")]
-        public BatchEventProcessorElement BatchEventProcessor {
-            get { return (BatchEventProcessorElement)(base["BatchEventProcessor"]); }
-            set { base["BatchEventProcessor"] = value; }
+        public BatchEventProcessorElement BatchEventProcessor
+        {
+            get => (BatchEventProcessorElement)base["BatchEventProcessor"];
+            set => base["BatchEventProcessor"] = value;
         }
     }
 }

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -44,7 +44,7 @@ namespace OptimizelySDK.Config
         {
             V2 = 2,
             V3 = 3,
-            V4 = 4
+            V4 = 4,
         }
 
         /// <summary>
@@ -119,7 +119,7 @@ namespace OptimizelySDK.Config
         {
             OPTLYSDKVersion.V2,
             OPTLYSDKVersion.V3,
-            OPTLYSDKVersion.V4
+            OPTLYSDKVersion.V4,
         };
 
         //========================= Mappings ===========================
@@ -129,14 +129,14 @@ namespace OptimizelySDK.Config
         /// </summary>
         private Dictionary<string, Group> _GroupIdMap;
 
-        public Dictionary<string, Group> GroupIdMap { get { return _GroupIdMap; } }
+        public Dictionary<string, Group> GroupIdMap => _GroupIdMap;
 
         /// <summary>
         /// Associative array of experiment key to Experiment(s) in the datafile
         /// </summary>
         private Dictionary<string, Experiment> _ExperimentKeyMap;
 
-        public Dictionary<string, Experiment> ExperimentKeyMap { get { return _ExperimentKeyMap; } }
+        public Dictionary<string, Experiment> ExperimentKeyMap => _ExperimentKeyMap;
 
         /// <summary>
         /// Associative array of experiment ID to Experiment(s) in the datafile
@@ -144,7 +144,7 @@ namespace OptimizelySDK.Config
         private Dictionary<string, Experiment> _ExperimentIdMap
             = new Dictionary<string, Experiment>();
 
-        public Dictionary<string, Experiment> ExperimentIdMap { get { return _ExperimentIdMap; } }
+        public Dictionary<string, Experiment> ExperimentIdMap => _ExperimentIdMap;
 
         /// <summary>
         /// Associative array of experiment key to associative array of variation key to variations
@@ -152,10 +152,8 @@ namespace OptimizelySDK.Config
         private Dictionary<string, Dictionary<string, Variation>> _VariationKeyMap
             = new Dictionary<string, Dictionary<string, Variation>>();
 
-        public Dictionary<string, Dictionary<string, Variation>> VariationKeyMap
-        {
-            get { return _VariationKeyMap; }
-        }
+        public Dictionary<string, Dictionary<string, Variation>> VariationKeyMap =>
+            _VariationKeyMap;
 
         /// <summary>
         /// Associative array of experiment ID to associative array of variation key to variations
@@ -163,10 +161,8 @@ namespace OptimizelySDK.Config
         private Dictionary<string, Dictionary<string, Variation>> _VariationKeyMapByExperimentId
             = new Dictionary<string, Dictionary<string, Variation>>();
 
-        public Dictionary<string, Dictionary<string, Variation>> VariationKeyMapByExperimentId
-        {
-            get { return _VariationKeyMapByExperimentId; }
-        }
+        public Dictionary<string, Dictionary<string, Variation>> VariationKeyMapByExperimentId =>
+            _VariationKeyMapByExperimentId;
 
         /// <summary>
         /// Associative array of experiment ID to associative array of variation key to variations
@@ -174,10 +170,8 @@ namespace OptimizelySDK.Config
         private Dictionary<string, Dictionary<string, Variation>> _VariationIdMapByExperimentId
             = new Dictionary<string, Dictionary<string, Variation>>();
 
-        public Dictionary<string, Dictionary<string, Variation>> VariationKeyIdByExperimentId
-        {
-            get { return _VariationIdMapByExperimentId; }
-        }
+        public Dictionary<string, Dictionary<string, Variation>> VariationKeyIdByExperimentId =>
+            _VariationIdMapByExperimentId;
 
         /// <summary>
         /// Associative array of experiment key to associative array of variation ID to variations
@@ -185,45 +179,42 @@ namespace OptimizelySDK.Config
         private Dictionary<string, Dictionary<string, Variation>> _VariationIdMap
             = new Dictionary<string, Dictionary<string, Variation>>();
 
-        public Dictionary<string, Dictionary<string, Variation>> VariationIdMap
-        {
-            get { return _VariationIdMap; }
-        }
+        public Dictionary<string, Dictionary<string, Variation>> VariationIdMap => _VariationIdMap;
 
         /// <summary>
         /// Associative array of event key to Event(s) in the datafile
         /// </summary>
         private Dictionary<string, Entity.Event> _EventKeyMap;
 
-        public Dictionary<string, Entity.Event> EventKeyMap { get { return _EventKeyMap; } }
+        public Dictionary<string, Entity.Event> EventKeyMap => _EventKeyMap;
 
         /// <summary>
         /// Associative array of attribute key to Attribute(s) in the datafile
         /// </summary>
         private Dictionary<string, Attribute> _AttributeKeyMap;
 
-        public Dictionary<string, Attribute> AttributeKeyMap { get { return _AttributeKeyMap; } }
+        public Dictionary<string, Attribute> AttributeKeyMap => _AttributeKeyMap;
 
         /// <summary>
         /// Associative array of audience ID to Audience(s) in the datafile
         /// </summary>
         private Dictionary<string, Audience> _AudienceIdMap;
 
-        public Dictionary<string, Audience> AudienceIdMap { get { return _AudienceIdMap; } }
+        public Dictionary<string, Audience> AudienceIdMap => _AudienceIdMap;
 
         /// <summary>
         /// Associative array of Feature Key to Feature(s) in the datafile
         /// </summary>
         private Dictionary<string, FeatureFlag> _FeatureKeyMap;
 
-        public Dictionary<string, FeatureFlag> FeatureKeyMap { get { return _FeatureKeyMap; } }
+        public Dictionary<string, FeatureFlag> FeatureKeyMap => _FeatureKeyMap;
 
         /// <summary>
         /// Associative array of Rollout ID to Rollout(s) in the datafile
         /// </summary>
         private Dictionary<string, Rollout> _RolloutIdMap;
 
-        public Dictionary<string, Rollout> RolloutIdMap { get { return _RolloutIdMap; } }
+        public Dictionary<string, Rollout> RolloutIdMap => _RolloutIdMap;
 
         /// <summary>
         /// Associative array of experiment IDs that exist in any feature
@@ -238,10 +229,8 @@ namespace OptimizelySDK.Config
         private Dictionary<string, Dictionary<string, Variation>> _FlagVariationMap =
             new Dictionary<string, Dictionary<string, Variation>>();
 
-        public Dictionary<string, Dictionary<string, Variation>> FlagVariationMap
-        {
-            get { return _FlagVariationMap; }
-        }
+        public Dictionary<string, Dictionary<string, Variation>> FlagVariationMap =>
+            _FlagVariationMap;
 
         //========================= Interfaces ===========================
 
@@ -323,34 +312,36 @@ namespace OptimizelySDK.Config
             Integrations = Integrations ?? new Integration[0];
             _ExperimentKeyMap = new Dictionary<string, Experiment>();
 
-            _GroupIdMap = ConfigParser<Group>.GenerateMap(entities: Groups,
-                getKey: g => g.Id.ToString(), clone: true);
-            _ExperimentIdMap = ConfigParser<Experiment>.GenerateMap(entities: Experiments,
-                getKey: e => e.Id, clone: true);
+            _GroupIdMap = ConfigParser<Group>.GenerateMap(Groups,
+                g => g.Id.ToString(), true);
+            _ExperimentIdMap = ConfigParser<Experiment>.GenerateMap(Experiments,
+                e => e.Id, true);
             _EventKeyMap =
-                ConfigParser<Entity.Event>.GenerateMap(entities: Events, getKey: e => e.Key,
-                    clone: true);
-            _AttributeKeyMap = ConfigParser<Attribute>.GenerateMap(entities: Attributes,
-                getKey: a => a.Key, clone: true);
-            _AudienceIdMap = ConfigParser<Audience>.GenerateMap(entities: Audiences,
-                getKey: a => a.Id.ToString(), clone: true);
-            _FeatureKeyMap = ConfigParser<FeatureFlag>.GenerateMap(entities: FeatureFlags,
-                getKey: f => f.Key, clone: true);
-            _RolloutIdMap = ConfigParser<Rollout>.GenerateMap(entities: Rollouts,
-                getKey: r => r.Id.ToString(), clone: true);
+                ConfigParser<Entity.Event>.GenerateMap(Events, e => e.Key,
+                    true);
+            _AttributeKeyMap = ConfigParser<Attribute>.GenerateMap(Attributes,
+                a => a.Key, true);
+            _AudienceIdMap = ConfigParser<Audience>.GenerateMap(Audiences,
+                a => a.Id.ToString(), true);
+            _FeatureKeyMap = ConfigParser<FeatureFlag>.GenerateMap(FeatureFlags,
+                f => f.Key, true);
+            _RolloutIdMap = ConfigParser<Rollout>.GenerateMap(Rollouts,
+                r => r.Id.ToString(), true);
 
             // Overwrite similar items in audience id map with typed audience id map.
-            var typedAudienceIdMap = ConfigParser<Audience>.GenerateMap(entities: TypedAudiences,
-                getKey: a => a.Id.ToString(), clone: true);
+            var typedAudienceIdMap = ConfigParser<Audience>.GenerateMap(TypedAudiences,
+                a => a.Id.ToString(), true);
             foreach (var item in typedAudienceIdMap)
+            {
                 _AudienceIdMap[item.Key] = item.Value;
+            }
 
-            foreach (Group group in Groups)
+            foreach (var group in Groups)
             {
                 var experimentsInGroup =
-                    ConfigParser<Experiment>.GenerateMap(group.Experiments, getKey: e => e.Id,
-                        clone: true);
-                foreach (Experiment experiment in experimentsInGroup.Values)
+                    ConfigParser<Experiment>.GenerateMap(group.Experiments, e => e.Id,
+                        true);
+                foreach (var experiment in experimentsInGroup.Values)
                 {
                     experiment.GroupId = group.Id;
                     experiment.GroupPolicy = group.Policy;
@@ -359,10 +350,12 @@ namespace OptimizelySDK.Config
                 // RJE: I believe that this is equivalent to this:
                 // $this->_experimentKeyMap = array_merge($this->_experimentKeyMap, $experimentsInGroup);
                 foreach (var experiment in experimentsInGroup.Values)
+                {
                     _ExperimentIdMap[experiment.Id] = experiment;
+                }
             }
 
-            foreach (Experiment experiment in _ExperimentIdMap.Values)
+            foreach (var experiment in _ExperimentIdMap.Values)
             {
                 _VariationKeyMap[experiment.Key] = new Dictionary<string, Variation>();
                 _VariationIdMap[experiment.Key] = new Dictionary<string, Variation>();
@@ -373,7 +366,7 @@ namespace OptimizelySDK.Config
 
                 if (experiment.Variations != null)
                 {
-                    foreach (Variation variation in experiment.Variations)
+                    foreach (var variation in experiment.Variations)
                     {
                         _VariationKeyMap[experiment.Key][variation.Key] = variation;
                         _VariationIdMap[experiment.Key][variation.Id] = variation;
@@ -437,7 +430,7 @@ namespace OptimizelySDK.Config
                     {
                         ExperimentFeatureMap[experimentId] = new List<string>
                         {
-                            feature.Id
+                            feature.Id,
                         };
                     }
                 }
@@ -470,7 +463,7 @@ namespace OptimizelySDK.Config
             IErrorHandler errorHandler
         )
         {
-            DatafileProjectConfig config = GetConfig(content);
+            var config = GetConfig(content);
 
             config.Logger = logger ?? new NoOpLogger();
             config.ErrorHandler = errorHandler ?? new NoOpErrorHandler(logger);
@@ -483,19 +476,25 @@ namespace OptimizelySDK.Config
         private static DatafileProjectConfig GetConfig(string configData)
         {
             if (configData == null)
+            {
                 throw new ConfigParseException("Unable to parse null datafile.");
+            }
 
             if (string.IsNullOrEmpty(configData))
+            {
                 throw new ConfigParseException("Unable to parse empty datafile.");
+            }
 
             var config = JsonConvert.DeserializeObject<DatafileProjectConfig>(configData);
             config._datafile = configData;
 
             if (SupportedVersions.TrueForAll((supportedVersion) =>
                     !(((int)supportedVersion).ToString() == config.Version)))
+            {
                 throw new ConfigParseException(
                     $@"This version of the C# SDK does not support the given datafile version: {
                         config.Version}");
+            }
 
             return config;
         }
@@ -510,12 +509,14 @@ namespace OptimizelySDK.Config
         public Group GetGroup(string groupId)
         {
             if (_GroupIdMap.ContainsKey(groupId))
+            {
                 return _GroupIdMap[groupId];
+            }
 
-            string message = $@"Group ID ""{groupId}"" is not in datafile.";
+            var message = $@"Group ID ""{groupId}"" is not in datafile.";
             Logger.Log(LogLevel.ERROR, message);
             ErrorHandler.HandleError(
-                new Exceptions.InvalidGroupException("Provided group is not in datafile."));
+                new InvalidGroupException("Provided group is not in datafile."));
             return new Group();
         }
 
@@ -527,12 +528,14 @@ namespace OptimizelySDK.Config
         public Experiment GetExperimentFromKey(string experimentKey)
         {
             if (_ExperimentKeyMap.ContainsKey(experimentKey))
+            {
                 return _ExperimentKeyMap[experimentKey];
+            }
 
-            string message = $@"Experiment key ""{experimentKey}"" is not in datafile.";
+            var message = $@"Experiment key ""{experimentKey}"" is not in datafile.";
             Logger.Log(LogLevel.ERROR, message);
             ErrorHandler.HandleError(
-                new Exceptions.InvalidExperimentException(
+                new InvalidExperimentException(
                     "Provided experiment is not in datafile."));
             return new Experiment();
         }
@@ -545,12 +548,14 @@ namespace OptimizelySDK.Config
         public Experiment GetExperimentFromId(string experimentId)
         {
             if (_ExperimentIdMap.ContainsKey(experimentId))
+            {
                 return _ExperimentIdMap[experimentId];
+            }
 
-            string message = $@"Experiment ID ""{experimentId}"" is not in datafile.";
+            var message = $@"Experiment ID ""{experimentId}"" is not in datafile.";
             Logger.Log(LogLevel.ERROR, message);
             ErrorHandler.HandleError(
-                new Exceptions.InvalidExperimentException(
+                new InvalidExperimentException(
                     "Provided experiment is not in datafile."));
             return new Experiment();
         }
@@ -563,12 +568,14 @@ namespace OptimizelySDK.Config
         public Entity.Event GetEvent(string eventKey)
         {
             if (_EventKeyMap.ContainsKey(eventKey))
+            {
                 return _EventKeyMap[eventKey];
+            }
 
-            string message = $@"Event key ""{eventKey}"" is not in datafile.";
+            var message = $@"Event key ""{eventKey}"" is not in datafile.";
             Logger.Log(LogLevel.ERROR, message);
             ErrorHandler.HandleError(
-                new Exceptions.InvalidEventException("Provided event is not in datafile."));
+                new InvalidEventException("Provided event is not in datafile."));
             return new Entity.Event();
         }
 
@@ -580,12 +587,14 @@ namespace OptimizelySDK.Config
         public Audience GetAudience(string audienceId)
         {
             if (_AudienceIdMap.ContainsKey(audienceId))
+            {
                 return _AudienceIdMap[audienceId];
+            }
 
-            string message = $@"Audience ID ""{audienceId}"" is not in datafile.";
+            var message = $@"Audience ID ""{audienceId}"" is not in datafile.";
             Logger.Log(LogLevel.ERROR, message);
             ErrorHandler.HandleError(
-                new Exceptions.InvalidAudienceException("Provided audience is not in datafile."));
+                new InvalidAudienceException("Provided audience is not in datafile."));
             return new Audience();
         }
 
@@ -597,12 +606,14 @@ namespace OptimizelySDK.Config
         public Attribute GetAttribute(string attributeKey)
         {
             if (_AttributeKeyMap.ContainsKey(attributeKey))
+            {
                 return _AttributeKeyMap[attributeKey];
+            }
 
-            string message = $@"Attribute key ""{attributeKey}"" is not in datafile.";
+            var message = $@"Attribute key ""{attributeKey}"" is not in datafile.";
             Logger.Log(LogLevel.ERROR, message);
             ErrorHandler.HandleError(
-                new Exceptions.InvalidAttributeException("Provided attribute is not in datafile."));
+                new InvalidAttributeException("Provided attribute is not in datafile."));
             return new Attribute();
         }
 
@@ -617,13 +628,15 @@ namespace OptimizelySDK.Config
         {
             if (_VariationKeyMap.ContainsKey(experimentKey) &&
                 _VariationKeyMap[experimentKey].ContainsKey(variationKey))
+            {
                 return _VariationKeyMap[experimentKey][variationKey];
+            }
 
-            string message = $@"No variation key ""{variationKey
+            var message = $@"No variation key ""{variationKey
             }"" defined in datafile for experiment ""{experimentKey}"".";
             Logger.Log(LogLevel.ERROR, message);
             ErrorHandler.HandleError(
-                new Exceptions.InvalidVariationException("Provided variation is not in datafile."));
+                new InvalidVariationException("Provided variation is not in datafile."));
             return new Variation();
         }
 
@@ -638,13 +651,15 @@ namespace OptimizelySDK.Config
         {
             if (_VariationKeyMapByExperimentId.ContainsKey(experimentId) &&
                 _VariationKeyMapByExperimentId[experimentId].ContainsKey(variationKey))
+            {
                 return _VariationKeyMapByExperimentId[experimentId][variationKey];
+            }
 
-            string message = $@"No variation key ""{variationKey
+            var message = $@"No variation key ""{variationKey
             }"" defined in datafile for experiment ""{experimentId}"".";
             Logger.Log(LogLevel.ERROR, message);
             ErrorHandler.HandleError(
-                new Exceptions.InvalidVariationException("Provided variation is not in datafile."));
+                new InvalidVariationException("Provided variation is not in datafile."));
             return new Variation();
         }
 
@@ -659,13 +674,15 @@ namespace OptimizelySDK.Config
         {
             if (_VariationIdMap.ContainsKey(experimentKey) &&
                 _VariationIdMap[experimentKey].ContainsKey(variationId))
+            {
                 return _VariationIdMap[experimentKey][variationId];
+            }
 
-            string message = $@"No variation ID ""{variationId
+            var message = $@"No variation ID ""{variationId
             }"" defined in datafile for experiment ""{experimentKey}"".";
             Logger.Log(LogLevel.ERROR, message);
             ErrorHandler.HandleError(
-                new Exceptions.InvalidVariationException("Provided variation is not in datafile."));
+                new InvalidVariationException("Provided variation is not in datafile."));
             return new Variation();
         }
 
@@ -680,13 +697,15 @@ namespace OptimizelySDK.Config
         {
             if (_VariationIdMapByExperimentId.ContainsKey(experimentId) &&
                 _VariationIdMapByExperimentId[experimentId].ContainsKey(variationId))
+            {
                 return _VariationIdMapByExperimentId[experimentId][variationId];
+            }
 
-            string message = $@"No variation ID ""{variationId
+            var message = $@"No variation ID ""{variationId
             }"" defined in datafile for experiment ""{experimentId}"".";
             Logger.Log(LogLevel.ERROR, message);
             ErrorHandler.HandleError(
-                new Exceptions.InvalidVariationException("Provided variation is not in datafile."));
+                new InvalidVariationException("Provided variation is not in datafile."));
             return new Variation();
         }
 
@@ -698,12 +717,14 @@ namespace OptimizelySDK.Config
         public FeatureFlag GetFeatureFlagFromKey(string featureKey)
         {
             if (_FeatureKeyMap.ContainsKey(featureKey))
+            {
                 return _FeatureKeyMap[featureKey];
+            }
 
-            string message = $@"Feature key ""{featureKey}"" is not in datafile.";
+            var message = $@"Feature key ""{featureKey}"" is not in datafile.";
             Logger.Log(LogLevel.ERROR, message);
             ErrorHandler.HandleError(
-                new Exceptions.InvalidFeatureException("Provided feature is not in datafile."));
+                new InvalidFeatureException("Provided feature is not in datafile."));
             return new FeatureFlag();
         }
 
@@ -741,12 +762,14 @@ namespace OptimizelySDK.Config
             }
 
             if (_RolloutIdMap.ContainsKey(rolloutId))
+            {
                 return _RolloutIdMap[rolloutId];
+            }
 
-            string message = $@"Rollout ID ""{rolloutId}"" is not in datafile.";
+            var message = $@"Rollout ID ""{rolloutId}"" is not in datafile.";
             Logger.Log(LogLevel.ERROR, message);
             ErrorHandler.HandleError(
-                new Exceptions.InvalidRolloutException("Provided rollout is not in datafile."));
+                new InvalidRolloutException("Provided rollout is not in datafile."));
             return new Rollout();
         }
 
@@ -763,10 +786,12 @@ namespace OptimizelySDK.Config
             {
                 var attribute = _AttributeKeyMap[attributeKey];
                 if (hasReservedPrefix)
+                {
                     Logger.Log(LogLevel.WARN,
                         $@"Attribute {attributeKey} unexpectedly has reserved prefix {
                             RESERVED_ATTRIBUTE_PREFIX
                         }; using attribute ID instead of reserved attribute name.");
+                }
 
                 return attribute.Id;
             }

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -18,14 +18,14 @@
 #define USE_ODP
 #endif
 
+using System.Collections.Generic;
+using System.Linq;
 using Newtonsoft.Json;
 using OptimizelySDK.Entity;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Exceptions;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Utils;
-using System.Collections.Generic;
-using System.Linq;
 using Attribute = OptimizelySDK.Entity.Attribute;
 
 namespace OptimizelySDK.Config

--- a/OptimizelySDK/Config/FallbackProjectConfigManager.cs
+++ b/OptimizelySDK/Config/FallbackProjectConfigManager.cs
@@ -48,24 +48,12 @@ namespace OptimizelySDK.Config
         /// <summary>
         /// SDK Key for Fallback is not used and always null
         /// </summary>
-        public virtual string SdkKey
-        {
-            get
-            {
-                return null;
-            }
-        }
+        public virtual string SdkKey => null;
 
         /// <summary>
         /// Access to current cached project configuration
         /// </summary>
         /// <returns>ProjectConfig instance</returns>
-        public virtual ProjectConfig CachedProjectConfig
-        {
-            get
-            {
-                return ProjectConfig;
-            }
-        }
+        public virtual ProjectConfig CachedProjectConfig => ProjectConfig;
     }
 }

--- a/OptimizelySDK/Config/HttpProjectConfigManager.cs
+++ b/OptimizelySDK/Config/HttpProjectConfigManager.cs
@@ -86,7 +86,7 @@ namespace OptimizelySDK.Config
                 var handler = new System.Net.Http.HttpClientHandler()
                 {
                     AutomaticDecompression = System.Net.DecompressionMethods.GZip |
-                                             System.Net.DecompressionMethods.Deflate
+                                             System.Net.DecompressionMethods.Deflate,
                 };
 
                 return handler;
@@ -118,7 +118,9 @@ namespace OptimizelySDK.Config
 
             // Send If-Modified-Since header if Last-Modified-Since header contains any value.
             if (!string.IsNullOrEmpty(LastModifiedSince))
+            {
                 request.Headers.Add("If-Modified-Since", LastModifiedSince);
+            }
 
             if (!string.IsNullOrEmpty(DatafileAccessToken))
             {
@@ -139,11 +141,15 @@ namespace OptimizelySDK.Config
             }
 
             // Update Last-Modified header if provided.
-            if (result.Headers.TryGetValues("Last-Modified", out IEnumerable<string> values))
+            if (result.Headers.TryGetValues("Last-Modified", out var values))
+            {
                 LastModifiedSince = values.First();
+            }
 
             if (result.StatusCode == System.Net.HttpStatusCode.NotModified)
+            {
                 return null;
+            }
 
             var content = result.Content.ReadAsStringAsync();
             content.Wait();
@@ -157,21 +163,27 @@ namespace OptimizelySDK.Config
 
             // Send If-Modified-Since header if Last-Modified-Since header contains any value.
             if (!string.IsNullOrEmpty(LastModifiedSince))
+            {
                 request.Headers.Add("If-Modified-Since", LastModifiedSince);
+            }
+
             var result = (System.Net.HttpWebResponse)request.GetResponse();
-            
-            if (result.StatusCode != System.Net.HttpStatusCode.OK) {
+
+            if (result.StatusCode != System.Net.HttpStatusCode.OK)
+            {
                 Logger.Log(LogLevel.ERROR, $"Error fetching datafile \"{result.StatusCode}\"");
             }
+
             var lastModified = result.Headers.GetValues("Last-Modified");
-            if(!string.IsNullOrEmpty(lastModified.First()))
+            if (!string.IsNullOrEmpty(lastModified.First()))
             {
                 LastModifiedSince = lastModified.First();
             }
 
             var encoding = System.Text.Encoding.ASCII;
-            using (var reader = new System.IO.StreamReader(result.GetResponseStream(), encoding)) {
-                string responseText = reader.ReadToEnd();
+            using (var reader = new System.IO.StreamReader(result.GetResponseStream(), encoding))
+            {
+                var responseText = reader.ReadToEnd();
                 return responseText;
             }
         }
@@ -186,7 +198,9 @@ namespace OptimizelySDK.Config
             var datafile = GetRemoteDatafileResponse();
 
             if (datafile == null)
+            {
                 return null;
+            }
 
             return DatafileProjectConfig.Create(datafile, Logger, ErrorHandler);
         }
@@ -245,7 +259,7 @@ namespace OptimizelySDK.Config
 #if !NET40 && !NET35
             public Builder WithAccessToken(string accessToken)
             {
-                this.DatafileAccessToken = accessToken;
+                DatafileAccessToken = accessToken;
 
                 return this;
             }
@@ -330,10 +344,14 @@ namespace OptimizelySDK.Config
                 HttpProjectConfigManager configManager = null;
 
                 if (Logger == null)
+                {
                     Logger = new DefaultLogger();
+                }
 
                 if (ErrorHandler == null)
+                {
                     ErrorHandler = new DefaultErrorHandler(Logger, false);
+                }
 
                 if (string.IsNullOrEmpty(Format))
                 {
@@ -418,11 +436,15 @@ namespace OptimizelySDK.Config
 
 
                 if (StartByDefault)
+                {
                     configManager.Start();
+                }
 
                 // Optionally block until config is available.
                 if (!defer)
+                {
                     configManager.GetConfig();
+                }
 
                 return configManager;
             }

--- a/OptimizelySDK/Config/HttpProjectConfigManager.cs
+++ b/OptimizelySDK/Config/HttpProjectConfigManager.cs
@@ -18,13 +18,13 @@
 #define USE_ODP
 #endif
 
-using OptimizelySDK.ErrorHandler;
-using OptimizelySDK.Logger;
-using OptimizelySDK.Notifications;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using OptimizelySDK.ErrorHandler;
+using OptimizelySDK.Logger;
+using OptimizelySDK.Notifications;
 
 namespace OptimizelySDK.Config
 {

--- a/OptimizelySDK/Config/PollingProjectConfigManager.cs
+++ b/OptimizelySDK/Config/PollingProjectConfigManager.cs
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
 using OptimizelySDK.OptlyConfig;
 using OptimizelySDK.Utils;
-using System;
-using System.Threading;
-using System.Threading.Tasks;
 
 namespace OptimizelySDK.Config
 {

--- a/OptimizelySDK/Config/PollingProjectConfigManager.cs
+++ b/OptimizelySDK/Config/PollingProjectConfigManager.cs
@@ -101,7 +101,11 @@ namespace OptimizelySDK.Config
         /// </summary>
         public void Stop()
         {
-            if (Disposed) return;
+            if (Disposed)
+            {
+                return;
+            }
+
             // don't call now and onwards.
             SchedulerService.Change(-1, -1);
 
@@ -116,13 +120,16 @@ namespace OptimizelySDK.Config
         /// <returns>ProjectConfig</returns>
         public ProjectConfig GetConfig()
         {
-            if (Disposed) return null;
+            if (Disposed)
+            {
+                return null;
+            }
 
             if (IsStarted)
             {
                 try
                 {
-                    bool isCompleted = CompletableConfigManager.Task.Wait(BlockingTimeout);
+                    var isCompleted = CompletableConfigManager.Task.Wait(BlockingTimeout);
                     if (!isCompleted)
                     {
                         // Don't wait next time.
@@ -150,13 +157,7 @@ namespace OptimizelySDK.Config
         /// Access to current cached project configuration
         /// </summary>
         /// <returns>ProjectConfig instance</returns>
-        public virtual ProjectConfig CachedProjectConfig
-        {
-            get
-            {
-                return CurrentProjectConfig;
-            }
-        }
+        public virtual ProjectConfig CachedProjectConfig => CurrentProjectConfig;
 
         /// <summary>
         /// Sets the latest available ProjectConfig valid instance.
@@ -166,12 +167,16 @@ namespace OptimizelySDK.Config
         public bool SetConfig(ProjectConfig projectConfig)
         {
             if (projectConfig == null)
+            {
                 return false;
+            }
 
             var previousVersion =
                 CurrentProjectConfig == null ? "null" : CurrentProjectConfig.Revision;
             if (projectConfig.Revision == previousVersion)
+            {
                 return false;
+            }
 
             CurrentProjectConfig = projectConfig;
             SetOptimizelyConfig(CurrentProjectConfig);
@@ -209,7 +214,10 @@ namespace OptimizelySDK.Config
 
         public virtual void Dispose()
         {
-            if (Disposed) return;
+            if (Disposed)
+            {
+                return;
+            }
 
             SchedulerService.Change(-1, -1);
             SchedulerService.Dispose();
@@ -231,7 +239,9 @@ namespace OptimizelySDK.Config
 
                     // during in-flight, if PollingProjectConfigManagerStopped, then don't need to set.
                     if (IsStarted)
+                    {
                         SetConfig(config);
+                    }
                 }
                 catch (Exception exception)
                 {

--- a/OptimizelySDK/Entity/Attribute.cs
+++ b/OptimizelySDK/Entity/Attribute.cs
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace OptimizelySDK.Entity
 {
-    public class Attribute : IdKeyEntity
-    {
-    }
+    public class Attribute : IdKeyEntity { }
 }

--- a/OptimizelySDK/Entity/Audience.cs
+++ b/OptimizelySDK/Entity/Audience.cs
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using OptimizelySDK.AudienceConditions;
 using OptimizelySDK.Utils;
-using System.Collections.Generic;
 
 namespace OptimizelySDK.Entity
 {

--- a/OptimizelySDK/Entity/Audience.cs
+++ b/OptimizelySDK/Entity/Audience.cs
@@ -49,7 +49,9 @@ namespace OptimizelySDK.Entity
             get
             {
                 if (Conditions == null)
+                {
                     return null;
+                }
 
                 if (_decodedConditions == null)
                 {
@@ -78,14 +80,20 @@ namespace OptimizelySDK.Entity
             get
             {
                 if (Conditions == null)
+                {
                     return null;
+                }
 
                 if (_conditionsString == null)
                 {
                     if (Conditions is JToken token)
+                    {
                         _conditionsString = token.ToString(Formatting.None);
+                    }
                     else
+                    {
                         _conditionsString = Conditions.ToString();
+                    }
                 }
 
                 return _conditionsString;

--- a/OptimizelySDK/Entity/Entity.cs
+++ b/OptimizelySDK/Entity/Entity.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 
 namespace OptimizelySDK.Entity

--- a/OptimizelySDK/Entity/Event.cs
+++ b/OptimizelySDK/Entity/Event.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace OptimizelySDK.Entity
 {
     public class Event : IdKeyEntity

--- a/OptimizelySDK/Entity/EventTags.cs
+++ b/OptimizelySDK/Entity/EventTags.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System.Collections.Generic;
 using OptimizelySDK.Logger;
 
@@ -20,15 +21,22 @@ namespace OptimizelySDK.Entity
 {
     public class EventTags : Dictionary<string, object>
     {
-        public EventTags FilterNullValues(ILogger logger) {
-            EventTags answer = new EventTags();
-            foreach (KeyValuePair<string, object> pair in this) {
-                if (pair.Value != null) {
+        public EventTags FilterNullValues(ILogger logger)
+        {
+            var answer = new EventTags();
+            foreach (var pair in this)
+            {
+                if (pair.Value != null)
+                {
                     answer[pair.Key] = pair.Value;
-                } else {
-                    logger.Log(LogLevel.ERROR, $"[EventTags] Null value for key {pair.Key} removed and will not be sent to results.");
+                }
+                else
+                {
+                    logger.Log(LogLevel.ERROR,
+                        $"[EventTags] Null value for key {pair.Key} removed and will not be sent to results.");
                 }
             }
+
             return answer;
         }
     }

--- a/OptimizelySDK/Entity/Experiment.cs
+++ b/OptimizelySDK/Entity/Experiment.cs
@@ -15,10 +15,10 @@
  */
 
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
-using OptimizelySDK.Utils;
-using OptimizelySDK.AudienceConditions;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OptimizelySDK.AudienceConditions;
+using OptimizelySDK.Utils;
 
 namespace OptimizelySDK.Entity
 {

--- a/OptimizelySDK/Entity/Experiment.cs
+++ b/OptimizelySDK/Entity/Experiment.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using OptimizelySDK.Utils;
@@ -23,9 +24,9 @@ namespace OptimizelySDK.Entity
 {
     public class Experiment : IdKeyEntity
     {
-        const string STATUS_RUNNING = "Running";
+        private const string STATUS_RUNNING = "Running";
 
-        const string MUTEX_GROUP_POLICY = "random";
+        private const string MUTEX_GROUP_POLICY = "random";
 
         /// <summary>
         /// Experiment Status
@@ -52,10 +53,10 @@ namespace OptimizelySDK.Entity
         /// </summary>
         public Dictionary<string, string> ForcedVariations { get; set; }
 
-		/// <summary>
-		/// ForcedVariations for the experiment
-		/// </summary>
-       	public Dictionary<string, string> UserIdToKeyVariations { get { return ForcedVariations; } }
+        /// <summary>
+        /// ForcedVariations for the experiment
+        /// </summary>
+        public Dictionary<string, string> UserIdToKeyVariations => ForcedVariations;
 
         /// <summary>
         /// Policy of the experiment group
@@ -77,17 +78,22 @@ namespace OptimizelySDK.Entity
             get
             {
                 if (AudienceIds == null || AudienceIds.Length == 0)
+                {
                     return null;
-                
+                }
+
                 if (_audienceIdsList == null)
                 {
                     var conditions = new List<ICondition>();
                     foreach (var audienceId in AudienceIds)
-                        conditions.Add(new AudienceIdCondition() { AudienceId = (string)audienceId });
+                    {
+                        conditions.Add(
+                            new AudienceIdCondition() { AudienceId = (string)audienceId });
+                    }
 
                     _audienceIdsList = new OrCondition() { Conditions = conditions.ToArray() };
                 }
-                
+
                 return _audienceIdsList;
             }
         }
@@ -102,10 +108,14 @@ namespace OptimizelySDK.Entity
             get
             {
                 if (AudienceIds == null)
+                {
                     return null;
+                }
 
                 if (_audienceIdsString == null)
+                {
                     _audienceIdsString = JsonConvert.SerializeObject(AudienceIds, Formatting.None);
+                }
 
                 return _audienceIdsString;
             }
@@ -131,14 +141,23 @@ namespace OptimizelySDK.Entity
             get
             {
                 if (AudienceConditions == null)
+                {
                     return null;
+                }
 
                 if (_audienceConditionsList == null)
                 {
                     if (AudienceConditions is string)
-                        _audienceConditionsList = ConditionParser.ParseAudienceConditions(JToken.Parse((string)AudienceConditions));
+                    {
+                        _audienceConditionsList =
+                            ConditionParser.ParseAudienceConditions(
+                                JToken.Parse((string)AudienceConditions));
+                    }
                     else
-                        _audienceConditionsList = ConditionParser.ParseAudienceConditions((JToken)AudienceConditions);
+                    {
+                        _audienceConditionsList =
+                            ConditionParser.ParseAudienceConditions((JToken)AudienceConditions);
+                    }
                 }
 
                 return _audienceConditionsList;
@@ -155,48 +174,73 @@ namespace OptimizelySDK.Entity
             get
             {
                 if (AudienceConditions == null)
+                {
                     return null;
+                }
 
                 if (_audienceConditionsString == null)
                 {
                     if (AudienceConditions is JToken token)
+                    {
                         _audienceConditionsString = token.ToString(Formatting.None);
+                    }
                     else
+                    {
                         _audienceConditionsString = AudienceConditions.ToString();
+                    }
                 }
 
                 return _audienceConditionsString;
             }
         }
 
-        bool isGenerateKeyMapCalled = false;
+        private bool isGenerateKeyMapCalled = false;
 
         private Dictionary<string, Variation> _VariationKeyToVariationMap;
-        public Dictionary<string, Variation> VariationKeyToVariationMap {
-            get {
-                if (!isGenerateKeyMapCalled) GenerateVariationKeyMap();
+
+        public Dictionary<string, Variation> VariationKeyToVariationMap
+        {
+            get
+            {
+                if (!isGenerateKeyMapCalled)
+                {
+                    GenerateVariationKeyMap();
+                }
+
                 return _VariationKeyToVariationMap;
             }
         }
 
-		private Dictionary<string, Variation> _VariationIdToVariationMap;
-		public Dictionary<string, Variation> VariationIdToVariationMap {
+        private Dictionary<string, Variation> _VariationIdToVariationMap;
+
+        public Dictionary<string, Variation> VariationIdToVariationMap
+        {
             get
             {
-                if (!isGenerateKeyMapCalled) GenerateVariationKeyMap();
+                if (!isGenerateKeyMapCalled)
+                {
+                    GenerateVariationKeyMap();
+                }
+
                 return _VariationIdToVariationMap;
             }
         }
 
         public void GenerateVariationKeyMap()
         {
-            if (Variations == null) return;
-            _VariationIdToVariationMap = ConfigParser<Variation>.GenerateMap(entities: Variations, getKey: a => a.Id, clone: true);
-            _VariationKeyToVariationMap = ConfigParser<Variation>.GenerateMap(entities: Variations, getKey: a => a.Key, clone: true);
+            if (Variations == null)
+            {
+                return;
+            }
+
+            _VariationIdToVariationMap =
+                ConfigParser<Variation>.GenerateMap(Variations, a => a.Id, true);
+            _VariationKeyToVariationMap =
+                ConfigParser<Variation>.GenerateMap(Variations, a => a.Key, true);
             isGenerateKeyMapCalled = true;
         }
 
-		// Code from PHP, need to build traffic and variations from config
+        // Code from PHP, need to build traffic and variations from config
 #if false
         /**
          * @param $variations array Variations in experiment.
@@ -211,31 +255,22 @@ namespace OptimizelySDK.Entity
          */
         public function setTrafficAllocation($trafficAllocation)
         {
-        $this->_trafficAllocation = ConfigParser::generateMap($trafficAllocation, null, TrafficAllocation::class);
+        $this->_trafficAllocation =
+ ConfigParser::generateMap($trafficAllocation, null, TrafficAllocation::class);
         }
 #endif
 
-		/// <summary>
-		/// Determine if experiment is in a mutually exclusive group
-		/// </summary>
-		public bool IsInMutexGroup
-        {
-            get
-            {
-                return !string.IsNullOrEmpty(GroupPolicy) && GroupPolicy == MUTEX_GROUP_POLICY;
-            }
-        }
+        /// <summary>
+        /// Determine if experiment is in a mutually exclusive group
+        /// </summary>
+        public bool IsInMutexGroup =>
+            !string.IsNullOrEmpty(GroupPolicy) && GroupPolicy == MUTEX_GROUP_POLICY;
 
         /// <summary>
         /// Determine if experiment is running or not
         /// </summary>
-        public bool IsExperimentRunning
-        {
-            get
-            {
-                return !string.IsNullOrEmpty(Status) && Status == STATUS_RUNNING;
-            }
-        }
+        public bool IsExperimentRunning =>
+            !string.IsNullOrEmpty(Status) && Status == STATUS_RUNNING;
 
         /// <summary>
         /// Determin if user is forced variation of experiment

--- a/OptimizelySDK/Entity/FeatureDecision.cs
+++ b/OptimizelySDK/Entity/FeatureDecision.cs
@@ -24,7 +24,7 @@ namespace OptimizelySDK.Entity
         public Experiment Experiment { get; }
         public Variation Variation { get; }
         public string Source { get; }
-        
+
         public FeatureDecision(Experiment experiment, Variation variation, string source)
         {
             Experiment = experiment;

--- a/OptimizelySDK/Entity/FeatureFlag.cs
+++ b/OptimizelySDK/Entity/FeatureFlag.cs
@@ -26,27 +26,29 @@ namespace OptimizelySDK.Entity
         public List<string> ExperimentIds { get; set; }
 
         private List<FeatureVariable> _Variables;
+
         public List<FeatureVariable> Variables
         {
-            get
-            {
-                return _Variables;
-            }
+            get => _Variables;
             set
             {
                 _Variables = value;
 
                 // Generating Feature Variable key map.
                 if (_Variables != null)
-                    VariableKeyToFeatureVariableMap = ConfigParser<FeatureVariable>.GenerateMap(entities: _Variables, getKey: v => v.Key, clone: true);
+                {
+                    VariableKeyToFeatureVariableMap =
+                        ConfigParser<FeatureVariable>.GenerateMap(_Variables, v => v.Key, true);
+                }
             }
         }
-        
+
         public Dictionary<string, FeatureVariable> VariableKeyToFeatureVariableMap { get; set; }
 
         public FeatureVariable GetFeatureVariableFromKey(string variableKey)
         {
-            if (VariableKeyToFeatureVariableMap != null && VariableKeyToFeatureVariableMap.ContainsKey(variableKey))
+            if (VariableKeyToFeatureVariableMap != null &&
+                VariableKeyToFeatureVariableMap.ContainsKey(variableKey))
             {
                 return VariableKeyToFeatureVariableMap[variableKey];
             }

--- a/OptimizelySDK/Entity/FeatureFlag.cs
+++ b/OptimizelySDK/Entity/FeatureFlag.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Utils;
 using System.Collections.Generic;
+using OptimizelySDK.Utils;
 
 namespace OptimizelySDK.Entity
 {

--- a/OptimizelySDK/Entity/FeatureVariable.cs
+++ b/OptimizelySDK/Entity/FeatureVariable.cs
@@ -23,11 +23,11 @@ namespace OptimizelySDK.Entity
         public const string DOUBLE_TYPE = "double";
         public const string BOOLEAN_TYPE = "boolean";
         public const string JSON_TYPE = "json";
-        
+
         public enum VariableStatus
         {
             ACTIVE,
-            ARCHIVED
+            ARCHIVED,
         }
 
 
@@ -37,17 +37,12 @@ namespace OptimizelySDK.Entity
 
         public string SubType
         {
-            get
-            {
-                return _subType;
-            }
-            set
-            {
-                _subType = value;
-            }
+            get => _subType;
+            set => _subType = value;
         }
 
         private string _type;
+
         public string Type
         {
             get
@@ -56,12 +51,10 @@ namespace OptimizelySDK.Entity
                 {
                     return JSON_TYPE;
                 }
+
                 return _type;
             }
-            set
-            {
-                _type = value;
-            }
+            set => _type = value;
         }
 
         public VariableStatus Status { get; set; }
@@ -73,7 +66,8 @@ namespace OptimizelySDK.Entity
         /// <param name="variableType">Variable type.</param>
         public static string GetFeatureVariableTypeName(string variableType)
         {
-            switch (variableType) {
+            switch (variableType)
+            {
                 case BOOLEAN_TYPE:
                     return "GetFeatureVariableBoolean";
                 case DOUBLE_TYPE:

--- a/OptimizelySDK/Entity/FeatureVariableUsage.cs
+++ b/OptimizelySDK/Entity/FeatureVariableUsage.cs
@@ -27,6 +27,5 @@ namespace OptimizelySDK.Entity
         /// Audience Name
         /// </summary>
         public string Value { get; set; }
-
     }
 }

--- a/OptimizelySDK/Entity/ForcedVariation.cs
+++ b/OptimizelySDK/Entity/ForcedVariation.cs
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace OptimizelySDK.Entity
 {
-    public class ForcedVariation : IdKeyEntity
-    {
-    }
+    public class ForcedVariation : IdKeyEntity { }
 }

--- a/OptimizelySDK/Entity/Group.cs
+++ b/OptimizelySDK/Entity/Group.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace OptimizelySDK.Entity
 {
     public class Group : Entity
@@ -43,9 +44,9 @@ namespace OptimizelySDK.Entity
      */
     public function setTrafficAllocation($trafficAllocation)
     {
-        $this->_trafficAllocation = ConfigParser::generateMap($trafficAllocation, null, TrafficAllocation::class);
+        $this->_trafficAllocation =
+ ConfigParser::generateMap($trafficAllocation, null, TrafficAllocation::class);
     }
 #endif
-
     }
 }

--- a/OptimizelySDK/Entity/IdKeyEntity.cs
+++ b/OptimizelySDK/Entity/IdKeyEntity.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 
 namespace OptimizelySDK.Entity
@@ -36,7 +37,9 @@ namespace OptimizelySDK.Entity
         {
             var entity = other as IdKeyEntity;
             if (entity == null || other.GetType() != GetType())
+            {
                 return false;
+            }
 
             return Id == entity.Id && Key == entity.Key;
         }

--- a/OptimizelySDK/Entity/Integration.cs
+++ b/OptimizelySDK/Entity/Integration.cs
@@ -21,14 +21,14 @@ namespace OptimizelySDK.Entity
     public class Integration : IdKeyEntity
     {
         public string Host { get; set; }
-        
+
         public string PublicKey { get; set; }
 
         public override string ToString()
         {
             var sb = new StringBuilder();
             sb.AppendFormat("Integration{{key='{0}'", Key);
-            
+
             if (!string.IsNullOrEmpty(Host))
             {
                 sb.AppendFormat(", host='{0}'", Host);
@@ -40,7 +40,7 @@ namespace OptimizelySDK.Entity
             }
 
             sb.Append("}");
-            
+
             return sb.ToString();
         }
     }

--- a/OptimizelySDK/Entity/Result.cs
+++ b/OptimizelySDK/Entity/Result.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using OptimizelySDK.OptimizelyDecisions;
 
 namespace OptimizelySDK.Entity
@@ -29,14 +30,14 @@ namespace OptimizelySDK.Entity
 
         public Result<T> SetReasons(DecisionReasons decisionReasons)
         {
-            DecisionReasons =  decisionReasons;
+            DecisionReasons = decisionReasons;
 
             return this;
         }
 
         public static Result<T> NullResult(DecisionReasons decisionReasons)
         {
-            return NewResult(default(T), decisionReasons);
+            return NewResult(default, decisionReasons);
         }
     }
 }

--- a/OptimizelySDK/Entity/TrafficAllocation.cs
+++ b/OptimizelySDK/Entity/TrafficAllocation.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace OptimizelySDK.Entity
 {
     public class TrafficAllocation : Entity

--- a/OptimizelySDK/Entity/UserAttributes.cs
+++ b/OptimizelySDK/Entity/UserAttributes.cs
@@ -13,18 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System.Collections.Generic;
 
 namespace OptimizelySDK.Entity
 {
     public class UserAttributes : Dictionary<string, object>
     {
-        public UserAttributes() : base()
-        {
-        }
+        public UserAttributes() : base() { }
 
-        public UserAttributes(IDictionary<string, object> dictionary) : base(dictionary)
-        {
-        }
+        public UserAttributes(IDictionary<string, object> dictionary) : base(dictionary) { }
     }
 }

--- a/OptimizelySDK/Entity/Variation.cs
+++ b/OptimizelySDK/Entity/Variation.cs
@@ -26,25 +26,31 @@ namespace OptimizelySDK.Entity
         [Newtonsoft.Json.JsonProperty("variables")]
         public List<FeatureVariableUsage> FeatureVariableUsageInstances
         {
-            get
-            {
-                return _FeatureVariableUsageInstances;
-            }
+            get => _FeatureVariableUsageInstances;
             set
             {
                 _FeatureVariableUsageInstances = value;
 
                 // Generating Variable Usage key map.
                 if (_FeatureVariableUsageInstances != null)
-                    VariableIdToVariableUsageInstanceMap = ConfigParser<FeatureVariableUsage>.GenerateMap(entities: _FeatureVariableUsageInstances, getKey: v => v.Id.ToString(), clone: true);
+                {
+                    VariableIdToVariableUsageInstanceMap =
+                        ConfigParser<FeatureVariableUsage>.GenerateMap(
+                            _FeatureVariableUsageInstances, v => v.Id.ToString(), true);
+                }
             }
         }
 
-        public Dictionary<string, FeatureVariableUsage> VariableIdToVariableUsageInstanceMap { get; set; }
+        public Dictionary<string, FeatureVariableUsage> VariableIdToVariableUsageInstanceMap
+        {
+            get;
+            set;
+        }
 
         public FeatureVariableUsage GetFeatureVariableUsageFromId(string variableId)
         {
-            if (VariableIdToVariableUsageInstanceMap != null && VariableIdToVariableUsageInstanceMap.ContainsKey(variableId))
+            if (VariableIdToVariableUsageInstanceMap != null &&
+                VariableIdToVariableUsageInstanceMap.ContainsKey(variableId))
             {
                 return VariableIdToVariableUsageInstanceMap[variableId];
             }
@@ -54,12 +60,6 @@ namespace OptimizelySDK.Entity
 
         public bool? FeatureEnabled { get; set; }
 
-        public bool IsFeatureEnabled
-        {
-            get
-            {
-                return FeatureEnabled ?? false;
-            }
-        }
+        public bool IsFeatureEnabled => FeatureEnabled ?? false;
     }
 }

--- a/OptimizelySDK/Entity/Variation.cs
+++ b/OptimizelySDK/Entity/Variation.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Utils;
 using System.Collections.Generic;
+using OptimizelySDK.Utils;
 
 namespace OptimizelySDK.Entity
 {

--- a/OptimizelySDK/ErrorHandler/DefaultErrorHandler.cs
+++ b/OptimizelySDK/ErrorHandler/DefaultErrorHandler.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using OptimizelySDK.Logger;
 using System;
 
@@ -34,16 +35,21 @@ namespace OptimizelySDK.ErrorHandler
         public void HandleError(Exception exception)
         {
             if (Logger != null)
+            {
                 Logger.Log(LogLevel.ERROR, exception.Message);
+            }
 
             if (ThrowExceptions)
+            {
                 throw exception;
+            }
         }
 
         /// <summary>
         /// An optional Logger include exceptions in your log
         /// </summary>
         private ILogger Logger;
+
         private bool ThrowExceptions;
     }
 }

--- a/OptimizelySDK/ErrorHandler/DefaultErrorHandler.cs
+++ b/OptimizelySDK/ErrorHandler/DefaultErrorHandler.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Logger;
 using System;
+using OptimizelySDK.Logger;
 
 namespace OptimizelySDK.ErrorHandler
 {

--- a/OptimizelySDK/ErrorHandler/IErrorHandler.cs
+++ b/OptimizelySDK/ErrorHandler/IErrorHandler.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 
 namespace OptimizelySDK.ErrorHandler

--- a/OptimizelySDK/ErrorHandler/NoOpErrorHandler.cs
+++ b/OptimizelySDK/ErrorHandler/NoOpErrorHandler.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Logger;
 using System;
+using OptimizelySDK.Logger;
 
 namespace OptimizelySDK.ErrorHandler
 {

--- a/OptimizelySDK/ErrorHandler/NoOpErrorHandler.cs
+++ b/OptimizelySDK/ErrorHandler/NoOpErrorHandler.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using OptimizelySDK.Logger;
 using System;
 
@@ -21,8 +22,6 @@ namespace OptimizelySDK.ErrorHandler
     public class NoOpErrorHandler : DefaultErrorHandler
     {
         public NoOpErrorHandler(ILogger logger = null)
-            : base(logger: logger, throwExceptions: false)
-        {
-        }
+            : base(logger, false) { }
     }
 }

--- a/OptimizelySDK/Event/BatchEventProcessor.cs
+++ b/OptimizelySDK/Event/BatchEventProcessor.cs
@@ -17,14 +17,14 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using OptimizelySDK.Event.Entity;
-using System.Threading;
-using OptimizelySDK.Utils;
-using OptimizelySDK.Logger;
-using OptimizelySDK.ErrorHandler;
 using System.Linq;
+using System.Threading;
+using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Event.Dispatcher;
+using OptimizelySDK.Event.Entity;
+using OptimizelySDK.Logger;
 using OptimizelySDK.Notifications;
+using OptimizelySDK.Utils;
 
 namespace OptimizelySDK.Event
 {

--- a/OptimizelySDK/Event/BatchEventProcessor.cs
+++ b/OptimizelySDK/Event/BatchEventProcessor.cs
@@ -37,7 +37,7 @@ namespace OptimizelySDK.Event
      * the BlockingQueue and buffers them for either a configured batch size or for a
      * maximum duration before the resulting LogEvent is sent to the NotificationManager.
      */
-    public class BatchEventProcessor: EventProcessor, IDisposable
+    public class BatchEventProcessor : EventProcessor, IDisposable
     {
         private const int DEFAULT_BATCH_SIZE = 10;
         private const int DEFAULT_QUEUE_CAPACITY = 1000;
@@ -56,7 +56,7 @@ namespace OptimizelySDK.Event
 
         public bool IsStarted { get; private set; }
         private Thread Executer;
-        
+
         public ILogger Logger { get; protected set; }
         public IErrorHandler ErrorHandler { get; protected set; }
         public NotificationCenter NotificationCenter { get; set; }
@@ -64,10 +64,10 @@ namespace OptimizelySDK.Event
         private readonly object mutex = new object();
 
         public IEventDispatcher EventDispatcher { get; private set; }
-        public BlockingCollection<object> EventQueue { get; private set; } 
+        public BlockingCollection<object> EventQueue { get; private set; }
         private List<UserEvent> CurrentBatch = new List<UserEvent>();
         private long FlushingIntervalDeadline;
-              
+
         public void Start()
         {
             if (IsStarted && !Disposed)
@@ -76,7 +76,8 @@ namespace OptimizelySDK.Event
                 return;
             }
 
-            FlushingIntervalDeadline = DateTime.Now.MillisecondsSince1970() + (long)FlushInterval.TotalMilliseconds;
+            FlushingIntervalDeadline = DateTime.Now.MillisecondsSince1970() +
+                                       (long)FlushInterval.TotalMilliseconds;
             Executer = new Thread(() => Run());
             Executer.Start();
             IsStarted = true;
@@ -94,12 +95,13 @@ namespace OptimizelySDK.Event
                 {
                     if (DateTime.Now.MillisecondsSince1970() > FlushingIntervalDeadline)
                     {
-                        Logger.Log(LogLevel.DEBUG, $"Deadline exceeded flushing current batch, {DateTime.Now.Millisecond}, {FlushingIntervalDeadline}.");
+                        Logger.Log(LogLevel.DEBUG,
+                            $"Deadline exceeded flushing current batch, {DateTime.Now.Millisecond}, {FlushingIntervalDeadline}.");
                         FlushQueue();
                     }
-                    
-                    if (!EventQueue.TryTake(out object item, 50))
-                    {                        
+
+                    if (!EventQueue.TryTake(out var item, 50))
+                    {
                         Thread.Sleep(50);
                         continue;
                     }
@@ -118,34 +120,41 @@ namespace OptimizelySDK.Event
                     }
 
                     if (item is UserEvent userEvent)
+                    {
                         AddToBatch(userEvent);
+                    }
                 }
             }
             catch (InvalidOperationException e)
             {
                 // An InvalidOperationException means that Take() was called on a completed collection
-                Logger.Log(LogLevel.DEBUG, "Unable to take item from eventQueue: " + e.GetAllMessages());
+                Logger.Log(LogLevel.DEBUG,
+                    "Unable to take item from eventQueue: " + e.GetAllMessages());
             }
             catch (Exception exception)
             {
-                Logger.Log(LogLevel.ERROR, "Uncaught exception processing buffer. Error: " + exception.GetAllMessages());
+                Logger.Log(LogLevel.ERROR,
+                    "Uncaught exception processing buffer. Error: " + exception.GetAllMessages());
             }
             finally
             {
-                Logger.Log(LogLevel.INFO, "Exiting processing loop. Attempting to flush pending events.");
+                Logger.Log(LogLevel.INFO,
+                    "Exiting processing loop. Attempting to flush pending events.");
                 FlushQueue();
             }
         }
 
         public void Flush()
         {
-            FlushingIntervalDeadline = DateTime.Now.MillisecondsSince1970() + (long)FlushInterval.TotalMilliseconds;
+            FlushingIntervalDeadline = DateTime.Now.MillisecondsSince1970() +
+                                       (long)FlushInterval.TotalMilliseconds;
             EventQueue.Add(FLUSH_SIGNAL);
         }
 
         private void FlushQueue()
         {
-            FlushingIntervalDeadline = DateTime.Now.MillisecondsSince1970() + (long)FlushInterval.TotalMilliseconds;
+            FlushingIntervalDeadline = DateTime.Now.MillisecondsSince1970() +
+                                       (long)FlushInterval.TotalMilliseconds;
 
             if (CurrentBatch.Count == 0)
             {
@@ -158,11 +167,12 @@ namespace OptimizelySDK.Event
                 toProcessBatch = new List<UserEvent>(CurrentBatch);
                 CurrentBatch.Clear();
             }
-            
 
-            LogEvent logEvent = EventFactory.CreateLogEvent(toProcessBatch.ToArray(), Logger);
 
-            NotificationCenter?.SendNotifications(NotificationCenter.NotificationType.LogEvent, logEvent);
+            var logEvent = EventFactory.CreateLogEvent(toProcessBatch.ToArray(), Logger);
+
+            NotificationCenter?.SendNotifications(NotificationCenter.NotificationType.LogEvent,
+                logEvent);
 
             try
             {
@@ -179,21 +189,29 @@ namespace OptimizelySDK.Event
         /// </summary>
         public void Stop()
         {
-            if (Disposed) return;
+            if (Disposed)
+            {
+                return;
+            }
 
             EventQueue.Add(SHUTDOWN_SIGNAL);
-            
+
             if (!Executer.Join(TimeoutInterval))
-                Logger.Log(LogLevel.ERROR, $"Timeout exceeded attempting to close for {TimeoutInterval.Milliseconds} ms");
+            {
+                Logger.Log(LogLevel.ERROR,
+                    $"Timeout exceeded attempting to close for {TimeoutInterval.Milliseconds} ms");
+            }
 
             IsStarted = false;
             Logger.Log(LogLevel.WARN, $"Stopping scheduler.");
         }
-        
-        public void Process(UserEvent userEvent) {
+
+        public void Process(UserEvent userEvent)
+        {
             Logger.Log(LogLevel.DEBUG, "Received userEvent: " + userEvent);
 
-            if (Disposed) { 
+            if (Disposed)
+            {
                 Logger.Log(LogLevel.WARN, "Executor shutdown, not accepting tasks.");
                 return;
             }
@@ -203,7 +221,7 @@ namespace OptimizelySDK.Event
                 Logger.Log(LogLevel.WARN, "Payload not accepted by the queue.");
             }
         }
-        
+
         private void AddToBatch(UserEvent userEvent)
         {
             if (ShouldSplit(userEvent))
@@ -214,19 +232,26 @@ namespace OptimizelySDK.Event
 
             // Reset the deadline if starting a new batch.
             if (CurrentBatch.Count == 0)
-                FlushingIntervalDeadline = DateTime.Now.MillisecondsSince1970() + (long)FlushInterval.TotalMilliseconds;
+            {
+                FlushingIntervalDeadline = DateTime.Now.MillisecondsSince1970() +
+                                           (long)FlushInterval.TotalMilliseconds;
+            }
 
-            lock (mutex) {
+            lock (mutex)
+            {
                 CurrentBatch.Add(userEvent);
             }
-            
-            if (CurrentBatch.Count >= BatchSize) {
+
+            if (CurrentBatch.Count >= BatchSize)
+            {
                 FlushQueue();
             }
         }
 
-        private bool ShouldSplit(UserEvent userEvent) {
-            if (CurrentBatch.Count == 0) {
+        private bool ShouldSplit(UserEvent userEvent)
+        {
+            if (CurrentBatch.Count == 0)
+            {
                 return false;
             }
 
@@ -236,10 +261,11 @@ namespace OptimizelySDK.Event
                 currentContext = CurrentBatch.Last().Context;
             }
 
-            EventContext newContext = userEvent.Context;
+            var newContext = userEvent.Context;
 
             // Revisions should match
-            if (currentContext.Revision != newContext.Revision) {
+            if (currentContext.Revision != newContext.Revision)
+            {
                 return true;
             }
 
@@ -251,10 +277,13 @@ namespace OptimizelySDK.Event
 
             return false;
         }
-        
+
         public void Dispose()
         {
-            if (Disposed) return;
+            if (Disposed)
+            {
+                return;
+            }
 
             Stop();
             Disposed = true;
@@ -262,7 +291,8 @@ namespace OptimizelySDK.Event
 
         public class Builder
         {
-            private BlockingCollection<object> EventQueue = new BlockingCollection<object>(DEFAULT_QUEUE_CAPACITY);
+            private BlockingCollection<object> EventQueue =
+                new BlockingCollection<object>(DEFAULT_QUEUE_CAPACITY);
 
             private IEventDispatcher EventDispatcher;
             private int BatchSize;
@@ -306,7 +336,7 @@ namespace OptimizelySDK.Event
 
                 return this;
             }
-            
+
             public Builder WithLogger(ILogger logger = null)
             {
                 Logger = logger;
@@ -347,19 +377,25 @@ namespace OptimizelySDK.Event
                 var batchEventProcessor = new BatchEventProcessor();
                 batchEventProcessor.Logger = Logger ?? new NoOpLogger();
                 batchEventProcessor.ErrorHandler = ErrorHandler ?? new NoOpErrorHandler(Logger);
-                batchEventProcessor.EventDispatcher = EventDispatcher ?? new DefaultEventDispatcher(Logger);
+                batchEventProcessor.EventDispatcher =
+                    EventDispatcher ?? new DefaultEventDispatcher(Logger);
                 batchEventProcessor.EventQueue = EventQueue;
-                batchEventProcessor.NotificationCenter = NotificationCenter;                
-                batchEventProcessor.BatchSize = BatchSize < 1 ? BatchEventProcessor.DEFAULT_BATCH_SIZE : BatchSize;
-                batchEventProcessor.FlushInterval = FlushInterval <= TimeSpan.FromSeconds(0) ? BatchEventProcessor.DEFAULT_FLUSH_INTERVAL : FlushInterval;
-                batchEventProcessor.TimeoutInterval = TimeoutInterval <= TimeSpan.FromSeconds(0) ? BatchEventProcessor.DEFAULT_TIMEOUT_INTERVAL : TimeoutInterval;
+                batchEventProcessor.NotificationCenter = NotificationCenter;
+                batchEventProcessor.BatchSize = BatchSize < 1 ? DEFAULT_BATCH_SIZE : BatchSize;
+                batchEventProcessor.FlushInterval = FlushInterval <= TimeSpan.FromSeconds(0) ?
+                    DEFAULT_FLUSH_INTERVAL :
+                    FlushInterval;
+                batchEventProcessor.TimeoutInterval = TimeoutInterval <= TimeSpan.FromSeconds(0) ?
+                    DEFAULT_TIMEOUT_INTERVAL :
+                    TimeoutInterval;
 
                 if (start)
+                {
                     batchEventProcessor.Start();
+                }
 
                 return batchEventProcessor;
             }
         }
-
     }
 }

--- a/OptimizelySDK/Event/Builder/EventBuilder.cs
+++ b/OptimizelySDK/Event/Builder/EventBuilder.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using OptimizelySDK.Bucketing;
 using OptimizelySDK.Entity;
 using OptimizelySDK.Logger;
@@ -36,8 +37,9 @@ namespace OptimizelySDK.Event.Builder
 
         private const string ACTIVATE_EVENT_KEY = "campaign_activated";
 
-        private static readonly Dictionary<string, string> HTTP_HEADERS = new Dictionary<string, string>
-        {
+        private static readonly Dictionary<string, string> HTTP_HEADERS =
+            new Dictionary<string, string>
+            {
                 { "Content-Type", "application/json" },
             };
 
@@ -68,15 +70,17 @@ namespace OptimizelySDK.Event.Builder
         /// <param name="config">ProjectConfig Configuration for the project</param>
         /// <param name="userId">string ID of user</param>
         /// <param name="userAttributes">associative array of Attributes for the user</param>
-        private Dictionary<string, object> GetCommonParams(ProjectConfig config, string userId, UserAttributes userAttributes)
+        private Dictionary<string, object> GetCommonParams(ProjectConfig config, string userId,
+            UserAttributes userAttributes
+        )
         {
             var comonParams = new Dictionary<string, object>();
 
             var visitor = new Dictionary<string, object>
             {
-                    { "snapshots", new object[0]},
-                    { "visitor_id", userId },
-                    { "attributes", new object[0] }
+                { "snapshots", new object[0] },
+                { "visitor_id", userId },
+                { "attributes", new object[0] },
             };
 
             comonParams[Params.VISITORS] = new object[] { visitor };
@@ -91,16 +95,18 @@ namespace OptimizelySDK.Event.Builder
             var userFeatures = new List<Dictionary<string, object>>();
 
             //Omit attribute values that are not supported by the log endpoint.
-            foreach (var validUserAttribute in userAttributes.Where(attribute => Validator.IsUserAttributeValid(attribute)))
-            {                
+            foreach (var validUserAttribute in userAttributes.Where(attribute =>
+                         Validator.IsUserAttributeValid(attribute)))
+            {
                 var attributeId = config.GetAttributeId(validUserAttribute.Key);
-                if (!string.IsNullOrEmpty(attributeId)) {
+                if (!string.IsNullOrEmpty(attributeId))
+                {
                     userFeatures.Add(new Dictionary<string, object>
                     {
                         { "entity_id", attributeId },
                         { "key", validUserAttribute.Key },
                         { "type", CUSTOM_ATTRIBUTE_FEATURE_TYPE },
-                        { "value", validUserAttribute.Value}
+                        { "value", validUserAttribute.Value },
                     });
                 }
             }
@@ -109,11 +115,11 @@ namespace OptimizelySDK.Event.Builder
             {
                 userFeatures.Add(new Dictionary<string, object>
                 {
-                        { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
-                        { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
-                        { "type", CUSTOM_ATTRIBUTE_FEATURE_TYPE },
-                        { "value",  config.BotFiltering}
-                    });
+                    { "entity_id", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                    { "key", ControlAttributes.BOT_FILTERING_ATTRIBUTE },
+                    { "type", CUSTOM_ATTRIBUTE_FEATURE_TYPE },
+                    { "value", config.BotFiltering },
+                });
             }
 
             visitor["attributes"] = userFeatures;
@@ -121,31 +127,32 @@ namespace OptimizelySDK.Event.Builder
             return comonParams;
         }
 
-        private Dictionary<string, object> GetImpressionParams(Experiment experiment, string variationId)
+        private Dictionary<string, object> GetImpressionParams(Experiment experiment,
+            string variationId
+        )
         {
-
             var impressionEvent = new Dictionary<string, object>();
 
             var decisions = new object[]
             {
-                    new Dictionary<string, object>
-                    {
-                        { Params.CAMPAIGN_ID,   experiment?.LayerId },
-                        { Params.EXPERIMENT_ID, experiment?.Id ?? string.Empty },
-                        { Params.VARIATION_ID,  variationId }
-                    }
+                new Dictionary<string, object>
+                {
+                    { Params.CAMPAIGN_ID, experiment?.LayerId },
+                    { Params.EXPERIMENT_ID, experiment?.Id ?? string.Empty },
+                    { Params.VARIATION_ID, variationId },
+                },
             };
 
 
             var events = new object[]
             {
-                    new Dictionary<string, object>
-                    {
-                        { "entity_id", experiment?.LayerId },
-                        { "timestamp", DateTimeUtils.SecondsSince1970*1000 },
-                        { "key", ACTIVATE_EVENT_KEY },
-                        { "uuid", Guid.NewGuid() }
-                    }
+                new Dictionary<string, object>
+                {
+                    { "entity_id", experiment?.LayerId },
+                    { "timestamp", DateTimeUtils.SecondsSince1970 * 1000 },
+                    { "key", ACTIVATE_EVENT_KEY },
+                    { "uuid", Guid.NewGuid() },
+                },
             };
 
             impressionEvent[Params.DECISIONS] = decisions;
@@ -154,51 +161,61 @@ namespace OptimizelySDK.Event.Builder
             return impressionEvent;
         }
 
-        private List<object> GetConversionParams(ProjectConfig config, string eventKey, string userId, Dictionary<string, object> eventTags)
+        private List<object> GetConversionParams(ProjectConfig config, string eventKey,
+            string userId, Dictionary<string, object> eventTags
+        )
         {
-
             var conversionEventParams = new List<object>();
             var snapshot = new Dictionary<string, object>();
 
             var eventDict = new Dictionary<string, object>
-                {
-                        { Params.ENTITY_ID, config.EventKeyMap[eventKey].Id },
-                        { Params.TIMESTAMP, DateTimeUtils.SecondsSince1970*1000 },
-                        { "uuid", Guid.NewGuid() },
-                        { "key", eventKey }
-                    };
+            {
+                { Params.ENTITY_ID, config.EventKeyMap[eventKey].Id },
+                { Params.TIMESTAMP, DateTimeUtils.SecondsSince1970 * 1000 },
+                { "uuid", Guid.NewGuid() },
+                { "key", eventKey },
+            };
 
-            if (eventTags != null) {
+            if (eventTags != null)
+            {
                 var revenue = EventTagUtils.GetRevenueValue(eventTags, Logger);
 
-                if (revenue != null) {
+                if (revenue != null)
+                {
                     eventDict[EventTagUtils.REVENUE_EVENT_METRIC_NAME] = revenue;
                 }
 
                 var eventValue = EventTagUtils.GetNumericValue(eventTags, Logger);
 
-                if (eventValue != null) {
+                if (eventValue != null)
+                {
                     eventDict[EventTagUtils.VALUE_EVENT_METRIC_NAME] = eventValue;
                 }
 
                 if (eventTags.Any())
+                {
                     eventDict["tags"] = eventTags;
+                }
             }
 
-            snapshot[Params.EVENTS] = new object[]{
-                    eventDict
-                };
+            snapshot[Params.EVENTS] = new object[]
+            {
+                eventDict,
+            };
 
             conversionEventParams.Add(snapshot);
 
             return conversionEventParams;
         }
 
-        private Dictionary<string, object> GetImpressionOrConversionParamsWithCommonParams(Dictionary<string, object> commonParams, object[] conversionOrImpressionOnlyParams)
+        private Dictionary<string, object> GetImpressionOrConversionParamsWithCommonParams(
+            Dictionary<string, object> commonParams, object[] conversionOrImpressionOnlyParams
+        )
         {
             var visitors = commonParams[Params.VISITORS] as object[];
 
-            if (visitors.Length > 0) {
+            if (visitors.Length > 0)
+            {
                 var visitor = visitors[0] as Dictionary<string, object>;
                 visitor["snapshots"] = conversionOrImpressionOnlyParams;
             }
@@ -215,14 +232,18 @@ namespace OptimizelySDK.Event.Builder
         /// <param name="userId">User Id</param>
         /// <param name="userAttributes">associative array of attributes for the user</param>
         /// <returns>LogEvent object to be sent to dispatcher</returns>
-        public virtual LogEvent CreateImpressionEvent(ProjectConfig config, Experiment experiment, string variationId,
-            string userId, UserAttributes userAttributes)
+        public virtual LogEvent CreateImpressionEvent(ProjectConfig config, Experiment experiment,
+            string variationId,
+            string userId, UserAttributes userAttributes
+        )
         {
-
-            var commonParams = GetCommonParams(config, userId, userAttributes ?? new UserAttributes());
+            var commonParams =
+                GetCommonParams(config, userId, userAttributes ?? new UserAttributes());
             var impressionOnlyParams = GetImpressionParams(experiment, variationId);
 
-            var impressionParams = GetImpressionOrConversionParamsWithCommonParams(commonParams, new object[] { impressionOnlyParams });
+            var impressionParams =
+                GetImpressionOrConversionParamsWithCommonParams(commonParams,
+                    new object[] { impressionOnlyParams });
 
             return new LogEvent(IMPRESSION_ENDPOINT, impressionParams, HTTP_VERB, HTTP_HEADERS);
         }
@@ -237,13 +258,18 @@ namespace OptimizelySDK.Event.Builder
         /// <param name="userAttributes">associative array of Attributes for the user</param>
         /// <param name="eventTags">Dict representing metadata associated with the event.</param>
         /// <returns>LogEvent object to be sent to dispatcher</returns>
-        public virtual LogEvent CreateConversionEvent(ProjectConfig config, string eventKey, string userId, UserAttributes userAttributes, EventTags eventTags)
+        public virtual LogEvent CreateConversionEvent(ProjectConfig config, string eventKey,
+            string userId, UserAttributes userAttributes, EventTags eventTags
+        )
         {
-            var commonParams = GetCommonParams(config, userId, userAttributes ?? new UserAttributes());
+            var commonParams =
+                GetCommonParams(config, userId, userAttributes ?? new UserAttributes());
 
-            var conversionOnlyParams = GetConversionParams(config, eventKey, userId, eventTags).ToArray();
+            var conversionOnlyParams =
+                GetConversionParams(config, eventKey, userId, eventTags).ToArray();
 
-            var conversionParams = GetImpressionOrConversionParamsWithCommonParams(commonParams, conversionOnlyParams);
+            var conversionParams =
+                GetImpressionOrConversionParamsWithCommonParams(commonParams, conversionOnlyParams);
 
             return new LogEvent(CONVERSION_ENDPOINT, conversionParams, HTTP_VERB, HTTP_HEADERS);
         }

--- a/OptimizelySDK/Event/Builder/EventBuilder.cs
+++ b/OptimizelySDK/Event/Builder/EventBuilder.cs
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using OptimizelySDK.Bucketing;
 using OptimizelySDK.Entity;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Utils;
-using System;
-using System.Collections.Generic;
-using System.Linq;
 
 namespace OptimizelySDK.Event.Builder
 {

--- a/OptimizelySDK/Event/Builder/Params.cs
+++ b/OptimizelySDK/Event/Builder/Params.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Event.Entity;
 using System;
+using OptimizelySDK.Event.Entity;
 
 namespace OptimizelySDK.Event.Builder
 {

--- a/OptimizelySDK/Event/Builder/Params.cs
+++ b/OptimizelySDK/Event/Builder/Params.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using OptimizelySDK.Event.Entity;
 using System;
 
@@ -21,23 +22,23 @@ namespace OptimizelySDK.Event.Builder
     [Obsolete("This class is deprecated.")]
     public static class Params
     {
-        public const string ACCOUNT_ID          = "account_id";
-        public const string ANONYMIZE_IP        = "anonymize_ip";
-        public const string CAMPAIGN_ID         = "campaign_id";
-        public const string CLIENT_ENGINE       = "client_name";
-        public const string CLIENT_VERSION      = "client_version";
-        public const string DECISIONS           = "decisions";
-        public const string ENRICH_DECISIONS    = "enrich_decisions";
-        public const string ENTITY_ID           = "entity_id";
-        public const string EVENTS              = "events";
-        public const string EXPERIMENT_ID       = "experiment_id";
-        public const string METADATA            = "metadata";
-        public const string PROJECT_ID          = "project_id";
-        public const string REVISION            = "revision";
-        public const string TIME                = "timestamp";
-        public const string TIMESTAMP           = "timestamp";
-        public const string VARIATION_ID        = "variation_id";
-        public const string VISITOR_ID          = "visitorId";
-        public const string VISITORS            = "visitors";
+        public const string ACCOUNT_ID = "account_id";
+        public const string ANONYMIZE_IP = "anonymize_ip";
+        public const string CAMPAIGN_ID = "campaign_id";
+        public const string CLIENT_ENGINE = "client_name";
+        public const string CLIENT_VERSION = "client_version";
+        public const string DECISIONS = "decisions";
+        public const string ENRICH_DECISIONS = "enrich_decisions";
+        public const string ENTITY_ID = "entity_id";
+        public const string EVENTS = "events";
+        public const string EXPERIMENT_ID = "experiment_id";
+        public const string METADATA = "metadata";
+        public const string PROJECT_ID = "project_id";
+        public const string REVISION = "revision";
+        public const string TIME = "timestamp";
+        public const string TIMESTAMP = "timestamp";
+        public const string VARIATION_ID = "variation_id";
+        public const string VISITOR_ID = "visitorId";
+        public const string VISITORS = "visitors";
     }
 }

--- a/OptimizelySDK/Event/Dispatcher/DefaultEventDispatcher.cs
+++ b/OptimizelySDK/Event/Dispatcher/DefaultEventDispatcher.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace OptimizelySDK.Event.Dispatcher
 {
     /// <summary>

--- a/OptimizelySDK/Event/Dispatcher/HttpClientEventDispatcher45.cs
+++ b/OptimizelySDK/Event/Dispatcher/HttpClientEventDispatcher45.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #if !NET35 && !NET40
 using OptimizelySDK.Logger;
 using OptimizelySDK.Utils;
@@ -46,18 +47,23 @@ namespace OptimizelySDK.Event.Dispatcher
         {
             try
             {
-                string json = logEvent.GetParamsAsJson();
+                var json = logEvent.GetParamsAsJson();
                 var request = new HttpRequestMessage
                 {
                     RequestUri = new Uri(logEvent.Url),
                     Method = HttpMethod.Post,
                     // The Content-Type header applies to the Content, not the Request itself
-                    Content = new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
+                    Content =
+                        new StringContent(json, System.Text.Encoding.UTF8, "application/json"),
                 };
 
                 foreach (var h in logEvent.Headers)
+                {
                     if (h.Key.ToLower() != "content-type")
+                    {
                         request.Content.Headers.Add(h.Key, h.Value);
+                    }
+                }
 
                 var result = await Client.SendAsync(request);
                 result.EnsureSuccessStatusCode();

--- a/OptimizelySDK/Event/Dispatcher/HttpClientEventDispatcher45.cs
+++ b/OptimizelySDK/Event/Dispatcher/HttpClientEventDispatcher45.cs
@@ -15,11 +15,11 @@
  */
 
 #if !NET35 && !NET40
-using OptimizelySDK.Logger;
-using OptimizelySDK.Utils;
 using System;
 using System.Net.Http;
 using System.Threading.Tasks;
+using OptimizelySDK.Logger;
+using OptimizelySDK.Utils;
 
 namespace OptimizelySDK.Event.Dispatcher
 {

--- a/OptimizelySDK/Event/Dispatcher/IEventDispatcher.cs
+++ b/OptimizelySDK/Event/Dispatcher/IEventDispatcher.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace OptimizelySDK.Event.Dispatcher
 {
     public interface IEventDispatcher

--- a/OptimizelySDK/Event/Dispatcher/WebRequestEventDispatcher35.cs
+++ b/OptimizelySDK/Event/Dispatcher/WebRequestEventDispatcher35.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 #if NET35 || NET40
 using System;
 using System.IO;
@@ -41,9 +42,12 @@ namespace OptimizelySDK.Event.Dispatcher
             Request.Method = logEvent.HttpVerb;
 
             foreach (var h in logEvent.Headers)
-                if(!WebHeaderCollection.IsRestricted(h.Key)){
+            {
+                if (!WebHeaderCollection.IsRestricted(h.Key))
+                {
                     Request.Headers[h.Key] = h.Value;
-                } 
+                }
+            }
 
             Request.ContentType = "application/json";
 
@@ -54,7 +58,8 @@ namespace OptimizelySDK.Event.Dispatcher
                 streamWriter.Close();
             }
 
-            IAsyncResult result = Request.BeginGetResponse(new AsyncCallback(FinaliseHttpAsyncRequest), this);
+            var result =
+                Request.BeginGetResponse(new AsyncCallback(FinaliseHttpAsyncRequest), this);
         }
 
         private static void FinaliseHttpAsyncRequest(IAsyncResult result)
@@ -70,10 +75,10 @@ namespace OptimizelySDK.Event.Dispatcher
             if (response.StatusCode == HttpStatusCode.OK)
             {
                 // Read the results, even though we don't need it.
-                Stream responseStream = response.GetResponseStream();
+                var responseStream = response.GetResponseStream();
                 var streamEncoder = System.Text.Encoding.UTF8;
-                StreamReader responseReader = new StreamReader(responseStream, streamEncoder);
-                string data = responseReader.ReadToEnd();
+                var responseReader = new StreamReader(responseStream, streamEncoder);
+                var data = responseReader.ReadToEnd();
             }
             else
             {

--- a/OptimizelySDK/Event/Entity/ConversionEvent.cs
+++ b/OptimizelySDK/Event/Entity/ConversionEvent.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using OptimizelySDK.Entity;
 using OptimizelySDK.Utils;
 using System;
@@ -48,7 +49,7 @@ namespace OptimizelySDK.Event.Entity
                 UserId = userId;
 
                 return this;
-            }            
+            }
 
             public Builder WithEventContext(EventContext eventContext)
             {
@@ -106,6 +107,5 @@ namespace OptimizelySDK.Event.Entity
                 return conversionEvent;
             }
         }
-
     }
 }

--- a/OptimizelySDK/Event/Entity/ConversionEvent.cs
+++ b/OptimizelySDK/Event/Entity/ConversionEvent.cs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+using System;
 using OptimizelySDK.Entity;
 using OptimizelySDK.Utils;
-using System;
 
 namespace OptimizelySDK.Event.Entity
 {

--- a/OptimizelySDK/Event/Entity/Decision.cs
+++ b/OptimizelySDK/Event/Entity/Decision.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using Newtonsoft.Json;
 
 namespace OptimizelySDK.Event.Entity
@@ -21,15 +22,21 @@ namespace OptimizelySDK.Event.Entity
     {
         [JsonProperty("campaign_id")]
         public string CampaignId { get; private set; }
+
         [JsonProperty("experiment_id")]
         public string ExperimentId { get; private set; }
+
         [JsonProperty("metadata")]
         public DecisionMetadata Metadata { get; private set; }
+
         [JsonProperty("variation_id")]
         public string VariationId { get; private set; }
-        public Decision() {}
 
-        public Decision(string campaignId, string experimentId, string variationId, DecisionMetadata metadata = null)
+        public Decision() { }
+
+        public Decision(string campaignId, string experimentId, string variationId,
+            DecisionMetadata metadata = null
+        )
         {
             CampaignId = campaignId;
             ExperimentId = experimentId;

--- a/OptimizelySDK/Event/Entity/DecisionMetadata.cs
+++ b/OptimizelySDK/Event/Entity/DecisionMetadata.cs
@@ -26,16 +26,22 @@ namespace OptimizelySDK.Event.Entity
     {
         [JsonProperty("flag_key")]
         public string FlagKey { get; private set; }
+
         [JsonProperty("rule_key")]
         public string RuleKey { get; private set; }
+
         [JsonProperty("rule_type")]
         public string RuleType { get; private set; }
+
         [JsonProperty("variation_key")]
         public string VariationKey { get; private set; }
+
         [JsonProperty("enabled")]
         public bool Enabled { get; private set; }
 
-        public DecisionMetadata(string flagKey, string ruleKey, string ruleType, string variationKey = "", bool enabled = false) 
+        public DecisionMetadata(string flagKey, string ruleKey, string ruleType,
+            string variationKey = "", bool enabled = false
+        )
         {
             FlagKey = flagKey;
             RuleKey = ruleKey;

--- a/OptimizelySDK/Event/Entity/EventBatch.cs
+++ b/OptimizelySDK/Event/Entity/EventBatch.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System.Collections.Generic;
 using Newtonsoft.Json;
 
@@ -57,7 +58,7 @@ namespace OptimizelySDK.Event.Entity
 
             public EventBatch Build()
             {
-                EventBatch eventBatch = new EventBatch();
+                var eventBatch = new EventBatch();
                 eventBatch.AccountId = AccountId;
                 eventBatch.ProjectId = ProjectId;
                 eventBatch.Revision = Revision;

--- a/OptimizelySDK/Event/Entity/EventContext.cs
+++ b/OptimizelySDK/Event/Entity/EventContext.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using Newtonsoft.Json;
 
 namespace OptimizelySDK.Event.Entity
@@ -23,7 +24,7 @@ namespace OptimizelySDK.Event.Entity
     public class EventContext
     {
         [JsonProperty("account_id")]
-        public string AccountId {get; protected set;}
+        public string AccountId { get; protected set; }
 
         [JsonProperty("project_id")]
         public string ProjectId { get; protected set; }
@@ -92,6 +93,5 @@ namespace OptimizelySDK.Event.Entity
                 return eventContext;
             }
         }
-
     }
 }

--- a/OptimizelySDK/Event/Entity/ImpressionEvent.cs
+++ b/OptimizelySDK/Event/Entity/ImpressionEvent.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using OptimizelySDK.Entity;
 using OptimizelySDK.Utils;
 using System;
@@ -117,6 +118,5 @@ namespace OptimizelySDK.Event.Entity
                 return impressionEvent;
             }
         }
-
     }
 }

--- a/OptimizelySDK/Event/Entity/ImpressionEvent.cs
+++ b/OptimizelySDK/Event/Entity/ImpressionEvent.cs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+using System;
 using OptimizelySDK.Entity;
 using OptimizelySDK.Utils;
-using System;
 
 namespace OptimizelySDK.Event.Entity
 {

--- a/OptimizelySDK/Event/Entity/Snapshot.cs
+++ b/OptimizelySDK/Event/Entity/Snapshot.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using Newtonsoft.Json;
 
 namespace OptimizelySDK.Event.Entity
@@ -25,7 +26,7 @@ namespace OptimizelySDK.Event.Entity
         [JsonProperty("events")]
         public SnapshotEvent[] Events { get; private set; }
 
-        public Snapshot(SnapshotEvent[] events, Decision[] decisions= null)
+        public Snapshot(SnapshotEvent[] events, Decision[] decisions = null)
         {
             Events = events;
             Decisions = decisions;

--- a/OptimizelySDK/Event/Entity/SnapshotEvent.cs
+++ b/OptimizelySDK/Event/Entity/SnapshotEvent.cs
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using Newtonsoft.Json;
 using OptimizelySDK.Entity;
+
 namespace OptimizelySDK.Event.Entity
 {
     /// <summary>
@@ -25,7 +27,7 @@ namespace OptimizelySDK.Event.Entity
         [JsonProperty("entity_id")]
         public string EntityId { get; private set; }
 
-        [JsonProperty(PropertyName ="uuid")]
+        [JsonProperty(PropertyName = "uuid")]
         public string UUID { get; private set; }
 
         [JsonProperty("key")]
@@ -35,7 +37,7 @@ namespace OptimizelySDK.Event.Entity
         public long TimeStamp { get; private set; }
 
         // The following properties are for Conversion that's why ignore if null.
-        [JsonProperty("revenue", NullValueHandling = NullValueHandling.Ignore)]        
+        [JsonProperty("revenue", NullValueHandling = NullValueHandling.Ignore)]
         public int? Revenue { get; private set; }
 
         [JsonProperty("value", NullValueHandling = NullValueHandling.Ignore)]
@@ -56,7 +58,7 @@ namespace OptimizelySDK.Event.Entity
 
             public SnapshotEvent Build()
             {
-                SnapshotEvent snapshotEvent = new SnapshotEvent();
+                var snapshotEvent = new SnapshotEvent();
                 snapshotEvent.EntityId = EntityId;
                 snapshotEvent.UUID = UUID;
                 snapshotEvent.Key = Key;
@@ -115,6 +117,5 @@ namespace OptimizelySDK.Event.Entity
                 return this;
             }
         }
-       
     }
 }

--- a/OptimizelySDK/Event/Entity/UserEvent.cs
+++ b/OptimizelySDK/Event/Entity/UserEvent.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 
 namespace OptimizelySDK.Event.Entity

--- a/OptimizelySDK/Event/Entity/Visitor.cs
+++ b/OptimizelySDK/Event/Entity/Visitor.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using Newtonsoft.Json;
 
 namespace OptimizelySDK.Event.Entity

--- a/OptimizelySDK/Event/Entity/VisitorAttribute.cs
+++ b/OptimizelySDK/Event/Entity/VisitorAttribute.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using Newtonsoft.Json;
 
 namespace OptimizelySDK.Event.Entity
@@ -31,12 +32,12 @@ namespace OptimizelySDK.Event.Entity
         [JsonProperty("value")]
         public object Value { get; set; }
 
-        public VisitorAttribute (string entityId, string key, string type, object value)
+        public VisitorAttribute(string entityId, string key, string type, object value)
         {
             EntityId = entityId;
             Key = key;
             Type = type;
-            Value = value;            
+            Value = value;
         }
     }
 }

--- a/OptimizelySDK/Event/ForwardingEventProcessor.cs
+++ b/OptimizelySDK/Event/ForwardingEventProcessor.cs
@@ -30,7 +30,10 @@ namespace OptimizelySDK.Event
         private IEventDispatcher EventDispatcher;
         private NotificationCenter NotificationCenter;
 
-        public ForwardingEventProcessor(IEventDispatcher eventDispatcher, NotificationCenter notificationCenter, ILogger logger= null, IErrorHandler errorHandler = null)
+        public ForwardingEventProcessor(IEventDispatcher eventDispatcher,
+            NotificationCenter notificationCenter, ILogger logger = null,
+            IErrorHandler errorHandler = null
+        )
         {
             EventDispatcher = eventDispatcher;
             NotificationCenter = notificationCenter;
@@ -40,16 +43,18 @@ namespace OptimizelySDK.Event
 
         public void Process(UserEvent userEvent)
         {
-            var logEvent = EventFactory.CreateLogEvent(userEvent, Logger);            
+            var logEvent = EventFactory.CreateLogEvent(userEvent, Logger);
 
             try
             {
                 EventDispatcher.DispatchEvent(logEvent);
-                NotificationCenter?.SendNotifications(NotificationCenter.NotificationType.LogEvent, logEvent);
+                NotificationCenter?.SendNotifications(NotificationCenter.NotificationType.LogEvent,
+                    logEvent);
             }
             catch (Exception ex)
             {
-                Logger.Log(LogLevel.ERROR, $"Error dispatching event: {logEvent.GetParamsAsJson()}. {ex.Message}");
+                Logger.Log(LogLevel.ERROR,
+                    $"Error dispatching event: {logEvent.GetParamsAsJson()}. {ex.Message}");
                 ErrorHandler.HandleError(ex);
             }
         }

--- a/OptimizelySDK/Event/ForwardingEventProcessor.cs
+++ b/OptimizelySDK/Event/ForwardingEventProcessor.cs
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
+using System;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Event.Dispatcher;
 using OptimizelySDK.Event.Entity;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Notifications;
-using System;
 
 namespace OptimizelySDK.Event
 {

--- a/OptimizelySDK/Event/LogEvent.cs
+++ b/OptimizelySDK/Event/LogEvent.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System.Collections.Generic;
 using System.Linq;
 
@@ -48,7 +49,9 @@ namespace OptimizelySDK.Event
         /// <summary>
         /// LogEvent Construtor
         /// </summary>
-        public LogEvent(string url, Dictionary<string, object> parameters, string httpVerb, Dictionary<string, string> headers)
+        public LogEvent(string url, Dictionary<string, object> parameters, string httpVerb,
+            Dictionary<string, string> headers
+        )
         {
             Url = url;
             Params = parameters;

--- a/OptimizelySDK/Event/UserEventFactory.cs
+++ b/OptimizelySDK/Event/UserEventFactory.cs
@@ -35,16 +35,18 @@ namespace OptimizelySDK.Event
         /// <param name="userAttributes">The user's attributes</param>
         /// <returns>ImpressionEvent instance</returns>
         public static ImpressionEvent CreateImpressionEvent(ProjectConfig projectConfig,
-                                                            Experiment activatedExperiment,
-                                                            string variationId,
-                                                            string userId,
-                                                            UserAttributes userAttributes,
-                                                            string flagKey,
-                                                            string ruleType,
-                                                            bool enabled = false)
+            Experiment activatedExperiment,
+            string variationId,
+            string userId,
+            UserAttributes userAttributes,
+            string flagKey,
+            string ruleType,
+            bool enabled = false
+        )
         {
-            Variation variation = projectConfig.GetVariationFromId(activatedExperiment?.Key, variationId);
-            return CreateImpressionEvent(projectConfig, activatedExperiment, variation, userId, userAttributes, flagKey, ruleType, enabled);
+            var variation = projectConfig.GetVariationFromId(activatedExperiment?.Key, variationId);
+            return CreateImpressionEvent(projectConfig, activatedExperiment, variation, userId,
+                userAttributes, flagKey, ruleType, enabled);
         }
 
         /// <summary>
@@ -59,45 +61,46 @@ namespace OptimizelySDK.Event
         /// <param name="ruleType">experiment or featureDecision source </param>
         /// <returns>ImpressionEvent instance</returns>
         public static ImpressionEvent CreateImpressionEvent(ProjectConfig projectConfig,
-                                                            Experiment activatedExperiment,
-                                                            Variation variation,
-                                                            string userId,
-                                                            UserAttributes userAttributes,
-                                                            string flagKey,
-                                                            string ruleType,
-                                                            bool enabled = false)
+            Experiment activatedExperiment,
+            Variation variation,
+            string userId,
+            UserAttributes userAttributes,
+            string flagKey,
+            string ruleType,
+            bool enabled = false
+        )
         {
-            if ((ruleType == FeatureDecision.DECISION_SOURCE_ROLLOUT || variation == null) && !projectConfig.SendFlagDecisions)
+            if ((ruleType == FeatureDecision.DECISION_SOURCE_ROLLOUT || variation == null) &&
+                !projectConfig.SendFlagDecisions)
             {
                 return null;
             }
 
-            var eventContext = new EventContext.Builder()
-            .WithProjectId(projectConfig.ProjectId)
-            .WithAccountId(projectConfig.AccountId)
-            .WithAnonymizeIP(projectConfig.AnonymizeIP)
-            .WithRevision(projectConfig.Revision)                
-            .Build();
+            var eventContext = new EventContext.Builder().WithProjectId(projectConfig.ProjectId).
+                WithAccountId(projectConfig.AccountId).
+                WithAnonymizeIP(projectConfig.AnonymizeIP).
+                WithRevision(projectConfig.Revision).
+                Build();
 
-            var variationKey = ""; 
-            var ruleKey = "";   
+            var variationKey = "";
+            var ruleKey = "";
             if (variation != null)
             {
                 variationKey = variation.Key;
                 ruleKey = activatedExperiment?.Key ?? string.Empty;
             }
+
             var metadata = new DecisionMetadata(flagKey, ruleKey, ruleType, variationKey, enabled);
 
-            return new ImpressionEvent.Builder()
-                .WithEventContext(eventContext)
-                .WithBotFilteringEnabled(projectConfig.BotFiltering)
-                .WithExperiment(activatedExperiment)
-                .WithMetadata(metadata)
-                .WithUserId(userId)
-                .WithVariation(variation)
-                .WithVisitorAttributes(EventFactory.BuildAttributeList(userAttributes, projectConfig))
-                .Build();
-            
+            return new ImpressionEvent.Builder().WithEventContext(eventContext).
+                WithBotFilteringEnabled(projectConfig.BotFiltering).
+                WithExperiment(activatedExperiment).
+                WithMetadata(metadata).
+                WithUserId(userId).
+                WithVariation(variation).
+                WithVisitorAttributes(
+                    EventFactory.BuildAttributeList(userAttributes, projectConfig)).
+                Build();
         }
 
         /// <summary>
@@ -109,29 +112,28 @@ namespace OptimizelySDK.Event
         /// <param name="userAttributes">The user's attributes</param>
         /// <param name="eventTags">Array Hash representing metadata associated with the event.</param>
         /// <returns>ConversionEvent instance</returns>
-        public static ConversionEvent CreateConversionEvent(ProjectConfig projectConfig,                                                            
-                                                            string eventKey,
-                                                            string userId,
-                                                            UserAttributes userAttributes,
-                                                            EventTags eventTags)
+        public static ConversionEvent CreateConversionEvent(ProjectConfig projectConfig,
+            string eventKey,
+            string userId,
+            UserAttributes userAttributes,
+            EventTags eventTags
+        )
         {
-            
+            var eventContext = new EventContext.Builder().WithProjectId(projectConfig.ProjectId).
+                WithAccountId(projectConfig.AccountId).
+                WithAnonymizeIP(projectConfig.AnonymizeIP).
+                WithRevision(projectConfig.Revision).
+                Build();
 
-            var eventContext = new EventContext.Builder()
-                    .WithProjectId(projectConfig.ProjectId)
-                    .WithAccountId(projectConfig.AccountId)
-                    .WithAnonymizeIP(projectConfig.AnonymizeIP)
-                    .WithRevision(projectConfig.Revision)
-                    .Build();
-
-            return new ConversionEvent.Builder()
-                .WithBotFilteringEnabled(projectConfig.BotFiltering)
-                .WithEventContext(eventContext)
-                .WithEventTags(eventTags)
-                .WithEvent(projectConfig.GetEvent(eventKey))
-                .WithUserId(userId)
-                .WithVisitorAttributes(EventFactory.BuildAttributeList(userAttributes, projectConfig))
-                .Build();            
+            return new ConversionEvent.Builder().
+                WithBotFilteringEnabled(projectConfig.BotFiltering).
+                WithEventContext(eventContext).
+                WithEventTags(eventTags).
+                WithEvent(projectConfig.GetEvent(eventKey)).
+                WithUserId(userId).
+                WithVisitorAttributes(
+                    EventFactory.BuildAttributeList(userAttributes, projectConfig)).
+                Build();
         }
     }
 }

--- a/OptimizelySDK/Exceptions/OptimizelyException.cs
+++ b/OptimizelySDK/Exceptions/OptimizelyException.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 
 
@@ -21,114 +22,84 @@ namespace OptimizelySDK.Exceptions
     public class OptimizelyException : Exception
     {
         public OptimizelyException(string message)
-            : base(message)
-        {
-        }
+            : base(message) { }
     }
 
     public class OptimizelyRuntimeException : OptimizelyException
     {
         public OptimizelyRuntimeException(string message)
-            : base(message)
-        {
-        }
+            : base(message) { }
     }
-    
+
     public class InvalidJsonException : OptimizelyException
     {
         public InvalidJsonException(string message)
-            : base(message)
-        {
-        }
+            : base(message) { }
     }
 
     public class InvalidAttributeException : OptimizelyException
     {
         public InvalidAttributeException(string message)
-            : base(message)
-        {
-        }
+            : base(message) { }
     }
 
     public class InvalidAudienceException : OptimizelyException
     {
         public InvalidAudienceException(string message)
-            : base(message)
-        {
-        }
+            : base(message) { }
     }
 
     public class InvalidEventException : OptimizelyException
     {
         public InvalidEventException(string message)
-            : base(message)
-        {
-        }
+            : base(message) { }
     }
 
     public class InvalidExperimentException : OptimizelyException
     {
         public InvalidExperimentException(string message)
-            : base(message)
-        {
-        }
+            : base(message) { }
     }
 
     public class InvalidGroupException : OptimizelyException
     {
         public InvalidGroupException(string message)
-            : base(message)
-        {
-        }
+            : base(message) { }
     }
 
     public class InvalidInputException : OptimizelyException
     {
         public InvalidInputException(string message)
-            : base(message)
-        {
-        }
+            : base(message) { }
     }
 
     public class InvalidVariationException : OptimizelyException
     {
         public InvalidVariationException(string message)
-            : base(message)
-        {
-        }
+            : base(message) { }
     }
 
     public class InvalidFeatureException : OptimizelyException
     {
         public InvalidFeatureException(string message)
-            : base(message)
-        {
-        }
+            : base(message) { }
     }
 
     public class InvalidRolloutException : OptimizelyException
     {
         public InvalidRolloutException(string message)
-            : base(message)
-        {
-        }
+            : base(message) { }
     }
 
     public class ConfigParseException : OptimizelyException
     {
         public ConfigParseException(string message)
-            : base(message)
-        {
-            
-        }
+            : base(message) { }
     }
 
     public class ParseException : OptimizelyException
     {
         public ParseException(string message)
-            : base(message)
-        {
-
-        }
+            : base(message) { }
     }
 }

--- a/OptimizelySDK/ForcedDecisionsStore.cs
+++ b/OptimizelySDK/ForcedDecisionsStore.cs
@@ -33,6 +33,7 @@ namespace OptimizelySDK
         {
             NullForcedDecisionStore = new ForcedDecisionsStore();
         }
+
         public ForcedDecisionsStore()
         {
             ForcedDecisionsMap = new Dictionary<string, OptimizelyForcedDecision>();
@@ -50,16 +51,13 @@ namespace OptimizelySDK
 
         public ForcedDecisionsStore(ForcedDecisionsStore forcedDecisionsStore)
         {
-            ForcedDecisionsMap = new Dictionary<string, OptimizelyForcedDecision>(forcedDecisionsStore.ForcedDecisionsMap);
+            ForcedDecisionsMap =
+                new Dictionary<string, OptimizelyForcedDecision>(forcedDecisionsStore.
+                    ForcedDecisionsMap);
         }
 
-        public int Count
-        {
-            get
-            {
-                return ForcedDecisionsMap.Count;
-            }
-        }
+        public int Count => ForcedDecisionsMap.Count;
+
         public bool Remove(OptimizelyDecisionContext context)
         {
             return ForcedDecisionsMap.Remove(context.GetKey());
@@ -75,10 +73,12 @@ namespace OptimizelySDK
             get
             {
                 if (context != null && context.IsValid
-                    && ForcedDecisionsMap.TryGetValue(context.GetKey(), out OptimizelyForcedDecision flagForcedDecision))
+                                    && ForcedDecisionsMap.TryGetValue(context.GetKey(),
+                                        out var flagForcedDecision))
                 {
                     return flagForcedDecision;
                 }
+
                 return null;
             }
             set
@@ -88,7 +88,6 @@ namespace OptimizelySDK
                     ForcedDecisionsMap[context.GetKey()] = value;
                 }
             }
-
         }
     }
 }

--- a/OptimizelySDK/IOptimizely.cs
+++ b/OptimizelySDK/IOptimizely.cs
@@ -18,8 +18,8 @@
 #define USE_ODP
 #endif
 
-using OptimizelySDK.Entity;
 using System.Collections.Generic;
+using OptimizelySDK.Entity;
 
 namespace OptimizelySDK
 {

--- a/OptimizelySDK/Logger/DefaultLogger.cs
+++ b/OptimizelySDK/Logger/DefaultLogger.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System.Diagnostics;
 
 namespace OptimizelySDK.Logger
@@ -24,7 +25,7 @@ namespace OptimizelySDK.Logger
     {
         public void Log(LogLevel level, string message)
         {
-            string line = $"[{level}] : {message}";
+            var line = $"[{level}] : {message}";
             Debug.WriteLine(line);
         }
     }

--- a/OptimizelySDK/Logger/ILogger.cs
+++ b/OptimizelySDK/Logger/ILogger.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace OptimizelySDK.Logger
 {
     public enum LogLevel

--- a/OptimizelySDK/Logger/NoOpLogger.cs
+++ b/OptimizelySDK/Logger/NoOpLogger.cs
@@ -13,12 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 namespace OptimizelySDK.Logger
 {
     public class NoOpLogger : ILogger
     {
-        public void Log(LogLevel level, string message)
-        {
-        }
+        public void Log(LogLevel level, string message) { }
     }
 }

--- a/OptimizelySDK/Notifications/NotificationCenter.cs
+++ b/OptimizelySDK/Notifications/NotificationCenter.cs
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Entity;
-using OptimizelySDK.Event;
-using OptimizelySDK.Logger;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OptimizelySDK.Entity;
+using OptimizelySDK.Event;
+using OptimizelySDK.Logger;
 
 namespace OptimizelySDK.Notifications
 {

--- a/OptimizelySDK/Notifications/NotificationCenter.cs
+++ b/OptimizelySDK/Notifications/NotificationCenter.cs
@@ -33,11 +33,11 @@ namespace OptimizelySDK.Notifications
         /// </summary>
         public enum NotificationType
         {
-            Activate,   // Activate called.
-            Track,      // Track called.
-            Decision,    // A decision is made in the system. i.e. user activation, feature access or feature-variable value retrieval.
+            Activate, // Activate called.
+            Track, // Track called.
+            Decision, // A decision is made in the system. i.e. user activation, feature access or feature-variable value retrieval.
             OptimizelyConfigUpdate, // When datafile is updated using HttpProjectConfigManager.
-            LogEvent    // LogEvent notification sends on flushing batch-event. // When datafile is updated using HttpProjectConfigManager.
+            LogEvent, // LogEvent notification sends on flushing batch-event. // When datafile is updated using HttpProjectConfigManager.
         };
 
         /// <summary>
@@ -49,8 +49,10 @@ namespace OptimizelySDK.Notifications
         /// <param name="variation">The variation entity</param>
         /// <param name="logEvent">The impression event</param>
         [Obsolete("ActivateCallback is deprecated. Use DecisionCallback instead.")]
-        public delegate void ActivateCallback(Experiment experiment, string userId, UserAttributes userAttributes,
-            Variation variation, LogEvent logEvent);
+        public delegate void ActivateCallback(Experiment experiment, string userId,
+            UserAttributes userAttributes,
+            Variation variation, LogEvent logEvent
+        );
 
         /// <summary>
         /// Delegate for track notifcations.
@@ -60,8 +62,10 @@ namespace OptimizelySDK.Notifications
         /// <param name="userAttributes">Associative array of attributes for the user</param>
         /// <param name="eventTags">Associative array of EventTags representing metadata associated with the event</param>
         /// <param name="logEvent">The conversion event</param>
-        public delegate void TrackCallback(string eventKey, string userId, UserAttributes userAttributes, EventTags eventTags,
-            LogEvent logEvent);
+        public delegate void TrackCallback(string eventKey, string userId,
+            UserAttributes userAttributes, EventTags eventTags,
+            LogEvent logEvent
+        );
 
         /// <summary>
         /// Delegate for decision notifications.
@@ -70,7 +74,9 @@ namespace OptimizelySDK.Notifications
         /// <param name="userId">The user identifier</param>
         /// <param name="userAttributes">Associative array of attributes for the user</param>
         /// <param name="decisionInfo">Dictionary containing decision information</param>
-        public delegate void DecisionCallback(string type, string userId, UserAttributes userAttributes, Dictionary<string, object> decisionInfo);
+        public delegate void DecisionCallback(string type, string userId,
+            UserAttributes userAttributes, Dictionary<string, object> decisionInfo
+        );
 
         /// <summary>
         /// Delegate for project config update.
@@ -95,10 +101,13 @@ namespace OptimizelySDK.Notifications
         /// <summary>
         /// Property representing total notifications count.
         /// </summary>
-        public int NotificationsCount {
-            get {
-                int notificationsCount = 0;
-                foreach (var notificationsMap in Notifications.Values) {
+        public int NotificationsCount
+        {
+            get
+            {
+                var notificationsCount = 0;
+                foreach (var notificationsMap in Notifications.Values)
+                {
                     notificationsCount += notificationsMap.Count;
                 }
 
@@ -114,14 +123,17 @@ namespace OptimizelySDK.Notifications
         {
             Logger = logger ?? new NoOpLogger();
 
-            foreach (NotificationType notificationType in Enum.GetValues(typeof(NotificationType))) {
+            foreach (NotificationType notificationType in Enum.GetValues(typeof(NotificationType)))
+            {
                 Notifications[notificationType] = new Dictionary<int, object>();
             }
         }
 
         public int GetNotificationCount(NotificationType notificationType)
         {
-            return Notifications.ContainsKey(notificationType) ? Notifications[notificationType].Count : 0;
+            return Notifications.ContainsKey(notificationType) ?
+                Notifications[notificationType].Count :
+                0;
         }
 
         /// <summary>
@@ -132,10 +144,14 @@ namespace OptimizelySDK.Notifications
         /// <returns>int | 0 for invalid notification type, -1 for adding existing notification
         /// or the notification id of newly added notification.</returns>
         [Obsolete("ActivateCallback is deprecated. Use DecisionCallback instead.")]
-        public int AddNotification(NotificationType notificationType, ActivateCallback activateCallback)
+        public int AddNotification(NotificationType notificationType,
+            ActivateCallback activateCallback
+        )
         {
             if (!IsNotificationTypeValid(notificationType, NotificationType.Activate))
+            {
                 return 0;
+            }
 
             return AddNotification(notificationType, (object)activateCallback);
         }
@@ -150,7 +166,9 @@ namespace OptimizelySDK.Notifications
         public int AddNotification(NotificationType notificationType, TrackCallback trackCallback)
         {
             if (!IsNotificationTypeValid(notificationType, NotificationType.Track))
+            {
                 return 0;
+            }
 
             return AddNotification(notificationType, (object)trackCallback);
         }
@@ -162,10 +180,14 @@ namespace OptimizelySDK.Notifications
         /// <param name="decisionCallback">Callback function to call when event gets triggered</param>
         /// <returns>int | 0 for invalid notification type, -1 for adding existing notification
         /// or the notification id of newly added notification.</returns>
-        public int AddNotification(NotificationType notificationType, DecisionCallback decisionCallback)
+        public int AddNotification(NotificationType notificationType,
+            DecisionCallback decisionCallback
+        )
         {
             if (!IsNotificationTypeValid(notificationType, NotificationType.Decision))
+            {
                 return 0;
+            }
 
             return AddNotification(notificationType, (object)decisionCallback);
         }
@@ -177,10 +199,14 @@ namespace OptimizelySDK.Notifications
         /// <param name="optimizelyConfigUpdate">Callback function to call when event gets triggered</param>
         /// <returns>0 for invalid notification type, -1 for adding existing notification
         /// or the notification id of newly added notification.</returns>
-        public int AddNotification(NotificationType notificationType, OptimizelyConfigUpdateCallback optimizelyConfigUpdate)
+        public int AddNotification(NotificationType notificationType,
+            OptimizelyConfigUpdateCallback optimizelyConfigUpdate
+        )
         {
             if (!IsNotificationTypeValid(notificationType, NotificationType.OptimizelyConfigUpdate))
+            {
                 return 0;
+            }
 
             return AddNotification(notificationType, (object)optimizelyConfigUpdate);
         }
@@ -192,10 +218,14 @@ namespace OptimizelySDK.Notifications
         /// <param name="logEventCallback">Callback function to call when event gets triggered</param>
         /// <returns>0 for invalid notification type, -1 for adding existing notification
         /// or the notification id of newly added notification.</returns>
-        public int AddNotification(NotificationType notificationType, LogEventCallback logEventCallback)
+        public int AddNotification(NotificationType notificationType,
+            LogEventCallback logEventCallback
+        )
         {
             if (!IsNotificationTypeValid(notificationType, NotificationType.LogEvent))
+            {
                 return 0;
+            }
 
             return AddNotification(notificationType, (object)logEventCallback);
         }
@@ -206,10 +236,15 @@ namespace OptimizelySDK.Notifications
         /// <param name="providedNotificationType">Provided notification type</param>
         /// <param name="expectedNotificationType">expected notification type</param>
         /// <returns>true if notification type is valid, false otherwise</returns>
-        private bool IsNotificationTypeValid(NotificationType providedNotificationType, NotificationType expectedNotificationType)
+        private bool IsNotificationTypeValid(NotificationType providedNotificationType,
+            NotificationType expectedNotificationType
+        )
         {
-            if (providedNotificationType != expectedNotificationType) {
-                Logger.Log(LogLevel.ERROR, $@"Invalid notification type provided for ""{expectedNotificationType}"" callback.");
+            if (providedNotificationType != expectedNotificationType)
+            {
+                Logger.Log(LogLevel.ERROR,
+                    $@"Invalid notification type provided for ""{expectedNotificationType
+                    }"" callback.");
                 return false;
             }
 
@@ -226,11 +261,17 @@ namespace OptimizelySDK.Notifications
         {
             var notificationHoldersList = Notifications[notificationType];
 
-            if (!Notifications.ContainsKey(notificationType) || Notifications[notificationType].Count == 0)
+            if (!Notifications.ContainsKey(notificationType) ||
+                Notifications[notificationType].Count == 0)
+            {
                 Notifications[notificationType][NotificationId] = notificationCallback;
-            else {
-                foreach (var notification in this.Notifications[notificationType]) {
-                    if ((Delegate)notification.Value == (Delegate)notificationCallback) {
+            }
+            else
+            {
+                foreach (var notification in Notifications[notificationType])
+                {
+                    if ((Delegate)notification.Value == (Delegate)notificationCallback)
+                    {
                         Logger.Log(LogLevel.ERROR, "The notification callback already exists.");
                         return -1;
                     }
@@ -239,7 +280,7 @@ namespace OptimizelySDK.Notifications
                 Notifications[notificationType][NotificationId] = notificationCallback;
             }
 
-            int retVal = NotificationId;
+            var retVal = NotificationId;
             NotificationId += 1;
 
             return retVal;
@@ -252,8 +293,11 @@ namespace OptimizelySDK.Notifications
         /// <returns>Returns true if found and removed, false otherwise.</returns>
         public bool RemoveNotification(int notificationId)
         {
-            foreach (var key in Notifications.Keys) {
-                if (Notifications[key] != null && Notifications[key].Any(notification => notification.Key == notificationId)) {
+            foreach (var key in Notifications.Keys)
+            {
+                if (Notifications[key] != null && Notifications[key].
+                        Any(notification => notification.Key == notificationId))
+                {
                     Notifications[key].Remove(notificationId);
                     return true;
                 }
@@ -276,7 +320,8 @@ namespace OptimizelySDK.Notifications
         /// </summary>
         public void ClearAllNotifications()
         {
-            foreach (var notificationsMap in Notifications.Values) {
+            foreach (var notificationsMap in Notifications.Values)
+            {
                 notificationsMap.Clear();
             }
         }
@@ -288,12 +333,17 @@ namespace OptimizelySDK.Notifications
         /// <param name="args">Arguments to pass in notification callbacks</param>
         public void SendNotifications(NotificationType notificationType, params object[] args)
         {
-            foreach (var notification in Notifications[notificationType]) {
-                try {
-                    Delegate d = notification.Value as Delegate;
+            foreach (var notification in Notifications[notificationType])
+            {
+                try
+                {
+                    var d = notification.Value as Delegate;
                     d.DynamicInvoke(args);
-                } catch (Exception exception) {
-                    Logger.Log(LogLevel.ERROR, "Problem calling notify callback. Error: " + exception.Message);
+                }
+                catch (Exception exception)
+                {
+                    Logger.Log(LogLevel.ERROR,
+                        "Problem calling notify callback. Error: " + exception.Message);
                 }
             }
         }

--- a/OptimizelySDK/Notifications/NotificationCenterRegistry.cs
+++ b/OptimizelySDK/Notifications/NotificationCenterRegistry.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Logger;
 using System.Collections.Generic;
+using OptimizelySDK.Logger;
 
 namespace OptimizelySDK.Notifications
 {

--- a/OptimizelySDK/Notifications/NotificationCenterRegistry.cs
+++ b/OptimizelySDK/Notifications/NotificationCenterRegistry.cs
@@ -71,7 +71,7 @@ namespace OptimizelySDK.Notifications
             lock (_mutex)
             {
                 if (_notificationCenters.TryGetValue(sdkKey,
-                        out NotificationCenter notificationCenter))
+                        out var notificationCenter))
                 {
                     notificationCenter.ClearAllNotifications();
                     _notificationCenters.Remove(sdkKey);

--- a/OptimizelySDK/Odp/Entity/Error.cs
+++ b/OptimizelySDK/Odp/Entity/Error.cs
@@ -25,17 +25,17 @@ namespace OptimizelySDK.Odp.Entity
         /// Human-readable message from the error
         /// </summary>
         public string Message { get; set; }
-        
+
         /// <summary>
         /// Points of failure producing the error
         /// </summary>
         public Location[] Locations { get; set; }
-        
+
         /// <summary>
         /// Files or urls producing the error
         /// </summary>
         public string[] Path { get; set; }
-        
+
         /// <summary>
         /// Additional technical error information 
         /// </summary>

--- a/OptimizelySDK/Odp/Entity/Location.cs
+++ b/OptimizelySDK/Odp/Entity/Location.cs
@@ -25,7 +25,7 @@ namespace OptimizelySDK.Odp.Entity
         /// Code or data line number 
         /// </summary>
         public int Line { get; set; }
-        
+
         /// <summary>
         /// Code or data column number
         /// </summary>

--- a/OptimizelySDK/Odp/Entity/Node.cs
+++ b/OptimizelySDK/Odp/Entity/Node.cs
@@ -25,7 +25,7 @@ namespace OptimizelySDK.Odp.Entity
         /// Descriptive label of a node
         /// </summary>
         public string Name { get; set; }
-        
+
         /// <summary>
         /// Status of the node
         /// </summary>

--- a/OptimizelySDK/Odp/Entity/Response.cs
+++ b/OptimizelySDK/Odp/Entity/Response.cs
@@ -34,12 +34,6 @@ namespace OptimizelySDK.Odp.Entity
         /// <summary>
         /// Determines if an error exists
         /// </summary>
-        public bool HasErrors
-        {
-            get
-            {
-                return Errors != null && Errors.Length > 0;
-            }
-        }
+        public bool HasErrors => Errors != null && Errors.Length > 0;
     }
 }

--- a/OptimizelySDK/Odp/ICache.cs
+++ b/OptimizelySDK/Odp/ICache.cs
@@ -16,7 +16,7 @@
 
 namespace OptimizelySDK.Odp
 {
-    public interface ICache<T> 
+    public interface ICache<T>
         where T : class
     {
         void Save(string key, T value);

--- a/OptimizelySDK/Odp/IOdpEventApiManager.cs
+++ b/OptimizelySDK/Odp/IOdpEventApiManager.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Odp.Entity;
 using System.Collections.Generic;
+using OptimizelySDK.Odp.Entity;
 
 namespace OptimizelySDK.Odp
 {

--- a/OptimizelySDK/Odp/IOdpEventManager.cs
+++ b/OptimizelySDK/Odp/IOdpEventManager.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Odp.Entity;
 using System;
+using OptimizelySDK.Odp.Entity;
 
 namespace OptimizelySDK.Odp
 {

--- a/OptimizelySDK/Odp/LruCache.cs
+++ b/OptimizelySDK/Odp/LruCache.cs
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Logger;
-using OptimizelySDK.Utils;
 using System;
 using System.Collections.Specialized;
 using System.Linq;
+using OptimizelySDK.Logger;
+using OptimizelySDK.Utils;
 
 namespace OptimizelySDK.Odp
 {

--- a/OptimizelySDK/Odp/LruCache.cs
+++ b/OptimizelySDK/Odp/LruCache.cs
@@ -209,11 +209,11 @@ namespace OptimizelySDK.Odp
         /// <summary>
         /// For Testing Only: Retrieve the current cache timout
         /// </summary>
-        internal TimeSpan TimeoutForTesting { get { return _timeout; } }
+        internal TimeSpan TimeoutForTesting => _timeout;
 
         /// <summary>
         /// For Testing Only: Retrieve hte current maximum cache size
         /// </summary>
-        internal int MaxSizeForTesting { get { return _maxSize; } }
+        internal int MaxSizeForTesting => _maxSize;
     }
 }

--- a/OptimizelySDK/Odp/OdpEventApiManager.cs
+++ b/OptimizelySDK/Odp/OdpEventApiManager.cs
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-using Newtonsoft.Json;
-using OptimizelySDK.ErrorHandler;
-using OptimizelySDK.Logger;
-using OptimizelySDK.Odp.Entity;
 using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using OptimizelySDK.ErrorHandler;
+using OptimizelySDK.Logger;
+using OptimizelySDK.Odp.Entity;
 
 namespace OptimizelySDK.Odp
 {

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.ErrorHandler;
-using OptimizelySDK.Logger;
-using OptimizelySDK.Odp.Entity;
-using OptimizelySDK.Utils;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
+using OptimizelySDK.ErrorHandler;
+using OptimizelySDK.Logger;
+using OptimizelySDK.Odp.Entity;
+using OptimizelySDK.Utils;
 
 namespace OptimizelySDK.Odp
 {
@@ -159,7 +159,7 @@ namespace OptimizelySDK.Odp
                     {
                         item = _eventQueue.Take();
                         // TODO: need to figure out why this is allowing item to read shutdown signal.
-                        Thread.Sleep(1); 
+                        Thread.Sleep(1);
                     }
 
                     if (item == null)

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -151,12 +151,15 @@ namespace OptimizelySDK.Odp
                     //      otherwise wait for the new event indefinitely
                     if (_currentBatch.Count > 0)
                     {
-                        _eventQueue.TryTake(out item, (int)(_flushingIntervalDeadline - DateTime.Now.MillisecondsSince1970()));
+                        _eventQueue.TryTake(out item,
+                            (int)(_flushingIntervalDeadline -
+                                  DateTime.Now.MillisecondsSince1970()));
                     }
                     else
                     {
                         item = _eventQueue.Take();
-                        Thread.Sleep(1); // TODO: need to figure out why this is allowing item to read shutdown signal.
+                        // TODO: need to figure out why this is allowing item to read shutdown signal.
+                        Thread.Sleep(1); 
                     }
 
                     if (item == null)
@@ -167,6 +170,7 @@ namespace OptimizelySDK.Odp
                             _logger.Log(LogLevel.DEBUG, $"Flushing queue.");
                             FlushQueue();
                         }
+
                         continue;
                     }
                     else if (item == _shutdownSignal)
@@ -184,7 +188,6 @@ namespace OptimizelySDK.Odp
                     {
                         AddToBatch(odpEvent);
                     }
-
                 }
             }
             catch (InvalidOperationException ioe)
@@ -520,10 +523,10 @@ namespace OptimizelySDK.Odp
                 var manager = new OdpEventManager();
                 manager._eventQueue = _eventQueue;
                 manager._odpEventApiManager = _odpEventApiManager;
-                manager._flushInterval = (_flushInterval > TimeSpan.Zero) ?
+                manager._flushInterval = _flushInterval > TimeSpan.Zero ?
                     _flushInterval :
                     Constants.DEFAULT_FLUSH_INTERVAL;
-                manager._batchSize = (_flushInterval == TimeSpan.Zero) ?
+                manager._batchSize = _flushInterval == TimeSpan.Zero ?
                     1 :
                     Constants.DEFAULT_BATCH_SIZE;
                 manager._timeoutInterval = _timeoutInterval <= TimeSpan.Zero ?
@@ -568,16 +571,16 @@ namespace OptimizelySDK.Odp
         /// For Testing Only: Read the current ODP config
         /// </summary>
         /// <returns>Current ODP settings</returns>
-        internal OdpConfig OdpConfigForTesting { get { return _odpConfig; } }
+        internal OdpConfig OdpConfigForTesting => _odpConfig;
 
         /// <summary>
         /// For Testing Only: Read the current flush interval
         /// </summary>
-        internal TimeSpan FlushIntervalForTesting { get { return _flushInterval; } }
+        internal TimeSpan FlushIntervalForTesting => _flushInterval;
 
         /// <summary>
         /// For Testing Only: Read the current timeout interval
         /// </summary>
-        internal TimeSpan TimeoutIntervalForTesting { get { return _timeoutInterval; } }
+        internal TimeSpan TimeoutIntervalForTesting => _timeoutInterval;
     }
 }

--- a/OptimizelySDK/Odp/OdpManager.cs
+++ b/OptimizelySDK/Odp/OdpManager.cs
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
+using System;
+using System.Collections.Generic;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Odp.Entity;
-using System;
-using System.Collections.Generic;
 
 namespace OptimizelySDK.Odp
 {

--- a/OptimizelySDK/Odp/OdpSegmentApiManager.cs
+++ b/OptimizelySDK/Odp/OdpSegmentApiManager.cs
@@ -14,11 +14,6 @@
  * limitations under the License.
  */
 
-using Newtonsoft.Json;
-using OptimizelySDK.AudienceConditions;
-using OptimizelySDK.ErrorHandler;
-using OptimizelySDK.Logger;
-using OptimizelySDK.Odp.Entity;
 using System;
 using System.Collections;
 using System.Collections.Generic;
@@ -26,6 +21,11 @@ using System.Linq;
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
+using OptimizelySDK.AudienceConditions;
+using OptimizelySDK.ErrorHandler;
+using OptimizelySDK.Logger;
+using OptimizelySDK.Odp.Entity;
 
 namespace OptimizelySDK.Odp
 {

--- a/OptimizelySDK/Odp/OdpSegmentApiManager.cs
+++ b/OptimizelySDK/Odp/OdpSegmentApiManager.cs
@@ -131,10 +131,10 @@ namespace OptimizelySDK.Odp
                 return null;
             }
 
-            return segments.Data.Customer.Audiences.Edges
-                .Where(e => e.Node.State == BaseCondition.QUALIFIED)
-                .Select(e => e.Node.Name)
-                .ToArray();
+            return segments.Data.Customer.Audiences.Edges.
+                Where(e => e.Node.State == BaseCondition.QUALIFIED).
+                Select(e => e.Node.Name).
+                ToArray();
         }
 
         /// <summary>
@@ -155,10 +155,9 @@ namespace OptimizelySDK.Odp
                         ""userId"": ""{userValue}"",
                         ""audiences"": {audiences}
                     }
-                }"
-                    .Replace("{userKey}", userKey)
-                    .Replace("{userValue}", userValue)
-                    .Replace("{audiences}", JsonConvert.SerializeObject(segmentsToCheck));
+                }".Replace("{userKey}", userKey).
+                    Replace("{userValue}", userValue).
+                    Replace("{audiences}", JsonConvert.SerializeObject(segmentsToCheck));
         }
 
         /// <summary>

--- a/OptimizelySDK/Odp/OdpSegmentManager.cs
+++ b/OptimizelySDK/Odp/OdpSegmentManager.cs
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Logger;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OptimizelySDK.Logger;
 
 namespace OptimizelySDK.Odp
 {

--- a/OptimizelySDK/Odp/OdpSegmentManager.cs
+++ b/OptimizelySDK/Odp/OdpSegmentManager.cs
@@ -165,6 +165,6 @@ namespace OptimizelySDK.Odp
         /// <summary>
         /// For Testing Only: Retrieve the current segment cache
         /// </summary>
-        internal ICache<List<string>> SegmentsCacheForTesting { get { return _segmentsCache; } }
+        internal ICache<List<string>> SegmentsCacheForTesting => _segmentsCache;
     }
 }

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -51,7 +51,7 @@ namespace OptimizelySDK
     public class Optimizely : IOptimizely, IDisposable
     {
         private Bucketer Bucketer;
-
+        [Obsolete]
         private EventBuilder EventBuilder;
 
         private IEventDispatcher EventDispatcher;
@@ -240,6 +240,7 @@ namespace OptimizelySDK
 #endif
         }
 
+        [Obsolete]
         private void InitializeComponents(IEventDispatcher eventDispatcher = null,
             ILogger logger = null,
             IErrorHandler errorHandler = null,

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -80,13 +80,7 @@ namespace OptimizelySDK
         /// It returns true if the ProjectConfig is valid otherwise false.
         /// Also, it may block execution if GetConfig() blocks execution to get ProjectConfig.
         /// </summary>
-        public bool IsValid
-        {
-            get
-            {
-                return ProjectConfigManager?.GetConfig() != null;
-            }
-        }
+        public bool IsValid => ProjectConfigManager?.GetConfig() != null;
 
         public static String SDK_VERSION
         {
@@ -94,26 +88,20 @@ namespace OptimizelySDK
             {
                 // Example output: "2.1.0" .  Should be kept in synch with NuGet package version.
 #if NET35 || NET40
-                Assembly assembly = Assembly.GetExecutingAssembly();
+                var assembly = Assembly.GetExecutingAssembly();
 #else
-                Assembly assembly = typeof(Optimizely).GetTypeInfo().Assembly;
+                var assembly = typeof(Optimizely).GetTypeInfo().Assembly;
 #endif
                 // Microsoft    Major.Minor.Build.Revision
                 // Semantic     Major.Minor.Patch
-                Version version = assembly.GetName().Version;
-                String answer = String.Format("{0}.{1}.{2}", version.Major, version.Minor,
+                var version = assembly.GetName().Version;
+                var answer = String.Format("{0}.{1}.{2}", version.Major, version.Minor,
                     version.Build);
                 return answer;
             }
         }
 
-        public static String SDK_TYPE
-        {
-            get
-            {
-                return "csharp-sdk";
-            }
-        }
+        public static String SDK_TYPE => "csharp-sdk";
 
         public const string USER_ID = "User Id";
         public const string EXPERIMENT_KEY = "Experiment Key";
@@ -156,7 +144,7 @@ namespace OptimizelySDK
                     null, eventProcessor, defaultDecideOptions, odpManager);
 #else
                 InitializeComponents(eventDispatcher, logger, errorHandler, userProfileService,
-                                    null, eventProcessor, defaultDecideOptions);
+                    null, eventProcessor, defaultDecideOptions);
 #endif
 
                 if (ValidateInputs(datafile, skipJsonValidation))
@@ -177,11 +165,15 @@ namespace OptimizelySDK
             }
             catch (Exception ex)
             {
-                string error = String.Empty;
+                var error = String.Empty;
                 if (ex.GetType() == typeof(ConfigParseException))
+                {
                     error = ex.Message;
+                }
                 else
+                {
                     error = "Provided 'datafile' is in an invalid format. " + ex.Message;
+                }
 
                 Logger.Log(LogLevel.ERROR, error);
                 ErrorHandler.HandleError(ex);
@@ -230,8 +222,8 @@ namespace OptimizelySDK
 
             if (ProjectConfigManager.SdkKey != null)
             {
-                NotificationCenterRegistry.GetNotificationCenter(configManager.SdkKey, logger)
-                    ?.AddNotification(NotificationCenter.NotificationType.OptimizelyConfigUpdate,
+                NotificationCenterRegistry.GetNotificationCenter(configManager.SdkKey, logger)?.
+                    AddNotification(NotificationCenter.NotificationType.OptimizelyConfigUpdate,
                         () =>
                         {
                             projectConfig = ProjectConfigManager.CachedProjectConfig;
@@ -297,10 +289,13 @@ namespace OptimizelySDK
                 return null;
             }
 
-            var inputValues = new Dictionary<string, string> { { USER_ID, userId }, { EXPERIMENT_KEY, experimentKey } };
+            var inputValues = new Dictionary<string, string>
+                { { USER_ID, userId }, { EXPERIMENT_KEY, experimentKey } };
 
             if (!ValidateStringInputs(inputValues))
+            {
                 return null;
+            }
 
             var experiment = config.GetExperimentFromKey(experimentKey);
 
@@ -354,10 +349,13 @@ namespace OptimizelySDK
                 return;
             }
 
-            var inputValues = new Dictionary<string, string> { { USER_ID, userId }, { EVENT_KEY, eventKey } };
+            var inputValues = new Dictionary<string, string>
+                { { USER_ID, userId }, { EVENT_KEY, eventKey } };
 
             if (!ValidateStringInputs(inputValues))
+            {
                 return;
+            }
 
             var eevent = config.GetEvent(eventKey);
 
@@ -422,26 +420,33 @@ namespace OptimizelySDK
                 return null;
             }
 
-            var inputValues = new Dictionary<string, string> { { USER_ID, userId }, { EXPERIMENT_KEY, experimentKey } };
+            var inputValues = new Dictionary<string, string>
+                { { USER_ID, userId }, { EXPERIMENT_KEY, experimentKey } };
 
             if (!ValidateStringInputs(inputValues))
+            {
                 return null;
+            }
 
-            Experiment experiment = config.GetExperimentFromKey(experimentKey);
+            var experiment = config.GetExperimentFromKey(experimentKey);
             if (experiment.Key == null)
+            {
                 return null;
+            }
+
             userAttributes = userAttributes ?? new UserAttributes();
 
             var userContext = CreateUserContextCopy(userId, userAttributes);
-            var variation = DecisionService.GetVariation(experiment, userContext, config)?.ResultObject;
+            var variation = DecisionService.GetVariation(experiment, userContext, config)?.
+                ResultObject;
             var decisionInfo = new Dictionary<string, object>
             {
                 { "experimentKey", experimentKey }, { "variationKey", variation?.Key },
             };
 
-            var decisionNotificationType = config.IsFeatureExperiment(experiment.Id)
-                ? DecisionNotificationTypes.FEATURE_TEST
-                : DecisionNotificationTypes.AB_TEST;
+            var decisionNotificationType = config.IsFeatureExperiment(experiment.Id) ?
+                DecisionNotificationTypes.FEATURE_TEST :
+                DecisionNotificationTypes.AB_TEST;
             NotificationCenter.SendNotifications(NotificationCenter.NotificationType.Decision,
                 decisionNotificationType, userId,
                 userAttributes, decisionInfo);
@@ -465,7 +470,8 @@ namespace OptimizelySDK
                 return false;
             }
 
-            var inputValues = new Dictionary<string, string> { { USER_ID, userId }, { EXPERIMENT_KEY, experimentKey } };
+            var inputValues = new Dictionary<string, string>
+                { { USER_ID, userId }, { EXPERIMENT_KEY, experimentKey } };
             return ValidateStringInputs(inputValues) &&
                    DecisionService.SetForcedVariation(experimentKey, userId, variationKey, config);
         }
@@ -484,10 +490,13 @@ namespace OptimizelySDK
                 return null;
             }
 
-            var inputValues = new Dictionary<string, string> { { USER_ID, userId }, { EXPERIMENT_KEY, experimentKey } };
+            var inputValues = new Dictionary<string, string>
+                { { USER_ID, userId }, { EXPERIMENT_KEY, experimentKey } };
 
             if (!ValidateStringInputs(inputValues))
+            {
                 return null;
+            }
 
             return DecisionService.GetForcedVariation(experimentKey, userId, config).ResultObject;
         }
@@ -516,24 +525,31 @@ namespace OptimizelySDK
                 return false;
             }
 
-            var inputValues = new Dictionary<string, string> { { USER_ID, userId }, { FEATURE_KEY, featureKey } };
+            var inputValues = new Dictionary<string, string>
+                { { USER_ID, userId }, { FEATURE_KEY, featureKey } };
 
             if (!ValidateStringInputs(inputValues))
+            {
                 return false;
+            }
 
             var featureFlag = config.GetFeatureFlagFromKey(featureKey);
             if (string.IsNullOrEmpty(featureFlag.Key))
+            {
                 return false;
+            }
 
             if (!Validator.IsFeatureFlagValid(config, featureFlag))
+            {
                 return false;
+            }
 
-            bool featureEnabled = false;
+            var featureEnabled = false;
             var sourceInfo = new Dictionary<string, string>();
             var decision = DecisionService.GetVariationForFeature(featureFlag,
                     CreateUserContextCopy(userId, userAttributes),
-                    config)
-                .ResultObject;
+                    config).
+                ResultObject;
             var variation = decision?.Variation;
             var decisionSource = decision?.Source ?? FeatureDecision.DECISION_SOURCE_ROLLOUT;
 
@@ -558,11 +574,15 @@ namespace OptimizelySDK
             }
 
             if (featureEnabled == true)
+            {
                 Logger.Log(LogLevel.INFO,
                     $@"Feature flag ""{featureKey}"" is enabled for user ""{userId}"".");
+            }
             else
+            {
                 Logger.Log(LogLevel.INFO,
                     $@"Feature flag ""{featureKey}"" is not enabled for user ""{userId}"".");
+            }
 
             var decisionInfo = new Dictionary<string, object>
             {
@@ -601,20 +621,24 @@ namespace OptimizelySDK
                 Logger.Log(LogLevel.ERROR,
                     $@"Datafile has invalid format. Failing '{
                         FeatureVariable.GetFeatureVariableTypeName(variableType)}'.");
-                return default(T);
+                return default;
             }
 
             var inputValues = new Dictionary<string, string>
             {
-                { USER_ID, userId }, { FEATURE_KEY, featureKey }, { VARIABLE_KEY, variableKey }
+                { USER_ID, userId }, { FEATURE_KEY, featureKey }, { VARIABLE_KEY, variableKey },
             };
 
             if (!ValidateStringInputs(inputValues))
-                return default(T);
+            {
+                return default;
+            }
 
             var featureFlag = config.GetFeatureFlagFromKey(featureKey);
             if (string.IsNullOrEmpty(featureFlag.Key))
-                return default(T);
+            {
+                return default;
+            }
 
             var featureVariable = featureFlag.GetFeatureVariableFromKey(variableKey);
             if (featureVariable == null)
@@ -622,22 +646,22 @@ namespace OptimizelySDK
                 Logger.Log(LogLevel.ERROR,
                     $@"No feature variable was found for key ""{variableKey}"" in feature flag ""{
                         featureKey}"".");
-                return default(T);
+                return default;
             }
             else if (featureVariable.Type != variableType)
             {
                 Logger.Log(LogLevel.ERROR,
                     $@"Variable is of type ""{featureVariable.Type
                     }"", but you requested it as type ""{variableType}"".");
-                return default(T);
+                return default;
             }
 
             var featureEnabled = false;
             var variableValue = featureVariable.DefaultValue;
             var decision = DecisionService.GetVariationForFeature(featureFlag,
                     CreateUserContextCopy(userId, userAttributes),
-                    config)
-                .ResultObject;
+                    config).
+                ResultObject;
 
             if (decision?.Variation != null)
             {
@@ -690,9 +714,10 @@ namespace OptimizelySDK
                 { "featureEnabled", featureEnabled },
                 { "variableKey", variableKey },
                 {
-                    "variableValue", typeCastedValue is OptimizelyJSON
-                        ? ((OptimizelyJSON)typeCastedValue).ToDictionary()
-                        : typeCastedValue
+                    "variableValue",
+                    typeCastedValue is OptimizelyJSON ?
+                        ((OptimizelyJSON)typeCastedValue).ToDictionary() :
+                        typeCastedValue
                 },
                 { "variableType", variableType.ToString().ToLower() },
                 { "source", decision?.Source },
@@ -796,10 +821,12 @@ namespace OptimizelySDK
             UserAttributes userAttributes = null
         )
         {
-            var inputValues = new Dictionary<string, string> { { USER_ID, userId }, };
+            var inputValues = new Dictionary<string, string> { { USER_ID, userId } };
 
             if (!ValidateStringInputs(inputValues))
+            {
                 return null;
+            }
 
             return new OptimizelyUserContext(this, userId, userAttributes, ErrorHandler, Logger);
         }
@@ -808,14 +835,17 @@ namespace OptimizelySDK
             UserAttributes userAttributes = null
         )
         {
-            var inputValues = new Dictionary<string, string> { { USER_ID, userId }, };
+            var inputValues = new Dictionary<string, string> { { USER_ID, userId } };
 
             if (!ValidateStringInputs(inputValues))
+            {
                 return null;
+            }
 
-            return new OptimizelyUserContext(this, userId, userAttributes, null, null, ErrorHandler, Logger
+            return new OptimizelyUserContext(this, userId, userAttributes, null, null, ErrorHandler,
+                Logger
 #if USE_ODP
-                , shouldIdentifyUser: false
+                , false
 #endif
             );
         }
@@ -913,7 +943,7 @@ namespace OptimizelySDK
             {
                 foreach (var featureVariable in flag?.Variables)
                 {
-                    string variableValue = featureVariable.DefaultValue;
+                    var variableValue = featureVariable.DefaultValue;
                     if (featureEnabled)
                     {
                         var featureVariableUsageInstance =
@@ -928,7 +958,9 @@ namespace OptimizelySDK
                         GetTypeCastedVariableValue(variableValue, featureVariable.Type);
 
                     if (typeCastedValue is OptimizelyJSON)
+                    {
                         typeCastedValue = ((OptimizelyJSON)typeCastedValue).ToDictionary();
+                    }
 
                     variableMap.Add(featureVariable.Key, typeCastedValue);
                 }
@@ -944,8 +976,9 @@ namespace OptimizelySDK
                     featureEnabled);
             }
 
-            var reasonsToReport = decisionReasons.ToReport(allOptions.Contains(OptimizelyDecideOption.INCLUDE_REASONS))
-                .ToArray();
+            var reasonsToReport = decisionReasons.
+                ToReport(allOptions.Contains(OptimizelyDecideOption.INCLUDE_REASONS)).
+                ToArray();
             var variationKey = decision?.Variation?.Key;
 
             // TODO: add ruleKey values when available later. use a copy of experimentKey until then.
@@ -959,7 +992,7 @@ namespace OptimizelySDK
                 { "variationKey", variationKey },
                 { "ruleKey", ruleKey },
                 { "reasons", reasonsToReport },
-                { "decisionEventDispatched", decisionEventDispatched }
+                { "decisionEventDispatched", decisionEventDispatched },
             };
 
             NotificationCenter.SendNotifications(NotificationCenter.NotificationType.Decision,
@@ -1018,7 +1051,7 @@ namespace OptimizelySDK
 
             var allOptions = GetAllOptions(options);
 
-            foreach (string key in keys)
+            foreach (var key in keys)
             {
                 var decision = Decide(user, key, options);
                 if (!allOptions.Contains(OptimizelyDecideOption.ENABLED_FLAGS_ONLY) ||
@@ -1033,7 +1066,7 @@ namespace OptimizelySDK
 
         private OptimizelyDecideOption[] GetAllOptions(OptimizelyDecideOption[] options)
         {
-            OptimizelyDecideOption[] copiedOptions = DefaultDecideOptions;
+            var copiedOptions = DefaultDecideOptions;
             if (options != null)
             {
                 copiedOptions = options.Union(DefaultDecideOptions).ToArray();
@@ -1117,7 +1150,7 @@ namespace OptimizelySDK
         /// <returns>List of the feature keys that are enabled for the user.</returns>
         public List<string> GetEnabledFeatures(string userId, UserAttributes userAttributes = null)
         {
-            List<string> enabledFeaturesList = new List<string>();
+            var enabledFeaturesList = new List<string>();
 
             var config = ProjectConfigManager?.GetConfig();
 
@@ -1129,13 +1162,17 @@ namespace OptimizelySDK
             }
 
             if (!ValidateStringInputs(new Dictionary<string, string> { { USER_ID, userId } }))
+            {
                 return enabledFeaturesList;
+            }
 
             foreach (var feature in config.FeatureKeyMap.Values)
             {
                 var featureKey = feature.Key;
                 if (IsFeatureEnabled(featureKey, userId, userAttributes))
+                {
                     enabledFeaturesList.Add(featureKey);
+                }
             }
 
             return enabledFeaturesList;
@@ -1180,7 +1217,9 @@ namespace OptimizelySDK
             }
 
             if (!Validator.IsFeatureFlagValid(config, featureFlag))
+            {
                 return null;
+            }
 
             var featureEnabled = false;
             var decisionResult = DecisionService.GetVariationForFeature(featureFlag,
@@ -1213,7 +1252,7 @@ namespace OptimizelySDK
             var valuesMap = new Dictionary<string, object>();
             foreach (var featureVariable in featureFlag.Variables)
             {
-                string variableValue = featureVariable.DefaultValue;
+                var variableValue = featureVariable.DefaultValue;
                 if (featureEnabled)
                 {
                     var featureVariableUsageInstance =
@@ -1228,7 +1267,9 @@ namespace OptimizelySDK
                     GetTypeCastedVariableValue(variableValue, featureVariable.Type);
 
                 if (typeCastedValue is OptimizelyJSON)
+                {
                     typeCastedValue = ((OptimizelyJSON)typeCastedValue).ToDictionary();
+                }
 
                 valuesMap.Add(featureVariable.Key, typeCastedValue);
             }
@@ -1331,7 +1372,7 @@ namespace OptimizelySDK
         /// <returns>True if all values are valid, false otherwise</returns>
         private bool ValidateStringInputs(Dictionary<string, string> inputs)
         {
-            bool isValid = true;
+            var isValid = true;
 
             // Empty user Id is valid value.
             if (inputs.ContainsKey(USER_ID))
@@ -1363,18 +1404,18 @@ namespace OptimizelySDK
             switch (type)
             {
                 case FeatureVariable.BOOLEAN_TYPE:
-                    bool.TryParse(value, out bool booleanValue);
+                    bool.TryParse(value, out var booleanValue);
                     result = booleanValue;
                     break;
 
                 case FeatureVariable.DOUBLE_TYPE:
                     double.TryParse(value, System.Globalization.NumberStyles.Number,
-                        System.Globalization.CultureInfo.InvariantCulture, out double doubleValue);
+                        System.Globalization.CultureInfo.InvariantCulture, out var doubleValue);
                     result = doubleValue;
                     break;
 
                 case FeatureVariable.INTEGER_TYPE:
-                    int.TryParse(value, out int intValue);
+                    int.TryParse(value, out var intValue);
                     result = intValue;
                     break;
 
@@ -1388,8 +1429,10 @@ namespace OptimizelySDK
             }
 
             if (result == null)
+            {
                 Logger.Log(LogLevel.ERROR,
                     $@"Unable to cast variable value ""{value}"" to type ""{type}"".");
+            }
 
             return result;
         }

--- a/OptimizelySDK/OptimizelyDecisionContext.cs
+++ b/OptimizelySDK/OptimizelyDecisionContext.cs
@@ -37,27 +37,28 @@ namespace OptimizelySDK
         /// <summary>
         /// Flag key of the context.
         /// </summary>
-        public string FlagKey { get { return flagKey; } }
+        public string FlagKey => flagKey;
 
         /// <summary>
         /// Rule key, it can be experiment or rollout key and nullable.
         /// </summary>
-        public string RuleKey { get { return ruleKey; } }
+        public string RuleKey => ruleKey;
 
-        public OptimizelyDecisionContext(string flagKey, string ruleKey= null)
+        public OptimizelyDecisionContext(string flagKey, string ruleKey = null)
         {
-            if (flagKey != null) {
+            if (flagKey != null)
+            {
                 IsValid = true;
             }
+
             this.flagKey = flagKey;
             this.ruleKey = ruleKey;
         }
 
         public string GetKey()
         {
-            return string.Format("{0}{1}{2}", FlagKey, OPTI_KEY_DIVIDER, RuleKey ?? OPTI_NULL_RULE_KEY);
+            return string.Format("{0}{1}{2}", FlagKey, OPTI_KEY_DIVIDER,
+                RuleKey ?? OPTI_NULL_RULE_KEY);
         }
-
-
     }
 }

--- a/OptimizelySDK/OptimizelyDecisions/DecisionMessage.cs
+++ b/OptimizelySDK/OptimizelyDecisions/DecisionMessage.cs
@@ -20,7 +20,10 @@ namespace OptimizelySDK.OptimizelyDecisions
     {
         public const string SDK_NOT_READY = "Optimizely SDK not configured properly yet.";
         public const string FLAG_KEY_INVALID = "No flag was found for key \"{0}\".";
-        public const string VARIABLE_VALUE_INVALID = "Variable value for key \"{0}\" is invalid or wrong type.";
+
+        public const string VARIABLE_VALUE_INVALID =
+            "Variable value for key \"{0}\" is invalid or wrong type.";
+
         public static string Reason(string format, params object[] args)
         {
             return string.Format(format, args);

--- a/OptimizelySDK/OptimizelyDecisions/DecisionReasons.cs
+++ b/OptimizelySDK/OptimizelyDecisions/DecisionReasons.cs
@@ -26,13 +26,13 @@ namespace OptimizelySDK.OptimizelyDecisions
 
         public void AddError(string format, params object[] args)
         {
-            string message = string.Format(format, args);
+            var message = string.Format(format, args);
             Errors.Add(message);
         }
 
         public string AddInfo(string format, params object[] args)
         {
-            string message = string.Format(format, args);
+            var message = string.Format(format, args);
             Infos.Add(message);
 
             return message;
@@ -40,7 +40,10 @@ namespace OptimizelySDK.OptimizelyDecisions
 
         public static DecisionReasons operator +(DecisionReasons a, DecisionReasons b)
         {
-            if (b == null) return a;
+            if (b == null)
+            {
+                return a;
+            }
 
             a.Errors.AddRange(b.Errors);
             a.Infos.AddRange(b.Infos);
@@ -50,12 +53,13 @@ namespace OptimizelySDK.OptimizelyDecisions
 
         public List<string> ToReport(bool includeReasons = false)
         {
-            List<string> reasons = new List<string>(Errors);
+            var reasons = new List<string>(Errors);
 
-            if (includeReasons) {
+            if (includeReasons)
+            {
                 reasons.AddRange(Infos);
             }
-            
+
             return reasons;
         }
     }

--- a/OptimizelySDK/OptimizelyDecisions/OptimizelyDecideOption.cs
+++ b/OptimizelySDK/OptimizelyDecisions/OptimizelyDecideOption.cs
@@ -22,6 +22,6 @@ namespace OptimizelySDK.OptimizelyDecisions
         ENABLED_FLAGS_ONLY,
         IGNORE_USER_PROFILE_SERVICE,
         INCLUDE_REASONS,
-        EXCLUDE_VARIABLES
+        EXCLUDE_VARIABLES,
     }
 }

--- a/OptimizelySDK/OptimizelyDecisions/OptimizelyDecision.cs
+++ b/OptimizelySDK/OptimizelyDecisions/OptimizelyDecision.cs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
-using System.Collections.Generic;
 
 namespace OptimizelySDK.OptimizelyDecisions
 {

--- a/OptimizelySDK/OptimizelyDecisions/OptimizelyDecision.cs
+++ b/OptimizelySDK/OptimizelyDecisions/OptimizelyDecision.cs
@@ -29,7 +29,7 @@ namespace OptimizelySDK.OptimizelyDecisions
         /// variation key for optimizely decision.
         /// </summary>
         public string VariationKey { get; private set; }
-        
+
         /// <summary>
         /// boolean value indicating if the flag is enabled or not.
         /// </summary>
@@ -39,34 +39,35 @@ namespace OptimizelySDK.OptimizelyDecisions
         /// collection of variables associated with the decision.
         /// </summary>
         public OptimizelyJSON Variables { get; private set; }
-        
+
         /// <summary>
         /// rule key of the decision.
         /// </summary>
         public string RuleKey { get; private set; }
-        
+
         /// <summary>
         /// flag key for which the decision was made.
         /// </summary>
         public string FlagKey { get; private set; }
-        
+
         /// <summary>
         /// user context for which the  decision was made.
         /// </summary>
         public OptimizelyUserContext UserContext { get; private set; }
-        
+
         /// <summary>
         /// an array of error/info/debug messages describing why the decision has been made.
         /// </summary>
         public string[] Reasons { get; private set; }
 
         public OptimizelyDecision(string variationKey,
-                              bool enabled,
-                              OptimizelyJSON variables,
-                              string ruleKey,
-                              string flagKey,
-                              OptimizelyUserContext userContext,
-                              string[] reasons)
+            bool enabled,
+            OptimizelyJSON variables,
+            string ruleKey,
+            string flagKey,
+            OptimizelyUserContext userContext,
+            string[] reasons
+        )
         {
             VariationKey = variationKey;
             Enabled = enabled;
@@ -87,7 +88,8 @@ namespace OptimizelySDK.OptimizelyDecisions
             OptimizelyUserContext optimizelyUserContext,
             string error,
             IErrorHandler errorHandler,
-            ILogger logger)
+            ILogger logger
+        )
         {
             return new OptimizelyDecision(
                 null,

--- a/OptimizelySDK/OptimizelyFactory.cs
+++ b/OptimizelySDK/OptimizelyFactory.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 #if !NETSTANDARD1_6 && !NET35
 using System.Configuration;
@@ -72,53 +73,67 @@ namespace OptimizelySDK
             OptimizelySDKConfigSection OptlySDKConfigSection = null;
             try
             {
-                OptlySDKConfigSection = ConfigurationManager.GetSection(ConfigSectionName) as OptimizelySDKConfigSection;
+                OptlySDKConfigSection =
+                    ConfigurationManager.GetSection(ConfigSectionName) as
+                        OptimizelySDKConfigSection;
             }
             catch (ConfigurationErrorsException ex)
             {
-                logger.Log(LogLevel.ERROR, "Invalid App.Config. Unable to initialize optimizely instance" + ex.Message);
-                return null;    
-            }            
+                logger.Log(LogLevel.ERROR,
+                    "Invalid App.Config. Unable to initialize optimizely instance" + ex.Message);
+                return null;
+            }
 
-            HttpProjectConfigElement httpProjectConfigElement = OptlySDKConfigSection.HttpProjectConfig;
+            var httpProjectConfigElement = OptlySDKConfigSection.HttpProjectConfig;
 
-            if (httpProjectConfigElement == null) return null;
+            if (httpProjectConfigElement == null)
+            {
+                return null;
+            }
 
             var errorHandler = new DefaultErrorHandler(logger, false);
             var eventDispatcher = new DefaultEventDispatcher(logger);
             var builder = new HttpProjectConfigManager.Builder();
             var notificationCenter = new NotificationCenter();
-            var configManager = builder
-                .WithSdkKey(httpProjectConfigElement.SDKKey)
-                .WithUrl(httpProjectConfigElement.Url)
-                .WithFormat(httpProjectConfigElement.Format)
-                .WithPollingInterval(TimeSpan.FromMilliseconds(httpProjectConfigElement.PollingInterval))
-                .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(httpProjectConfigElement.BlockingTimeOutPeriod))
+            var configManager = builder.WithSdkKey(httpProjectConfigElement.SDKKey).
+                WithUrl(httpProjectConfigElement.Url).
+                WithFormat(httpProjectConfigElement.Format).
+                WithPollingInterval(
+                    TimeSpan.FromMilliseconds(httpProjectConfigElement.PollingInterval)).
+                WithBlockingTimeoutPeriod(
+                    TimeSpan.FromMilliseconds(httpProjectConfigElement.BlockingTimeOutPeriod))
 #if !NET40 && !NET35
-                .WithAccessToken(httpProjectConfigElement.DatafileAccessToken)
+                .
+                WithAccessToken(httpProjectConfigElement.DatafileAccessToken)
 #endif
-                .WithLogger(logger)
-                .WithErrorHandler(errorHandler)
-                .WithNotificationCenter(notificationCenter)
-                .Build(true);
+                .
+                WithLogger(logger).
+                WithErrorHandler(errorHandler).
+                WithNotificationCenter(notificationCenter).
+                Build(true);
 
             EventProcessor eventProcessor = null;
 
             var batchEventProcessorElement = OptlySDKConfigSection.BatchEventProcessor;
 
-            if (batchEventProcessorElement == null) return null;
+            if (batchEventProcessorElement == null)
+            {
+                return null;
+            }
 
-            eventProcessor = new BatchEventProcessor.Builder()
-                .WithMaxBatchSize(batchEventProcessorElement.BatchSize)
-                .WithFlushInterval(TimeSpan.FromMilliseconds(batchEventProcessorElement.FlushInterval))
-                .WithTimeoutInterval(TimeSpan.FromMilliseconds(batchEventProcessorElement.TimeoutInterval))
-                .WithLogger(logger)
-                .WithEventDispatcher(eventDispatcher)
-                .WithNotificationCenter(notificationCenter)
-                .Build();
+            eventProcessor = new BatchEventProcessor.Builder().
+                WithMaxBatchSize(batchEventProcessorElement.BatchSize).
+                WithFlushInterval(
+                    TimeSpan.FromMilliseconds(batchEventProcessorElement.FlushInterval)).
+                WithTimeoutInterval(
+                    TimeSpan.FromMilliseconds(batchEventProcessorElement.TimeoutInterval)).
+                WithLogger(logger).
+                WithEventDispatcher(eventDispatcher).
+                WithNotificationCenter(notificationCenter).
+                Build();
 
-            return NewDefaultInstance(configManager, notificationCenter, eventDispatcher, errorHandler, logger, eventProcessor: eventProcessor);
-
+            return NewDefaultInstance(configManager, notificationCenter, eventDispatcher,
+                errorHandler, logger, eventProcessor: eventProcessor);
         }
 #endif
 
@@ -127,7 +142,9 @@ namespace OptimizelySDK
             return NewDefaultInstance(sdkKey, null);
         }
 #if !NET40 && !NET35
-        public static Optimizely NewDefaultInstance(string sdkKey, string fallback, string datafileAuthToken)
+        public static Optimizely NewDefaultInstance(string sdkKey, string fallback,
+            string datafileAuthToken
+        )
         {
             var logger = OptimizelyLogger ?? new DefaultLogger();
             var errorHandler = new DefaultErrorHandler(logger, false);
@@ -135,30 +152,29 @@ namespace OptimizelySDK
             var builder = new HttpProjectConfigManager.Builder();
             var notificationCenter = new NotificationCenter();
 
-            var configManager = builder
-                .WithSdkKey(sdkKey)
-                .WithDatafile(fallback)
-                .WithLogger(logger)
-                .WithPollingInterval(PollingInterval)
-                .WithBlockingTimeoutPeriod(BlockingTimeOutPeriod)
-                .WithErrorHandler(errorHandler)
-                .WithAccessToken(datafileAuthToken)
-                .WithNotificationCenter(notificationCenter)
-                .Build(true);
+            var configManager = builder.WithSdkKey(sdkKey).
+                WithDatafile(fallback).
+                WithLogger(logger).
+                WithPollingInterval(PollingInterval).
+                WithBlockingTimeoutPeriod(BlockingTimeOutPeriod).
+                WithErrorHandler(errorHandler).
+                WithAccessToken(datafileAuthToken).
+                WithNotificationCenter(notificationCenter).
+                Build(true);
 
             EventProcessor eventProcessor = null;
 
 #if !NETSTANDARD1_6 && !NET35
-            eventProcessor = new BatchEventProcessor.Builder()
-                .WithLogger(logger)
-                .WithMaxBatchSize(MaxEventBatchSize)
-                .WithFlushInterval(MaxEventFlushInterval)
-                .WithEventDispatcher(eventDispatcher)
-                .WithNotificationCenter(notificationCenter)
-                .Build();
+            eventProcessor = new BatchEventProcessor.Builder().WithLogger(logger).
+                WithMaxBatchSize(MaxEventBatchSize).
+                WithFlushInterval(MaxEventFlushInterval).
+                WithEventDispatcher(eventDispatcher).
+                WithNotificationCenter(notificationCenter).
+                Build();
 #endif
 
-            return NewDefaultInstance(configManager, notificationCenter, eventDispatcher, errorHandler, logger, eventProcessor: eventProcessor);
+            return NewDefaultInstance(configManager, notificationCenter, eventDispatcher,
+                errorHandler, logger, eventProcessor: eventProcessor);
         }
 #endif
         public static Optimizely NewDefaultInstance(string sdkKey, string fallback)
@@ -169,35 +185,38 @@ namespace OptimizelySDK
             var builder = new HttpProjectConfigManager.Builder();
             var notificationCenter = new NotificationCenter();
 
-            var configManager = builder
-                .WithSdkKey(sdkKey)
-                .WithDatafile(fallback)
-                .WithLogger(logger)
-                .WithPollingInterval(PollingInterval)
-                .WithBlockingTimeoutPeriod(BlockingTimeOutPeriod)
-                .WithErrorHandler(errorHandler)
-                .WithNotificationCenter(notificationCenter)
-                .Build(true);
+            var configManager = builder.WithSdkKey(sdkKey).
+                WithDatafile(fallback).
+                WithLogger(logger).
+                WithPollingInterval(PollingInterval).
+                WithBlockingTimeoutPeriod(BlockingTimeOutPeriod).
+                WithErrorHandler(errorHandler).
+                WithNotificationCenter(notificationCenter).
+                Build(true);
 
             EventProcessor eventProcessor = null;
 
 #if !NETSTANDARD1_6 && !NET35
-            eventProcessor = new BatchEventProcessor.Builder()
-                .WithLogger(logger)
-                .WithMaxBatchSize(MaxEventBatchSize)
-                .WithFlushInterval(MaxEventFlushInterval)
-                .WithEventDispatcher(eventDispatcher)
-                .WithNotificationCenter(notificationCenter)
-                .Build();
+            eventProcessor = new BatchEventProcessor.Builder().WithLogger(logger).
+                WithMaxBatchSize(MaxEventBatchSize).
+                WithFlushInterval(MaxEventFlushInterval).
+                WithEventDispatcher(eventDispatcher).
+                WithNotificationCenter(notificationCenter).
+                Build();
 #endif
 
-            return NewDefaultInstance(configManager, notificationCenter, eventDispatcher, errorHandler, logger, eventProcessor: eventProcessor);
+            return NewDefaultInstance(configManager, notificationCenter, eventDispatcher,
+                errorHandler, logger, eventProcessor: eventProcessor);
         }
 
-        public static Optimizely NewDefaultInstance(ProjectConfigManager configManager, NotificationCenter notificationCenter = null, IEventDispatcher eventDispatcher = null,
-                                                    IErrorHandler errorHandler = null, ILogger logger = null, UserProfileService userprofileService = null, EventProcessor eventProcessor = null)
+        public static Optimizely NewDefaultInstance(ProjectConfigManager configManager,
+            NotificationCenter notificationCenter = null, IEventDispatcher eventDispatcher = null,
+            IErrorHandler errorHandler = null, ILogger logger = null,
+            UserProfileService userprofileService = null, EventProcessor eventProcessor = null
+        )
         {
-            return new Optimizely(configManager, notificationCenter, eventDispatcher, logger, errorHandler, userprofileService, eventProcessor);      
+            return new Optimizely(configManager, notificationCenter, eventDispatcher, logger,
+                errorHandler, userprofileService, eventProcessor);
         }
     }
 }

--- a/OptimizelySDK/OptimizelyForcedDecision.cs
+++ b/OptimizelySDK/OptimizelyForcedDecision.cs
@@ -25,6 +25,6 @@ namespace OptimizelySDK
             _variationKey = variationKey;
         }
 
-        public string VariationKey { get { return _variationKey; } }
+        public string VariationKey => _variationKey;
     }
 }

--- a/OptimizelySDK/OptimizelyJSON.cs
+++ b/OptimizelySDK/OptimizelyJSON.cs
@@ -48,7 +48,9 @@ namespace OptimizelySDK
             }
         }
 
-        public OptimizelyJSON(Dictionary<string, object> dict, IErrorHandler errorHandler, ILogger logger)
+        public OptimizelyJSON(Dictionary<string, object> dict, IErrorHandler errorHandler,
+            ILogger logger
+        )
         {
             try
             {
@@ -64,7 +66,7 @@ namespace OptimizelySDK
             }
         }
 
-        override public string ToString()
+        public override string ToString()
         {
             return Payload;
         }
@@ -93,26 +95,32 @@ namespace OptimizelySDK
                 {
                     return GetObject<T>(Dict);
                 }
+
                 var path = jsonPath.Split('.');
 
                 var currentObject = Dict;
-                for (int i = 0; i < path.Length - 1; i++)
+                for (var i = 0; i < path.Length - 1; i++)
                 {
                     currentObject = currentObject[path[i]] as Dictionary<string, object>;
                 }
+
                 return GetObject<T>(currentObject[path[path.Length - 1]]);
             }
             catch (KeyNotFoundException exception)
             {
                 Logger.Log(LogLevel.ERROR, "Value for JSON key not found.");
-                ErrorHandler.HandleError(new Exceptions.OptimizelyRuntimeException(exception.Message));
+                ErrorHandler.HandleError(
+                    new Exceptions.OptimizelyRuntimeException(exception.Message));
             }
             catch (Exception exception)
             {
-                Logger.Log(LogLevel.ERROR, "Value for path could not be assigned to provided type.");
-                ErrorHandler.HandleError(new Exceptions.OptimizelyRuntimeException(exception.Message));
+                Logger.Log(LogLevel.ERROR,
+                    "Value for path could not be assigned to provided type.");
+                ErrorHandler.HandleError(
+                    new Exceptions.OptimizelyRuntimeException(exception.Message));
             }
-            return default(T);
+
+            return default;
         }
 
         private T GetObject<T>(object o)
@@ -121,6 +129,7 @@ namespace OptimizelySDK
             {
                 deserializedObj = JsonConvert.DeserializeObject<T>(JsonConvert.SerializeObject(o));
             }
+
             return deserializedObj;
         }
 
@@ -133,12 +142,14 @@ namespace OptimizelySDK
         {
             if (o is JObject jo)
             {
-                return jo.ToObject<IDictionary<string, object>>().ToDictionary(k => k.Key, v => ConvertIntoCollection(v.Value));
+                return jo.ToObject<IDictionary<string, object>>().
+                    ToDictionary(k => k.Key, v => ConvertIntoCollection(v.Value));
             }
             else if (o is JArray ja)
             {
                 return ja.ToObject<List<object>>().Select(ConvertIntoCollection).ToList();
             }
+
             return o;
         }
     }

--- a/OptimizelySDK/OptimizelyJSON.cs
+++ b/OptimizelySDK/OptimizelyJSON.cs
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Logger;
 using System;
 using System.Collections.Generic;
-using Newtonsoft.Json.Linq;
-using OptimizelySDK.ErrorHandler;
 using System.Linq;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OptimizelySDK.ErrorHandler;
+using OptimizelySDK.Logger;
 
 namespace OptimizelySDK
 {

--- a/OptimizelySDK/OptimizelySDK.csproj
+++ b/OptimizelySDK/OptimizelySDK.csproj
@@ -1,214 +1,214 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <ProjectGuid>{4DDE7FAA-110D-441C-AB3B-3F31B593E8BF}</ProjectGuid>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
-        <RootNamespace>OptimizelySDK</RootNamespace>
-        <AssemblyName>OptimizelySDK</AssemblyName>
-        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-        <FileAlignment>512</FileAlignment>
-        <TargetFrameworkProfile />
-        <ReleaseVersion>1.2.1</ReleaseVersion>
-        <AssemblyOriginatorKeyFile>..\keypair.snk</AssemblyOriginatorKeyFile>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath>bin\Debug\</OutputPath>
-        <DefineConstants>TRACE;DEBUG</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <Prefer32Bit>false</Prefer32Bit>
-        <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath>bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
-        <Prefer32Bit>false</Prefer32Bit>
-    </PropertyGroup>
-    <PropertyGroup>
-        <DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v3.5'">NET35</DefineConstants>
-        <DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v4.0'">NET40</DefineConstants>
-        <!-- <DefineConstants Condition=" !$(DefineConstants.Contains(';NET')) ">$(DefineConstants);$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", ""))</DefineConstants> -->
-        <!-- <DefineConstants Condition=" $(DefineConstants.Contains(';NET')) ">$(DefineConstants.Remove($(DefineConstants.LastIndexOf(";NET"))));$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", ""))</DefineConstants> -->
-    </PropertyGroup>
-    <ItemGroup>
-        <Reference Include="Microsoft.CSharp" />
-        <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-            <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-            <Private>True</Private>
-        </Reference>
-        <Reference Include="NJsonSchema, Version=8.30.6304.31883, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
-            <HintPath>..\packages\NJsonSchema.8.30.6304.31883\lib\net45\NJsonSchema.dll</HintPath>
-            <Private>True</Private>
-        </Reference>
-        <Reference Include="System" />
-        <Reference Include="System.Configuration" />
-        <Reference Include="System.Core" />
-        <Reference Include="System.Net.Http" />
-        <Reference Include="System.Xml.Linq" />
-        <Reference Include="System.Data.DataSetExtensions" />
-        <Reference Include="System.Data" />
-        <Reference Include="System.Xml" />
-        <Reference Include="MurmurHash">
-            <HintPath>..\packages\murmurhash-signed.1.0.2\lib\net45\MurmurHash.dll</HintPath>
-        </Reference>
-    </ItemGroup>
-    <ItemGroup>
-        <Compile Include="AudienceConditions\AndCondition.cs" />
-        <Compile Include="AudienceConditions\AudienceIdCondition.cs" />
-        <Compile Include="AudienceConditions\EmptyCondition.cs" />
-        <Compile Include="AudienceConditions\ICondition.cs" />
-        <Compile Include="AudienceConditions\NotCondition.cs" />
-        <Compile Include="AudienceConditions\OrCondition.cs" />
-        <Compile Include="Bucketing\Bucketer.cs" />
-        <Compile Include="Bucketing\Decision.cs" />
-        <Compile Include="ClientConfigHandler.cs" />
-        <Compile Include="Entity\Attribute.cs" />
-        <Compile Include="Entity\Audience.cs" />
-        <Compile Include="AudienceConditions\BaseCondition.cs" />
-        <Compile Include="Entity\Entity.cs" />
-        <Compile Include="Entity\Event.cs" />
-        <Compile Include="Entity\EventTags.cs" />
-        <Compile Include="Entity\Experiment.cs" />
-        <Compile Include="Entity\FeatureDecision.cs" />
-        <Compile Include="Entity\FeatureFlag.cs" />
-        <Compile Include="Entity\FeatureVariable.cs" />
-        <Compile Include="Entity\FeatureVariableUsage.cs" />
-        <Compile Include="Entity\ForcedVariation.cs" />
-        <Compile Include="Entity\Group.cs" />
-        <Compile Include="Entity\IdKeyEntity.cs" />
-        <Compile Include="Entity\Integration.cs" />
-        <Compile Include="Event\Entity\DecisionMetadata.cs" />
-        <Compile Include="Odp\Constants.cs" />
-        <Compile Include="Odp\Entity\Audience.cs" />
-        <Compile Include="Odp\Entity\Customer.cs" />
-        <Compile Include="Odp\Entity\Data.cs" />
-        <Compile Include="Odp\Entity\Edge.cs" />
-        <Compile Include="Odp\Entity\Error.cs" />
-        <Compile Include="Odp\Entity\Location.cs" />
-        <Compile Include="Odp\Entity\Extension.cs" />
-        <Compile Include="Odp\Entity\Node.cs" />
-        <Compile Include="Odp\Entity\OdpEvent.cs" />
-        <Compile Include="Odp\Entity\Response.cs" />
-        <Compile Include="Odp\Enums.cs" />
-        <Compile Include="Odp\IOdpManager.cs" />
-        <Compile Include="Odp\IOdpSegmentManager.cs" />
-        <Compile Include="Odp\OdpManager.cs" />
-        <Compile Include="Odp\OdpSegmentApiManager.cs" />
-        <Compile Include="Odp\IOdpSegmentApiManager.cs" />
-        <Compile Include="Odp\ICache.cs" />
-        <Compile Include="Odp\IOdpEventApiManager.cs" />
-        <Compile Include="Odp\IOdpEventManager.cs" />
-        <Compile Include="Odp\LruCache.cs" />
-        <Compile Include="Odp\OdpConfig.cs" />
-        <Compile Include="Odp\OdpEventManager.cs" />
-        <Compile Include="Odp\OdpEventApiManager.cs" />
-        <Compile Include="Odp\OdpSegmentManager.cs" />
-        <Compile Include="OptimizelyDecisions\DecisionMessage.cs" />
-        <Compile Include="OptimizelyDecisions\DecisionReasons.cs" />
-        <Compile Include="OptimizelyDecisions\OptimizelyDecideOption.cs" />
-        <Compile Include="OptimizelyDecisions\OptimizelyDecision.cs" />
-        <Compile Include="OptimizelyForcedDecision.cs" />
-        <Compile Include="ForcedDecisionsStore.cs" />
-        <Compile Include="OptimizelyUserContext.cs" />
-        <Compile Include="OptimizelyJSON.cs" />
-        <Compile Include="Entity\Rollout.cs" />
-        <Compile Include="Entity\TrafficAllocation.cs" />
-        <Compile Include="Entity\UserAttributes.cs" />
-        <Compile Include="Entity\Variation.cs" />
-        <Compile Include="ErrorHandler\DefaultErrorHandler.cs" />
-        <Compile Include="ErrorHandler\IErrorHandler.cs" />
-        <Compile Include="ErrorHandler\NoOpErrorHandler.cs" />
-        <Compile Include="Event\BatchEventProcessor.cs" />
-        <Compile Include="Event\Builder\EventBuilder.cs" />
-        <Compile Include="Event\Builder\Params.cs" />
-        <Compile Include="Event\Dispatcher\DefaultEventDispatcher.cs" />
-        <Compile Include="Event\Dispatcher\WebRequestEventDispatcher35.cs" />
-        <Compile Include="Event\Dispatcher\HttpClientEventDispatcher45.cs" />
-        <Compile Include="Event\Dispatcher\IEventDispatcher.cs" />
-        <Compile Include="Event\EventFactory.cs" />
-        <Compile Include="Event\EventProcessor.cs" />
-        <Compile Include="Event\ForwardingEventProcessor.cs" />
-        <Compile Include="Event\UserEventFactory.cs" />
-        <Compile Include="Event\LogEvent.cs" />
-        <Compile Include="Exceptions\OptimizelyException.cs" />
-        <Compile Include="IOptimizely.cs" />
-        <Compile Include="Logger\DefaultLogger.cs" />
-        <Compile Include="Logger\ILogger.cs" />
-        <Compile Include="Logger\NoOpLogger.cs" />
-        <Compile Include="Notifications\NotificationCenter.cs" />
-        <Compile Include="Optimizely.cs" />
-        <Compile Include="Bucketing\UserProfile.cs" />
-        <Compile Include="OptimizelyDecisionContext.cs" />
-        <Compile Include="OptlyConfig\IOptimizelyConfigManager.cs" />
-        <Compile Include="OptlyConfig\OptimizelyEvent.cs" />
-        <Compile Include="OptlyConfig\OptimizelyAttribute.cs" />
-        <Compile Include="OptlyConfig\OptimizelyAudience.cs" />
-        <Compile Include="OptlyConfig\OptimizelyConfig.cs" />
-        <Compile Include="OptlyConfig\OptimizelyConfigService.cs" />
-        <Compile Include="OptlyConfig\OptimizelyExperiment.cs" />
-        <Compile Include="OptlyConfig\OptimizelyFeature.cs" />
-        <Compile Include="OptlyConfig\OptimizelyVariable.cs" />
-        <Compile Include="OptlyConfig\OptimizelyVariation.cs" />
-        <Compile Include="Utils\AttributeMatchTypes.cs" />
-        <Compile Include="Utils\CollectionExtensions.cs" />
-        <Compile Include="Utils\ConditionParser.cs" />
-        <Compile Include="Utils\DecisionInfoTypes.cs" />
-        <Compile Include="Utils\EventTagUtils.cs" />
-        <Compile Include="Bucketing\UserProfileUtil.cs" />
-        <Compile Include="Utils\ExperimentUtils.cs" />
-        <Compile Include="Utils\ControlAttributes.cs" />
-        <Compile Include="Utils\ExceptionExtensions.cs" />
-        <Compile Include="Utils\DateTimeUtils.cs" />
-        <Compile Include="Utils\Validator.cs" />
-        <Compile Include="Properties\AssemblyInfo.cs" />
-        <Compile Include="Utils\ConfigParser.cs" />
-        <Compile Include="Utils\Schema.cs" />
-        <Compile Include="Bucketing\UserProfileService.cs" />
-        <Compile Include="Bucketing\DecisionService.cs" />
-        <Compile Include="ProjectConfig.cs" />
-        <Compile Include="Config\DatafileProjectConfig.cs" />
-        <Compile Include="Config\ProjectConfigManager.cs" />
-        <Compile Include="Config\PollingProjectConfigManager.cs" />
-        <Compile Include="Config\HttpProjectConfigManager.cs" />
-        <Compile Include="Config\FallbackProjectConfigManager.cs" />
-        <Compile Include="OptimizelyFactory.cs" />
-        <Compile Include="Event\Entity\UserEvent.cs" />
-        <Compile Include="Event\Entity\ConversionEvent.cs" />
-        <Compile Include="Event\Entity\ImpressionEvent.cs" />
-        <Compile Include="Event\Entity\VisitorAttribute.cs" />
-        <Compile Include="Event\Entity\Visitor.cs" />
-        <Compile Include="Event\Entity\Decision.cs" />
-        <Compile Include="Event\Entity\Snapshot.cs" />
-        <Compile Include="Event\Entity\SnapshotEvent.cs" />
-        <Compile Include="Event\Entity\EventBatch.cs" />
-        <Compile Include="Event\Entity\EventContext.cs" />
-        <Compile Include="AudienceConditions\SemanticVersion.cs" />
-        <Compile Include="Entity\Result.cs" />
-        <Compile Include="Notifications\NotificationCenterRegistry.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <EmbeddedResource Include="Utils\schema.json" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="packages.config" />
-    </ItemGroup>
-    <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-         Other similar extension points exist, see Microsoft.Common.targets.
-    <Target Name="BeforeBuild">
-    </Target>
-    <Target Name="AfterBuild">
-    </Target>
-    -->
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4DDE7FAA-110D-441C-AB3B-3F31B593E8BF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>OptimizelySDK</RootNamespace>
+    <AssemblyName>OptimizelySDK</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile/>
+    <ReleaseVersion>1.2.1</ReleaseVersion>
+    <AssemblyOriginatorKeyFile>..\keypair.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+    <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
+  <PropertyGroup>
+    <DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v3.5'">NET35</DefineConstants>
+    <DefineConstants Condition=" '$(TargetFrameworkVersion)' == 'v4.0'">NET40</DefineConstants>
+    <!-- <DefineConstants Condition=" !$(DefineConstants.Contains(';NET')) ">$(DefineConstants);$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", ""))</DefineConstants> -->
+    <!-- <DefineConstants Condition=" $(DefineConstants.Contains(';NET')) ">$(DefineConstants.Remove($(DefineConstants.LastIndexOf(";NET"))));$(TargetFrameworkVersion.Replace("v", "NET").Replace(".", ""))</DefineConstants> -->
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CSharp"/>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="NJsonSchema, Version=8.30.6304.31883, Culture=neutral, PublicKeyToken=c2f9c3bdfae56102, processorArchitecture=MSIL">
+      <HintPath>..\packages\NJsonSchema.8.30.6304.31883\lib\net45\NJsonSchema.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System"/>
+    <Reference Include="System.Configuration"/>
+    <Reference Include="System.Core"/>
+    <Reference Include="System.Net.Http"/>
+    <Reference Include="System.Xml.Linq"/>
+    <Reference Include="System.Data.DataSetExtensions"/>
+    <Reference Include="System.Data"/>
+    <Reference Include="System.Xml"/>
+    <Reference Include="MurmurHash">
+      <HintPath>..\packages\murmurhash-signed.1.0.2\lib\net45\MurmurHash.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="AudienceConditions\AndCondition.cs"/>
+    <Compile Include="AudienceConditions\AudienceIdCondition.cs"/>
+    <Compile Include="AudienceConditions\EmptyCondition.cs"/>
+    <Compile Include="AudienceConditions\ICondition.cs"/>
+    <Compile Include="AudienceConditions\NotCondition.cs"/>
+    <Compile Include="AudienceConditions\OrCondition.cs"/>
+    <Compile Include="Bucketing\Bucketer.cs"/>
+    <Compile Include="Bucketing\Decision.cs"/>
+    <Compile Include="ClientConfigHandler.cs"/>
+    <Compile Include="Entity\Attribute.cs"/>
+    <Compile Include="Entity\Audience.cs"/>
+    <Compile Include="AudienceConditions\BaseCondition.cs"/>
+    <Compile Include="Entity\Entity.cs"/>
+    <Compile Include="Entity\Event.cs"/>
+    <Compile Include="Entity\EventTags.cs"/>
+    <Compile Include="Entity\Experiment.cs"/>
+    <Compile Include="Entity\FeatureDecision.cs"/>
+    <Compile Include="Entity\FeatureFlag.cs"/>
+    <Compile Include="Entity\FeatureVariable.cs"/>
+    <Compile Include="Entity\FeatureVariableUsage.cs"/>
+    <Compile Include="Entity\ForcedVariation.cs"/>
+    <Compile Include="Entity\Group.cs"/>
+    <Compile Include="Entity\IdKeyEntity.cs"/>
+    <Compile Include="Entity\Integration.cs"/>
+    <Compile Include="Event\Entity\DecisionMetadata.cs"/>
+    <Compile Include="Odp\Constants.cs"/>
+    <Compile Include="Odp\Entity\Audience.cs"/>
+    <Compile Include="Odp\Entity\Customer.cs"/>
+    <Compile Include="Odp\Entity\Data.cs"/>
+    <Compile Include="Odp\Entity\Edge.cs"/>
+    <Compile Include="Odp\Entity\Error.cs"/>
+    <Compile Include="Odp\Entity\Location.cs"/>
+    <Compile Include="Odp\Entity\Extension.cs"/>
+    <Compile Include="Odp\Entity\Node.cs"/>
+    <Compile Include="Odp\Entity\OdpEvent.cs"/>
+    <Compile Include="Odp\Entity\Response.cs"/>
+    <Compile Include="Odp\Enums.cs"/>
+    <Compile Include="Odp\IOdpManager.cs"/>
+    <Compile Include="Odp\IOdpSegmentManager.cs"/>
+    <Compile Include="Odp\OdpManager.cs"/>
+    <Compile Include="Odp\OdpSegmentApiManager.cs"/>
+    <Compile Include="Odp\IOdpSegmentApiManager.cs"/>
+    <Compile Include="Odp\ICache.cs"/>
+    <Compile Include="Odp\IOdpEventApiManager.cs"/>
+    <Compile Include="Odp\IOdpEventManager.cs"/>
+    <Compile Include="Odp\LruCache.cs"/>
+    <Compile Include="Odp\OdpConfig.cs"/>
+    <Compile Include="Odp\OdpEventManager.cs"/>
+    <Compile Include="Odp\OdpEventApiManager.cs"/>
+    <Compile Include="Odp\OdpSegmentManager.cs"/>
+    <Compile Include="OptimizelyDecisions\DecisionMessage.cs"/>
+    <Compile Include="OptimizelyDecisions\DecisionReasons.cs"/>
+    <Compile Include="OptimizelyDecisions\OptimizelyDecideOption.cs"/>
+    <Compile Include="OptimizelyDecisions\OptimizelyDecision.cs"/>
+    <Compile Include="OptimizelyForcedDecision.cs"/>
+    <Compile Include="ForcedDecisionsStore.cs"/>
+    <Compile Include="OptimizelyUserContext.cs"/>
+    <Compile Include="OptimizelyJSON.cs"/>
+    <Compile Include="Entity\Rollout.cs"/>
+    <Compile Include="Entity\TrafficAllocation.cs"/>
+    <Compile Include="Entity\UserAttributes.cs"/>
+    <Compile Include="Entity\Variation.cs"/>
+    <Compile Include="ErrorHandler\DefaultErrorHandler.cs"/>
+    <Compile Include="ErrorHandler\IErrorHandler.cs"/>
+    <Compile Include="ErrorHandler\NoOpErrorHandler.cs"/>
+    <Compile Include="Event\BatchEventProcessor.cs"/>
+    <Compile Include="Event\Builder\EventBuilder.cs"/>
+    <Compile Include="Event\Builder\Params.cs"/>
+    <Compile Include="Event\Dispatcher\DefaultEventDispatcher.cs"/>
+    <Compile Include="Event\Dispatcher\WebRequestEventDispatcher35.cs"/>
+    <Compile Include="Event\Dispatcher\HttpClientEventDispatcher45.cs"/>
+    <Compile Include="Event\Dispatcher\IEventDispatcher.cs"/>
+    <Compile Include="Event\EventFactory.cs"/>
+    <Compile Include="Event\EventProcessor.cs"/>
+    <Compile Include="Event\ForwardingEventProcessor.cs"/>
+    <Compile Include="Event\UserEventFactory.cs"/>
+    <Compile Include="Event\LogEvent.cs"/>
+    <Compile Include="Exceptions\OptimizelyException.cs"/>
+    <Compile Include="IOptimizely.cs"/>
+    <Compile Include="Logger\DefaultLogger.cs"/>
+    <Compile Include="Logger\ILogger.cs"/>
+    <Compile Include="Logger\NoOpLogger.cs"/>
+    <Compile Include="Notifications\NotificationCenter.cs"/>
+    <Compile Include="Optimizely.cs"/>
+    <Compile Include="Bucketing\UserProfile.cs"/>
+    <Compile Include="OptimizelyDecisionContext.cs"/>
+    <Compile Include="OptlyConfig\IOptimizelyConfigManager.cs"/>
+    <Compile Include="OptlyConfig\OptimizelyEvent.cs"/>
+    <Compile Include="OptlyConfig\OptimizelyAttribute.cs"/>
+    <Compile Include="OptlyConfig\OptimizelyAudience.cs"/>
+    <Compile Include="OptlyConfig\OptimizelyConfig.cs"/>
+    <Compile Include="OptlyConfig\OptimizelyConfigService.cs"/>
+    <Compile Include="OptlyConfig\OptimizelyExperiment.cs"/>
+    <Compile Include="OptlyConfig\OptimizelyFeature.cs"/>
+    <Compile Include="OptlyConfig\OptimizelyVariable.cs"/>
+    <Compile Include="OptlyConfig\OptimizelyVariation.cs"/>
+    <Compile Include="Utils\AttributeMatchTypes.cs"/>
+    <Compile Include="Utils\CollectionExtensions.cs"/>
+    <Compile Include="Utils\ConditionParser.cs"/>
+    <Compile Include="Utils\DecisionInfoTypes.cs"/>
+    <Compile Include="Utils\EventTagUtils.cs"/>
+    <Compile Include="Bucketing\UserProfileUtil.cs"/>
+    <Compile Include="Utils\ExperimentUtils.cs"/>
+    <Compile Include="Utils\ControlAttributes.cs"/>
+    <Compile Include="Utils\ExceptionExtensions.cs"/>
+    <Compile Include="Utils\DateTimeUtils.cs"/>
+    <Compile Include="Utils\Validator.cs"/>
+    <Compile Include="Properties\AssemblyInfo.cs"/>
+    <Compile Include="Utils\ConfigParser.cs"/>
+    <Compile Include="Utils\Schema.cs"/>
+    <Compile Include="Bucketing\UserProfileService.cs"/>
+    <Compile Include="Bucketing\DecisionService.cs"/>
+    <Compile Include="ProjectConfig.cs"/>
+    <Compile Include="Config\DatafileProjectConfig.cs"/>
+    <Compile Include="Config\ProjectConfigManager.cs"/>
+    <Compile Include="Config\PollingProjectConfigManager.cs"/>
+    <Compile Include="Config\HttpProjectConfigManager.cs"/>
+    <Compile Include="Config\FallbackProjectConfigManager.cs"/>
+    <Compile Include="OptimizelyFactory.cs"/>
+    <Compile Include="Event\Entity\UserEvent.cs"/>
+    <Compile Include="Event\Entity\ConversionEvent.cs"/>
+    <Compile Include="Event\Entity\ImpressionEvent.cs"/>
+    <Compile Include="Event\Entity\VisitorAttribute.cs"/>
+    <Compile Include="Event\Entity\Visitor.cs"/>
+    <Compile Include="Event\Entity\Decision.cs"/>
+    <Compile Include="Event\Entity\Snapshot.cs"/>
+    <Compile Include="Event\Entity\SnapshotEvent.cs"/>
+    <Compile Include="Event\Entity\EventBatch.cs"/>
+    <Compile Include="Event\Entity\EventContext.cs"/>
+    <Compile Include="AudienceConditions\SemanticVersion.cs"/>
+    <Compile Include="Entity\Result.cs"/>
+    <Compile Include="Notifications\NotificationCenterRegistry.cs"/>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Utils\schema.json"/>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config"/>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets"/>
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
 </Project>

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -63,16 +63,13 @@ namespace OptimizelySDK
 
         public OptimizelyUserContext(Optimizely optimizely, string userId,
             UserAttributes userAttributes, IErrorHandler errorHandler, ILogger logger
-        ) : this(optimizely, userId, userAttributes, null, null, errorHandler, logger)
-        {
-        }
+        ) : this(optimizely, userId, userAttributes, null, null, errorHandler, logger) { }
 
         public OptimizelyUserContext(Optimizely optimizely, string userId,
             UserAttributes userAttributes, ForcedDecisionsStore forcedDecisionsStore,
             IErrorHandler errorHandler, ILogger logger
-        ) : this(optimizely, userId, userAttributes, forcedDecisionsStore, null, errorHandler, logger)
-        {
-        }
+        ) : this(optimizely, userId, userAttributes, forcedDecisionsStore, null, errorHandler,
+            logger) { }
 
         public OptimizelyUserContext(Optimizely optimizely, string userId,
             UserAttributes userAttributes, ForcedDecisionsStore forcedDecisionsStore,

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -69,7 +69,8 @@ namespace OptimizelySDK
             UserAttributes userAttributes, ForcedDecisionsStore forcedDecisionsStore,
             IErrorHandler errorHandler, ILogger logger
         ) : this(optimizely, userId, userAttributes, forcedDecisionsStore, null, errorHandler,
-            logger) { }
+            logger)
+        { }
 
         public OptimizelyUserContext(Optimizely optimizely, string userId,
             UserAttributes userAttributes, ForcedDecisionsStore forcedDecisionsStore,

--- a/OptimizelySDK/OptlyConfig/OptimizelyAttribute.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyAttribute.cs
@@ -18,7 +18,5 @@ using OptimizelySDK.Entity;
 
 namespace OptimizelySDK.OptlyConfig
 {
-    public class OptimizelyAttribute : IdKeyEntity
-    {
-    }
+    public class OptimizelyAttribute : IdKeyEntity { }
 }

--- a/OptimizelySDK/OptlyConfig/OptimizelyConfig.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyConfig.cs
@@ -39,7 +39,10 @@ namespace OptimizelySDK.OptlyConfig
 
         private string _datafile;
 
-        public OptimizelyConfig(string revision, IDictionary<string, OptimizelyExperiment> experimentsMap, IDictionary<string, OptimizelyFeature> featuresMap, string datafile = null)
+        public OptimizelyConfig(string revision,
+            IDictionary<string, OptimizelyExperiment> experimentsMap,
+            IDictionary<string, OptimizelyFeature> featuresMap, string datafile = null
+        )
         {
             Revision = revision;
             ExperimentsMap = experimentsMap;
@@ -47,7 +50,11 @@ namespace OptimizelySDK.OptlyConfig
             _datafile = datafile;
         }
 
-        public OptimizelyConfig(string revision, string sdkKey, string environmentKey, OptimizelyAttribute[] attributes, OptimizelyAudience[] audiences, OptimizelyEvent[] events, IDictionary<string, OptimizelyExperiment> experimentsMap, IDictionary<string, OptimizelyFeature> featuresMap, string datafile = null)
+        public OptimizelyConfig(string revision, string sdkKey, string environmentKey,
+            OptimizelyAttribute[] attributes, OptimizelyAudience[] audiences,
+            OptimizelyEvent[] events, IDictionary<string, OptimizelyExperiment> experimentsMap,
+            IDictionary<string, OptimizelyFeature> featuresMap, string datafile = null
+        )
         {
             Revision = revision;
             SDKKey = sdkKey;

--- a/OptimizelySDK/OptlyConfig/OptimizelyConfigService.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyConfigService.cs
@@ -15,8 +15,8 @@
  */
 
 using System;
-using System.Collections.Generic;
 using System.Collections;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;

--- a/OptimizelySDK/OptlyConfig/OptimizelyConfigService.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyConfigService.cs
@@ -37,6 +37,7 @@ namespace OptimizelySDK.OptlyConfig
             {
                 return;
             }
+
             featureIdVariablesMap = GetFeatureVariablesByIdMap(projectConfig);
             var attributes = GetAttributes(projectConfig);
             var audiences = GetAudiences(projectConfig);
@@ -68,18 +69,22 @@ namespace OptimizelySDK.OptlyConfig
                 optimizelyEvent.ExperimentIds = ev.ExperimentIds;
                 optimizelyEvents.Add(optimizelyEvent);
             }
+
             return optimizelyEvents.ToArray();
         }
 
         private OptimizelyAudience[] GetAudiences(ProjectConfig projectConfig)
         {
-            var typedAudiences = projectConfig.TypedAudiences?.Select(aud => new OptimizelyAudience(aud.Id,
-                aud.Name,
-                JsonConvert.SerializeObject(aud.Conditions)));
+            var typedAudiences = projectConfig.TypedAudiences?.Select(aud =>
+                new OptimizelyAudience(aud.Id,
+                    aud.Name,
+                    JsonConvert.SerializeObject(aud.Conditions)));
             var typedAudienceIds = typedAudiences.Select(ta => ta.Id).ToList();
-            var filteredAudiencesArr = Array.FindAll(projectConfig.Audiences, aud => !aud.Id.Equals("$opt_dummy_audience")
+            var filteredAudiencesArr = Array.FindAll(projectConfig.Audiences, aud =>
+                !aud.Id.Equals("$opt_dummy_audience")
                 && !typedAudienceIds.Contains(aud.Id));
-            var optimizelyAudience = filteredAudiencesArr.Select(aud => new OptimizelyAudience(aud.Id, aud.Name, aud.Conditions));
+            var optimizelyAudience = filteredAudiencesArr.Select(aud =>
+                new OptimizelyAudience(aud.Id, aud.Name, aud.Conditions));
 
             optimizelyAudience = optimizelyAudience.Concat(typedAudiences).OrderBy(aud => aud.Name);
 
@@ -96,6 +101,7 @@ namespace OptimizelySDK.OptlyConfig
                 attribute.Key = attr.Key;
                 attributes.Add(attribute);
             }
+
             return attributes.ToArray();
         }
 
@@ -104,8 +110,9 @@ namespace OptimizelySDK.OptlyConfig
         /// </summary>
         /// <param name="experimentsMapById"></param>
         /// <returns>Map of experiment key.</returns>
-
-        private IDictionary<string, OptimizelyExperiment> GetExperimentsKeyMap(IDictionary<string, OptimizelyExperiment> experimentsMapById)
+        private IDictionary<string, OptimizelyExperiment> GetExperimentsKeyMap(
+            IDictionary<string, OptimizelyExperiment> experimentsMapById
+        )
         {
             var experimentKeyMaps = new Dictionary<string, OptimizelyExperiment>();
 
@@ -113,6 +120,7 @@ namespace OptimizelySDK.OptlyConfig
             {
                 experimentKeyMaps[experiment.Key] = experiment;
             }
+
             return experimentKeyMaps;
         }
 
@@ -121,17 +129,23 @@ namespace OptimizelySDK.OptlyConfig
         /// </summary>
         /// <param name="projectConfig">The project config</param>
         /// <returns>Dictionary | Dictionary of experiment key and value as experiment object</returns>
-        private IDictionary<string, OptimizelyExperiment> GetExperimentsMapById(ProjectConfig projectConfig)
+        private IDictionary<string, OptimizelyExperiment> GetExperimentsMapById(
+            ProjectConfig projectConfig
+        )
         {
             var experimentsMap = new Dictionary<string, OptimizelyExperiment>();
             var featureVariableIdMap = GetVariableIdMap(projectConfig);
             var experiments = projectConfig?.Experiments?.ToList();
-            experiments = projectConfig?.Groups?.SelectMany(g => g.Experiments).Concat(experiments)?.ToList();
+            experiments = projectConfig?.Groups?.SelectMany(g => g.Experiments).
+                Concat(experiments)?.
+                ToList();
 
-            foreach (Experiment experiment in experiments)
+            foreach (var experiment in experiments)
             {
-                var featureId = projectConfig.GetExperimentFeatureList(experiment.Id)?.FirstOrDefault();
-                var variationsMap = GetVariationsMap(experiment.Variations, featureVariableIdMap, featureId);
+                var featureId = projectConfig.GetExperimentFeatureList(experiment.Id)?.
+                    FirstOrDefault();
+                var variationsMap = GetVariationsMap(experiment.Variations, featureVariableIdMap,
+                    featureId);
                 var experimentAudience = GetExperimentAudiences(experiment, projectConfig);
                 var optimizelyExperiment = new OptimizelyExperiment(experiment.Id,
                     experiment.Key,
@@ -151,12 +165,14 @@ namespace OptimizelySDK.OptlyConfig
         /// <param name="featureVariableIdMap">The map of feature variables and id</param>
         /// <param name="featureId">feature Id of the feature</param>
         /// <returns>Dictionary | Dictionary of experiment key and value as experiment object</returns>
-        private IDictionary<string, OptimizelyVariation> GetVariationsMap(IEnumerable<Variation> variations,
+        private IDictionary<string, OptimizelyVariation> GetVariationsMap(
+            IEnumerable<Variation> variations,
             IDictionary<string, FeatureVariable> featureVariableIdMap,
-            string featureId)
+            string featureId
+        )
         {
             var variationsMap = new Dictionary<string, OptimizelyVariation>();
-            foreach (Variation variation in variations)
+            foreach (var variation in variations)
             {
                 var variablesMap = MergeFeatureVariables(
                     featureVariableIdMap,
@@ -184,20 +200,23 @@ namespace OptimizelySDK.OptlyConfig
         /// <param name="isFeatureEnabled">isFeatureEnabled of variation</param>
         /// <returns>Dictionary | Dictionary of FeatureVariable key and value as FeatureVariable object</returns>
         private IDictionary<string, OptimizelyVariable> MergeFeatureVariables(
-           IDictionary<string, FeatureVariable> variableIdMap,
-           string featureId,
-           IEnumerable<FeatureVariableUsage> featureVariableUsages,
-           bool isFeatureEnabled)
+            IDictionary<string, FeatureVariable> variableIdMap,
+            string featureId,
+            IEnumerable<FeatureVariableUsage> featureVariableUsages,
+            bool isFeatureEnabled
+        )
         {
             var variablesMap = new Dictionary<string, OptimizelyVariable>();
 
             if (!string.IsNullOrEmpty(featureId))
             {
-                variablesMap = featureIdVariablesMap[featureId]?.Select(f => new OptimizelyVariable(f.Id,
+                variablesMap = featureIdVariablesMap[featureId]?.
+                    Select(f => new OptimizelyVariable(f.Id,
                         f.Key,
                         f.Type.ToString().ToLower(),
                         f.DefaultValue)
-                ).ToDictionary(k => k.Key, v => v);
+                    ).
+                    ToDictionary(k => k.Key, v => v);
 
                 foreach (var featureVariableUsage in featureVariableUsages)
                 {
@@ -205,7 +224,9 @@ namespace OptimizelySDK.OptlyConfig
                     var optimizelyVariable = new OptimizelyVariable(featureVariableUsage.Id,
                         defaultVariable.Key,
                         defaultVariable.Type.ToString().ToLower(),
-                        isFeatureEnabled ? featureVariableUsage.Value : defaultVariable.DefaultValue);
+                        isFeatureEnabled ?
+                            featureVariableUsage.Value :
+                            defaultVariable.DefaultValue);
 
                     variablesMap[defaultVariable.Key] = optimizelyVariable;
                 }
@@ -220,19 +241,29 @@ namespace OptimizelySDK.OptlyConfig
         /// <param name="projectConfig">The project config</param>
         /// <param name="experimentsMapById">Dictionary of experiment Id as key and value as experiment object</param>
         /// <returns>Dictionary | Dictionary of FeatureFlag key and value as OptimizelyFeature object</returns>
-        private IDictionary<string, OptimizelyFeature> GetFeaturesMap(ProjectConfig projectConfig, IDictionary<string, OptimizelyExperiment> experimentsMapById)
+        private IDictionary<string, OptimizelyFeature> GetFeaturesMap(ProjectConfig projectConfig,
+            IDictionary<string, OptimizelyExperiment> experimentsMapById
+        )
         {
             var FeaturesMap = new Dictionary<string, OptimizelyFeature>();
 
             foreach (var featureFlag in projectConfig.FeatureFlags)
             {
-                var experimentRules = featureFlag.ExperimentIds.Select(experimentId => experimentsMapById[experimentId]).ToList();
+                var experimentRules = featureFlag.ExperimentIds.
+                    Select(experimentId => experimentsMapById[experimentId]).
+                    ToList();
 
-                var featureVariableMap = featureFlag.Variables.Select(v => (OptimizelyVariable)v).ToDictionary(k => k.Key, v => v) ?? new Dictionary<string, OptimizelyVariable>();
+                var featureVariableMap =
+                    featureFlag.Variables.Select(v => (OptimizelyVariable)v).
+                        ToDictionary(k => k.Key, v => v) ??
+                    new Dictionary<string, OptimizelyVariable>();
 
-                var featureExperimentMap = experimentRules.ToDictionary(experiment => experiment.Key, experiment => experiment);
+                var featureExperimentMap =
+                    experimentRules.ToDictionary(experiment => experiment.Key,
+                        experiment => experiment);
                 var rollout = projectConfig.GetRolloutFromId(featureFlag.RolloutId);
-                var deliveryRules = GetDeliveryRules(featureFlag.Id, rollout.Experiments, projectConfig);
+                var deliveryRules =
+                    GetDeliveryRules(featureFlag.Id, rollout.Experiments, projectConfig);
 
                 var optimizelyFeature = new OptimizelyFeature(featureFlag.Id,
                     featureFlag.Key,
@@ -254,9 +285,12 @@ namespace OptimizelySDK.OptlyConfig
         /// </summary>
         /// <param name="projectConfig">The project config</param>
         /// <returns>Dictionary | Dictionary of FeatureFlag key and value as list of all FeatureVariable inside it</returns>
-        private IDictionary<string, List<FeatureVariable>> GetFeatureVariablesByIdMap(ProjectConfig projectConfig)
+        private IDictionary<string, List<FeatureVariable>> GetFeatureVariablesByIdMap(
+            ProjectConfig projectConfig
+        )
         {
-            var featureIdVariablesMap = projectConfig?.FeatureFlags?.ToDictionary(k => k.Id, v => v.Variables);
+            var featureIdVariablesMap =
+                projectConfig?.FeatureFlags?.ToDictionary(k => k.Id, v => v.Variables);
 
             return featureIdVariablesMap ?? new Dictionary<string, List<FeatureVariable>>();
         }
@@ -273,7 +307,9 @@ namespace OptimizelySDK.OptlyConfig
             {
                 return "";
             }
-            var s = JsonConvert.DeserializeObject<List<object>>(experiment.AudienceConditionsString);
+
+            var s = JsonConvert.DeserializeObject<List<object>>(experiment.
+                AudienceConditionsString);
             return GetSerializedAudiences(s, projectConfig.AudienceIdMap);
         }
 
@@ -294,50 +330,63 @@ namespace OptimizelySDK.OptlyConfig
         /// <param name="audienceConditions">List of audience conditions in experiment</param>
         /// <param name="audienceIdMap">The audience Id map</param>
         /// <returns>string | Serialized audience in which IDs are replaced with audience name.</returns>
-        private string GetSerializedAudiences(List<object> audienceConditions, Dictionary<string, Audience> audienceIdMap)
+        private string GetSerializedAudiences(List<object> audienceConditions,
+            Dictionary<string, Audience> audienceIdMap
+        )
         {
-            StringBuilder sAudience = new StringBuilder("");
+            var sAudience = new StringBuilder("");
 
             if (audienceConditions != null)
             {
-                string cond = "";
+                var cond = "";
                 foreach (var item in audienceConditions)
                 {
                     var subAudience = "";
                     // Checks if item is list of conditions means if it is sub audience
                     if (item is JArray)
                     {
-                        subAudience = GetSerializedAudiences(((JArray)item).ToObject<List<object>>(), audienceIdMap);
+                        subAudience =
+                            GetSerializedAudiences(((JArray)item).ToObject<List<object>>(),
+                                audienceIdMap);
                         subAudience = "(" + subAudience + ")";
                     }
-                    else if (AUDIENCE_CONDITIONS.Contains(item.ToString())) // Checks if item is an audience condition
+                    else if
+                        (AUDIENCE_CONDITIONS.
+                         Contains(item.ToString())) // Checks if item is an audience condition
                     {
                         cond = item.ToString().ToUpper();
                     }
                     else
-                    {   // Checks if item is audience id
+                    {
+                        // Checks if item is audience id
                         var itemStr = item.ToString();
-                        var audienceName = audienceIdMap.ContainsKey(itemStr) ? audienceIdMap[itemStr].Name : itemStr;
+                        var audienceName = audienceIdMap.ContainsKey(itemStr) ?
+                            audienceIdMap[itemStr].Name :
+                            itemStr;
                         // if audience condition is "NOT" then add "NOT" at start. Otherwise check if there is already audience id in sAudience then append condition between saudience and item
                         if (!string.IsNullOrEmpty(sAudience.ToString()) || cond.Equals("NOT"))
                         {
                             cond = string.IsNullOrEmpty(cond) ? "OR" : cond;
-                            sAudience = string.IsNullOrEmpty(sAudience.ToString()) ? new StringBuilder(cond + " \"" + audienceIdMap[itemStr]?.Name + "\"") :
-                                        sAudience.Append(" " + cond + " \"" + audienceName + "\"");
+                            sAudience = string.IsNullOrEmpty(sAudience.ToString()) ?
+                                new StringBuilder(
+                                    cond + " \"" + audienceIdMap[itemStr]?.Name + "\"") :
+                                sAudience.Append(" " + cond + " \"" + audienceName + "\"");
                         }
                         else
                         {
                             sAudience = new StringBuilder("\"" + audienceName + "\"");
                         }
                     }
+
                     // Checks if sub audience is empty or not
                     if (!string.IsNullOrEmpty(subAudience))
                     {
                         if (!string.IsNullOrEmpty(sAudience.ToString()) || cond == "NOT")
                         {
                             cond = string.IsNullOrEmpty(cond) ? "OR" : cond;
-                            sAudience = string.IsNullOrEmpty(sAudience.ToString()) ? new StringBuilder(cond + " " + subAudience) :
-                                    sAudience.Append(" " + cond + " " + subAudience);
+                            sAudience = string.IsNullOrEmpty(sAudience.ToString()) ?
+                                new StringBuilder(cond + " " + subAudience) :
+                                sAudience.Append(" " + cond + " " + subAudience);
                         }
                         else
                         {
@@ -346,6 +395,7 @@ namespace OptimizelySDK.OptlyConfig
                     }
                 }
             }
+
             return sAudience.ToString();
         }
 
@@ -356,8 +406,10 @@ namespace OptimizelySDK.OptlyConfig
         /// <param name="experiments">Experiments</param>
         /// <param name="projectConfig">Project Config</param>
         /// <returns>List | List of Optimizely rollout experiments.</returns>
-        private List<OptimizelyExperiment> GetDeliveryRules(string featureId, IEnumerable<Experiment> experiments,
-            ProjectConfig projectConfig)
+        private List<OptimizelyExperiment> GetDeliveryRules(string featureId,
+            IEnumerable<Experiment> experiments,
+            ProjectConfig projectConfig
+        )
         {
             if (experiments == null)
             {
@@ -371,11 +423,11 @@ namespace OptimizelySDK.OptlyConfig
             foreach (var experiment in experiments)
             {
                 var optimizelyExperiment = new OptimizelyExperiment(
-                        id: experiment.Id,
-                        key: experiment.Key,
-                        audiences: GetExperimentAudiences(experiment, projectConfig),
-                        variationsMap: GetVariationsMap(experiment.Variations, featureVariableIdMap, featureId)
-                    );
+                    experiment.Id,
+                    experiment.Key,
+                    GetExperimentAudiences(experiment, projectConfig),
+                    GetVariationsMap(experiment.Variations, featureVariableIdMap, featureId)
+                );
                 deliveryRules.Add(optimizelyExperiment);
             }
 
@@ -389,7 +441,8 @@ namespace OptimizelySDK.OptlyConfig
         /// <returns>Dictionary | Dictionary of FeatureVariableId as key and value as object of FeatureVariable</returns>
         private IDictionary<string, FeatureVariable> GetVariableIdMap(ProjectConfig projectConfig)
         {
-            var featureVariablesIdMap = projectConfig?.FeatureFlags?.SelectMany(f => f.Variables).ToDictionary(k => k.Id, v => v);
+            var featureVariablesIdMap = projectConfig?.FeatureFlags?.SelectMany(f => f.Variables).
+                ToDictionary(k => k.Id, v => v);
 
             return featureVariablesIdMap ?? new Dictionary<string, FeatureVariable>();
         }

--- a/OptimizelySDK/OptlyConfig/OptimizelyExperiment.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyExperiment.cs
@@ -20,11 +20,12 @@ namespace OptimizelySDK.OptlyConfig
 {
     public class OptimizelyExperiment : Entity.IdKeyEntity
     {
-        
         public IDictionary<string, OptimizelyVariation> VariationsMap { get; private set; }
         public string Audiences { get; private set; }
 
-        public OptimizelyExperiment(string id, string key, string audiences, IDictionary<string, OptimizelyVariation> variationsMap)
+        public OptimizelyExperiment(string id, string key, string audiences,
+            IDictionary<string, OptimizelyVariation> variationsMap
+        )
         {
             Id = id;
             Key = key;

--- a/OptimizelySDK/OptlyConfig/OptimizelyFeature.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyFeature.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 using System.Collections.Generic;
 
@@ -20,15 +21,19 @@ namespace OptimizelySDK.OptlyConfig
 {
     public class OptimizelyFeature : Entity.IdKeyEntity
     {
-        
         public List<OptimizelyExperiment> ExperimentRules { get; private set; }
         public List<OptimizelyExperiment> DeliveryRules { get; private set; }
 
         [Obsolete("Use experimentRules and deliveryRules.")]
         public IDictionary<string, OptimizelyExperiment> ExperimentsMap { get; private set; }
+
         public IDictionary<string, OptimizelyVariable> VariablesMap { get; private set; }
 
-        public OptimizelyFeature(string id, string key, List<OptimizelyExperiment> experimentRules, List<OptimizelyExperiment> deliveryRules, IDictionary<string, OptimizelyExperiment> experimentsMap, IDictionary<string, OptimizelyVariable> variablesMap)
+        public OptimizelyFeature(string id, string key, List<OptimizelyExperiment> experimentRules,
+            List<OptimizelyExperiment> deliveryRules,
+            IDictionary<string, OptimizelyExperiment> experimentsMap,
+            IDictionary<string, OptimizelyVariable> variablesMap
+        )
         {
             Id = id;
             Key = key;

--- a/OptimizelySDK/OptlyConfig/OptimizelyFeature.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyFeature.cs
@@ -29,6 +29,7 @@ namespace OptimizelySDK.OptlyConfig
 
         public IDictionary<string, OptimizelyVariable> VariablesMap { get; private set; }
 
+        [Obsolete]
         public OptimizelyFeature(string id, string key, List<OptimizelyExperiment> experimentRules,
             List<OptimizelyExperiment> deliveryRules,
             IDictionary<string, OptimizelyExperiment> experimentsMap,

--- a/OptimizelySDK/OptlyConfig/OptimizelyVariable.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyVariable.cs
@@ -18,7 +18,7 @@ using OptimizelySDK.Entity;
 
 namespace OptimizelySDK.OptlyConfig
 {
-    public class OptimizelyVariable : Entity.IdKeyEntity
+    public class OptimizelyVariable : IdKeyEntity
     {
         public string Type { get; private set; }
         public string Value { get; private set; }
@@ -31,7 +31,9 @@ namespace OptimizelySDK.OptlyConfig
             Value = value;
         }
 
-        public OptimizelyVariable(FeatureVariable featureVariable, FeatureVariableUsage featureVariableUsage)
+        public OptimizelyVariable(FeatureVariable featureVariable,
+            FeatureVariableUsage featureVariableUsage
+        )
         {
             Id = featureVariable.Id;
             Key = featureVariable.Key;
@@ -42,7 +44,7 @@ namespace OptimizelySDK.OptlyConfig
 
         public static explicit operator OptimizelyVariable(FeatureVariable featureVariable)
         {
-            return new OptimizelyVariable(featureVariable, null);            
+            return new OptimizelyVariable(featureVariable, null);
         }
     }
 }

--- a/OptimizelySDK/OptlyConfig/OptimizelyVariation.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyVariation.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using Newtonsoft.Json;
 using System.Collections.Generic;
+using Newtonsoft.Json;
 
 namespace OptimizelySDK.OptlyConfig
 {

--- a/OptimizelySDK/OptlyConfig/OptimizelyVariation.cs
+++ b/OptimizelySDK/OptlyConfig/OptimizelyVariation.cs
@@ -23,9 +23,12 @@ namespace OptimizelySDK.OptlyConfig
     {
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
         public bool? FeatureEnabled { get; private set; }
+
         public IDictionary<string, OptimizelyVariable> VariablesMap { get; private set; }
 
-        public OptimizelyVariation(string id, string key, bool? featureEnabled, IDictionary<string, OptimizelyVariable> variablesMap)
+        public OptimizelyVariation(string id, string key, bool? featureEnabled,
+            IDictionary<string, OptimizelyVariable> variablesMap
+        )
         {
             Id = id;
             Key = key;

--- a/OptimizelySDK/ProjectConfig.cs
+++ b/OptimizelySDK/ProjectConfig.cs
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Entity;
 using System.Collections.Generic;
+using OptimizelySDK.Entity;
 
 namespace OptimizelySDK
 {

--- a/OptimizelySDK/Utils/CollectionExtensions.cs
+++ b/OptimizelySDK/Utils/CollectionExtensions.cs
@@ -46,7 +46,7 @@ namespace OptimizelySDK.Utils
                 return left;
             }
 
-            foreach (KeyValuePair<TKey, TValue> kvp in right.Where(
+            foreach (var kvp in right.Where(
                          kvp => !left.ContainsKey(kvp.Key)))
             {
                 left.Add(kvp.Key, kvp.Value);

--- a/OptimizelySDK/Utils/ConditionParser.cs
+++ b/OptimizelySDK/Utils/ConditionParser.cs
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
+using System.Collections.Generic;
 using Newtonsoft.Json.Linq;
 using OptimizelySDK.AudienceConditions;
-using System.Collections.Generic;
 
 namespace OptimizelySDK.Utils
 {
@@ -137,7 +137,7 @@ namespace OptimizelySDK.Utils
                     break;
                 case NOT_OPERATOR:
                     condition = new NotCondition()
-                        { Condition = conditions.Count == 0 ? null : conditions[0] };
+                    { Condition = conditions.Count == 0 ? null : conditions[0] };
                     break;
                 default:
                     break;

--- a/OptimizelySDK/Utils/ConditionParser.cs
+++ b/OptimizelySDK/Utils/ConditionParser.cs
@@ -28,38 +28,48 @@ namespace OptimizelySDK.Utils
         /// <summary>
         /// const string Representing AND operator.
         /// </summary>
-        const string AND_OPERATOR = "and";
+        private const string AND_OPERATOR = "and";
 
         /// <summary>
         /// const string Representing OR operator.
         /// </summary>
-        const string OR_OPERATOR = "or";
+        private const string OR_OPERATOR = "or";
 
         /// <summary>
         /// const string Representing NOT operator.
         /// </summary>
-        const string NOT_OPERATOR = "not";
+        private const string NOT_OPERATOR = "not";
 
         public static ICondition ParseAudienceConditions(JToken audienceConditions)
         {
             if (audienceConditions.Type != JTokenType.Array)
+            {
                 return new AudienceIdCondition { AudienceId = (string)audienceConditions };
+            }
 
             var conditionsArray = audienceConditions as JArray;
             if (conditionsArray.Count == 0)
+            {
                 return new EmptyCondition();
+            }
 
             var startIndex = 0;
             var conditionOperator = GetOperator(conditionsArray.First.ToString());
 
             if (conditionOperator != null)
+            {
                 startIndex = 1;
+            }
             else
+            {
                 conditionOperator = OR_OPERATOR;
+            }
 
-            List<ICondition> conditions = new List<ICondition>();
-            for (int i = startIndex; i < conditionsArray.Count; ++i)
+            var conditions = new List<ICondition>();
+            for (var i = startIndex; i < conditionsArray.Count; ++i)
+            {
                 conditions.Add(ParseAudienceConditions(conditionsArray[i]));
+            }
 
             return GetConditions(conditions, conditionOperator);
         }
@@ -67,6 +77,7 @@ namespace OptimizelySDK.Utils
         public static ICondition ParseConditions(JToken conditionObj)
         {
             if (conditionObj.Type != JTokenType.Array)
+            {
                 return new BaseCondition
                 {
                     Match = conditionObj["match"]?.ToString(),
@@ -74,18 +85,23 @@ namespace OptimizelySDK.Utils
                     Name = conditionObj["name"].ToString(),
                     Value = conditionObj["value"]?.ToObject<object>(),
                 };
+            }
 
             var startIndex = 0;
             var conditionsArray = conditionObj as JArray;
             var conditionOperator = GetOperator(conditionsArray.First.ToString());
 
             if (conditionOperator != null)
+            {
                 startIndex = 1;
+            }
             else
+            {
                 conditionOperator = OR_OPERATOR;
+            }
 
-            List<ICondition> conditions = new List<ICondition>();
-            for (int i = startIndex; i < conditionsArray.Count; ++i)
+            var conditions = new List<ICondition>();
+            for (var i = startIndex; i < conditionsArray.Count; ++i)
             {
                 conditions.Add(ParseConditions(conditionsArray[i]));
             }
@@ -95,7 +111,7 @@ namespace OptimizelySDK.Utils
 
         public static string GetOperator(object condition)
         {
-            string conditionOperator = (string)condition;
+            var conditionOperator = (string)condition;
             switch (conditionOperator)
             {
                 case OR_OPERATOR:
@@ -107,7 +123,8 @@ namespace OptimizelySDK.Utils
             }
         }
 
-        public static ICondition GetConditions(List<ICondition> conditions, string conditionOperator)
+        public static ICondition GetConditions(List<ICondition> conditions, string conditionOperator
+        )
         {
             ICondition condition = null;
             switch (conditionOperator)
@@ -119,7 +136,8 @@ namespace OptimizelySDK.Utils
                     condition = new OrCondition() { Conditions = conditions.ToArray() };
                     break;
                 case NOT_OPERATOR:
-                    condition = new NotCondition() { Condition = conditions.Count == 0 ? null : conditions[0] };
+                    condition = new NotCondition()
+                        { Condition = conditions.Count == 0 ? null : conditions[0] };
                     break;
                 default:
                     break;

--- a/OptimizelySDK/Utils/ConfigParser.cs
+++ b/OptimizelySDK/Utils/ConfigParser.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,7 +29,9 @@ namespace OptimizelySDK.Utils
         /// <param name="getKey">A function to return the key value from the entity</param>
         /// <param name="clone">Whether or not to clone the original entity</param>
         /// <returns>associative array of key => entity</returns>
-        public static Dictionary<string, T> GenerateMap(IEnumerable<T> entities, Func<T, string> getKey, bool clone)
+        public static Dictionary<string, T> GenerateMap(IEnumerable<T> entities,
+            Func<T, string> getKey, bool clone
+        )
         {
             return entities.ToDictionary(e => getKey(e), e => clone ? (T)e.Clone() : e);
         }

--- a/OptimizelySDK/Utils/ControlAttributes.cs
+++ b/OptimizelySDK/Utils/ControlAttributes.cs
@@ -19,7 +19,7 @@ namespace OptimizelySDK.Utils
     public class ControlAttributes
     {
         public const string BOT_FILTERING_ATTRIBUTE = "$opt_bot_filtering";
-        public const string BUCKETING_ID_ATTRIBUTE  = "$opt_bucketing_id";
-        public const string USER_AGENT_ATTRIBUTE    = "$opt_user_agent";
+        public const string BUCKETING_ID_ATTRIBUTE = "$opt_bucketing_id";
+        public const string USER_AGENT_ATTRIBUTE = "$opt_user_agent";
     }
 }

--- a/OptimizelySDK/Utils/DateTimeUtils.cs
+++ b/OptimizelySDK/Utils/DateTimeUtils.cs
@@ -7,13 +7,8 @@ namespace OptimizelySDK.Utils
         /// <summary>
         /// Helper to compute Unix time (i.e. since Jan 1, 1970)
         /// </summary>
-        public static long SecondsSince1970
-        {
-            get
-            {
-                return (long)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds;
-            }
-        }
+        public static long SecondsSince1970 =>
+            (long)(DateTime.UtcNow - new DateTime(1970, 1, 1)).TotalSeconds;
 
         public static long MillisecondsSince1970(this DateTime dateTime)
         {

--- a/OptimizelySDK/Utils/EventTagUtils.cs
+++ b/OptimizelySDK/Utils/EventTagUtils.cs
@@ -26,10 +26,10 @@ namespace OptimizelySDK.Utils
 
         public static object GetRevenueValue(Dictionary<string, object> eventTags, ILogger logger)
         {
-            int result = 0;
-            bool isCasted = false;
-            string logMessage = string.Empty;
-            LogLevel logLevel = LogLevel.INFO;
+            var result = 0;
+            var isCasted = false;
+            var logMessage = string.Empty;
+            var logLevel = LogLevel.INFO;
 
             if (eventTags == null)
             {
@@ -58,20 +58,26 @@ namespace OptimizelySDK.Utils
             }
 
             if (logger != null)
+            {
                 logger.Log(logLevel, logMessage);
+            }
 
             if (isCasted)
+            {
                 return result;
+            }
 
             return null;
         }
 
-        public static object GetNumericValue(Dictionary<string, object> eventTags, ILogger logger  = null)
+        public static object GetNumericValue(Dictionary<string, object> eventTags,
+            ILogger logger = null
+        )
         {
             float refVar = 0;
-            bool isCasted = false;
-            string logMessage = string.Empty;
-            LogLevel logLevel = LogLevel.INFO;
+            var isCasted = false;
+            var logMessage = string.Empty;
+            var logLevel = LogLevel.INFO;
 
             if (eventTags == null)
             {
@@ -92,10 +98,16 @@ namespace OptimizelySDK.Utils
             {
                 logMessage = "Provided numeric value is boolean which is an invalid format.";
                 logLevel = LogLevel.ERROR;
-            } else if (!(eventTags[VALUE_EVENT_METRIC_NAME] is int) && !(eventTags[VALUE_EVENT_METRIC_NAME] is string) && !(eventTags[VALUE_EVENT_METRIC_NAME] is float)
-                && !(eventTags[VALUE_EVENT_METRIC_NAME] is decimal) && !(eventTags[VALUE_EVENT_METRIC_NAME] is double) && !(eventTags[VALUE_EVENT_METRIC_NAME] is long)
-                && !(eventTags[VALUE_EVENT_METRIC_NAME] is short) && !(eventTags[VALUE_EVENT_METRIC_NAME] is uint))
-              {
+            }
+            else if (!(eventTags[VALUE_EVENT_METRIC_NAME] is int) &&
+                     !(eventTags[VALUE_EVENT_METRIC_NAME] is string) &&
+                     !(eventTags[VALUE_EVENT_METRIC_NAME] is float)
+                     && !(eventTags[VALUE_EVENT_METRIC_NAME] is decimal) &&
+                     !(eventTags[VALUE_EVENT_METRIC_NAME] is double) &&
+                     !(eventTags[VALUE_EVENT_METRIC_NAME] is long)
+                     && !(eventTags[VALUE_EVENT_METRIC_NAME] is short) &&
+                     !(eventTags[VALUE_EVENT_METRIC_NAME] is uint))
+            {
                 logMessage = "Numeric metric value is not in integer, float, or string form.";
                 logLevel = LogLevel.ERROR;
             }
@@ -108,14 +120,16 @@ namespace OptimizelySDK.Utils
             {
                 if (!float.TryParse(eventTags[VALUE_EVENT_METRIC_NAME].ToString(), out refVar))
                 {
-                    logMessage = $"Provided numeric value {eventTags[VALUE_EVENT_METRIC_NAME]} is in an invalid format.";
+                    logMessage =
+                        $"Provided numeric value {eventTags[VALUE_EVENT_METRIC_NAME]} is in an invalid format.";
                     logLevel = LogLevel.ERROR;
                 }
                 else
                 {
                     if (float.IsInfinity(refVar))
                     {
-                        logMessage = $"Provided numeric value {eventTags[VALUE_EVENT_METRIC_NAME]} is in an invalid format.";
+                        logMessage =
+                            $"Provided numeric value {eventTags[VALUE_EVENT_METRIC_NAME]} is in an invalid format.";
                         logLevel = LogLevel.ERROR;
                     }
                     else
@@ -127,10 +141,12 @@ namespace OptimizelySDK.Utils
             }
 
             if (logger != null)
+            {
                 logger.Log(logLevel, logMessage);
+            }
 
             object o = refVar;
-            if(isCasted && eventTags[VALUE_EVENT_METRIC_NAME] is float)
+            if (isCasted && eventTags[VALUE_EVENT_METRIC_NAME] is float)
             {
                 // Special case, maximum value when passed and gone through tryparse, it loses precision.
                 o = eventTags[VALUE_EVENT_METRIC_NAME];
@@ -140,4 +156,3 @@ namespace OptimizelySDK.Utils
         }
     }
 }
- 

--- a/OptimizelySDK/Utils/ExceptionExtensions.cs
+++ b/OptimizelySDK/Utils/ExceptionExtensions.cs
@@ -23,9 +23,13 @@ namespace OptimizelySDK.Utils
         public static string GetAllMessages(this Exception exception, string separator = "\n")
         {
             if (exception.InnerException == null)
+            {
                 return exception.Message;
+            }
 
-            return (string.IsNullOrEmpty(exception.Message) ? "" : $"{exception.Message}{separator}{GetAllMessages(exception.InnerException, separator)}");
+            return string.IsNullOrEmpty(exception.Message) ?
+                "" :
+                $"{exception.Message}{separator}{GetAllMessages(exception.InnerException, separator)}";
         }
     }
 }

--- a/OptimizelySDK/Utils/ExperimentUtils.cs
+++ b/OptimizelySDK/Utils/ExperimentUtils.cs
@@ -25,7 +25,6 @@ namespace OptimizelySDK.Utils
     {
         public static bool IsExperimentActive(Experiment experiment, ILogger logger)
         {
-
             if (!experiment.IsExperimentRunning)
             {
                 logger.Log(LogLevel.INFO, $"Experiment \"{experiment.Key}\" is not running.");
@@ -51,7 +50,8 @@ namespace OptimizelySDK.Utils
             OptimizelyUserContext user,
             string loggingKeyType,
             string loggingKey,
-            ILogger logger)
+            ILogger logger
+        )
         {
             var reasons = new DecisionReasons();
             if (user == null)
@@ -63,21 +63,29 @@ namespace OptimizelySDK.Utils
             if (experiment.AudienceConditionsList != null)
             {
                 expConditions = experiment.AudienceConditionsList;
-                logger.Log(LogLevel.DEBUG, $@"Evaluating audiences for {loggingKeyType} ""{loggingKey}"": {experiment.AudienceConditionsString}.");
+                logger.Log(LogLevel.DEBUG,
+                    $@"Evaluating audiences for {loggingKeyType} ""{loggingKey}"": {
+                        experiment.AudienceConditionsString}.");
             }
             else
             {
                 expConditions = experiment.AudienceIdsList;
-                logger.Log(LogLevel.DEBUG, $@"Evaluating audiences for {loggingKeyType} ""{loggingKey}"": {experiment.AudienceIdsString}.");
+                logger.Log(LogLevel.DEBUG,
+                    $@"Evaluating audiences for {loggingKeyType} ""{loggingKey}"": {
+                        experiment.AudienceIdsString}.");
             }
 
             // If there are no audiences, return true because that means ALL users are included in the experiment.
             if (expConditions == null)
+            {
                 return Result<bool>.NewResult(true, reasons);
+            }
 
             var result = expConditions.Evaluate(config, user, logger).GetValueOrDefault();
             var resultText = result.ToString().ToUpper();
-            logger.Log(LogLevel.INFO, reasons.AddInfo($@"Audiences for {loggingKeyType} ""{loggingKey}"" collectively evaluated to {resultText}"));
+            logger.Log(LogLevel.INFO,
+                reasons.AddInfo($@"Audiences for {loggingKeyType} ""{loggingKey
+                }"" collectively evaluated to {resultText}"));
             return Result<bool>.NewResult(result, reasons);
         }
     }

--- a/OptimizelySDK/Utils/ExperimentUtils.cs
+++ b/OptimizelySDK/Utils/ExperimentUtils.cs
@@ -1,4 +1,4 @@
-/* 
+﻿/* 
  * Copyright 2017-2022, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/OptimizelySDK/Utils/Schema.cs
+++ b/OptimizelySDK/Utils/Schema.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using System.IO;
 using System.Reflection;
 
@@ -25,7 +26,9 @@ namespace OptimizelySDK.Utils
         public static string GetSchemaJson()
         {
             if (cache != null)
+            {
                 return cache;
+            }
 #if NET35 || NET40
             var assembly = Assembly.GetExecutingAssembly();
 #else
@@ -33,9 +36,11 @@ namespace OptimizelySDK.Utils
 #endif
             const string resourceName = "OptimizelySDK.Utils.schema.json";
 
-            using (Stream stream = assembly.GetManifestResourceStream(resourceName))
-            using (StreamReader reader = new StreamReader(stream))
+            using (var stream = assembly.GetManifestResourceStream(resourceName))
+            using (var reader = new StreamReader(stream))
+            {
                 return cache = reader.ReadToEnd();
+            }
         }
     }
 }

--- a/OptimizelySDK/Utils/Validator.cs
+++ b/OptimizelySDK/Utils/Validator.cs
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 using OptimizelySDK.Entity;
 using System;
 using System.Collections.Generic;
@@ -37,11 +38,9 @@ namespace OptimizelySDK.Utils
         {
             try
             {
-                return !NJsonSchema.JsonSchema4
-                    .FromJsonAsync(schemaJson ?? Schema.GetSchemaJson())
-                    .Result
-                    .Validate(configJson)
-                    .Any();
+                return !NJsonSchema.JsonSchema4.FromJsonAsync(schemaJson ?? Schema.GetSchemaJson()).
+                    Result.Validate(configJson).
+                    Any();
             }
             catch (Newtonsoft.Json.JsonReaderException)
             {
@@ -75,10 +74,10 @@ namespace OptimizelySDK.Utils
             return !int.TryParse(attribute.Key, out key);
         }
 
-        public static bool AreEventTagsValid(Dictionary<string, object> eventTags) {
+        public static bool AreEventTagsValid(Dictionary<string, object> eventTags)
+        {
             int key;
             return eventTags.All(tag => !int.TryParse(tag.Key, out key));
-
         }
 
         /// <summary>
@@ -93,15 +92,19 @@ namespace OptimizelySDK.Utils
             var experimentIds = featureFlag.ExperimentIds;
 
             if (experimentIds == null || experimentIds.Count <= 1)
+            {
                 return true;
+            }
 
             var groupId = projectConfig.GetExperimentFromId(experimentIds[0]).GroupId;
 
-            for (int i = 1; i < experimentIds.Count; i++)
+            for (var i = 1; i < experimentIds.Count; i++)
             {
                 // Every experiment should have the same group Id.
                 if (projectConfig.GetExperimentFromId(experimentIds[i]).GroupId != groupId)
+                {
                     return false;
+                }
             }
 
             return true;
@@ -114,8 +117,9 @@ namespace OptimizelySDK.Utils
         /// <returns>true if attribute key is not null and value is one of the supported type, false otherwise</returns>
         public static bool IsUserAttributeValid(KeyValuePair<string, object> attribute)
         {
-            return (attribute.Key != null) && 
-                (attribute.Value is string || attribute.Value is bool || IsValidNumericValue(attribute.Value));
+            return attribute.Key != null &&
+                   (attribute.Value is string || attribute.Value is bool ||
+                    IsValidNumericValue(attribute.Value));
         }
 
         /// <summary>
@@ -125,9 +129,11 @@ namespace OptimizelySDK.Utils
         /// <returns></returns>
         public static bool IsNumericType(object value)
         {
-            return value is byte || value is sbyte || value is char || value is short || value is ushort
-                || value is int || value is uint || value is long || value is ulong || value is float
-                || value is double || value is decimal;
+            return value is byte || value is sbyte || value is char || value is short ||
+                   value is ushort
+                   || value is int || value is uint || value is long || value is ulong ||
+                   value is float
+                   || value is double || value is decimal;
         }
 
         /// <summary>
@@ -140,8 +146,11 @@ namespace OptimizelySDK.Utils
             if (IsNumericType(value))
             {
                 var doubleValue = Convert.ToDouble(value);
-                if (double.IsInfinity(doubleValue) || double.IsNaN(doubleValue) || Math.Abs(doubleValue) > OPT_NUMBER_LIMIT)
+                if (double.IsInfinity(doubleValue) || double.IsNaN(doubleValue) ||
+                    Math.Abs(doubleValue) > OPT_NUMBER_LIMIT)
+                {
                     return false;
+                }
 
                 return true;
             }
@@ -150,4 +159,3 @@ namespace OptimizelySDK.Utils
         }
     }
 }
-

--- a/OptimizelySDK/Utils/Validator.cs
+++ b/OptimizelySDK/Utils/Validator.cs
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-using OptimizelySDK.Entity;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using OptimizelySDK.Entity;
 using Attribute = OptimizelySDK.Entity.Attribute;
 
 namespace OptimizelySDK.Utils

--- a/OptimizelySDK/packages.config
+++ b/OptimizelySDK/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="murmurhash-signed" version="1.0.2" targetFramework="net45" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
-  <package id="NJsonSchema" version="8.30.6304.31883" targetFramework="net45" />
+    <package id="murmurhash-signed" version="1.0.2" targetFramework="net45"/>
+    <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45"/>
+    <package id="NJsonSchema" version="8.30.6304.31883" targetFramework="net45"/>
 </packages>


### PR DESCRIPTION
## Summary
- Create/update ruleset in .editorconfig that is industry accepted AND approved by C# devs
- Apply the code quality / formatting ruleset to 
  - OptimizelySDK
  - OptimizelySDK.Tests
- Adjust GitHub workflow yml to lint the whole codebase and not just the modified files 

## Test plan

- Confirm unit tests report successful results
- Confirm super-linter runs in GitHub Actions and confirm whole SDK adheres to the established ruleset

## Issues
- FSSDK-8844