### PR TITLE
[FSSDK-9006] Corrections to nuspec

### DIFF
--- a/OptimizelySDK.Package/OptimizelySDK.nuspec
+++ b/OptimizelySDK.Package/OptimizelySDK.nuspec
@@ -2,7 +2,7 @@
 <package>
     <metadata>
         <id>Optimizely.SDK</id>
-        <version>3.2.0</version>
+        <version>3.11.2</version>
         <title>Optimizely C# SDK</title>
         <authors>Optimizely Development Team</authors>
         <owners>fullstack.optimizely</owners>
@@ -12,8 +12,8 @@
         <iconUrl>https://github.com/optimizely/csharp-sdk/blob/master/OptimizelySDK.png?raw=true</iconUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <description>C# SDK for Optimizely Feature Experimentation, Optimizely Full Stack (legacy), and Optimizely Rollouts</description>
-        <releaseNotes>https://github.com/optimizely/csharp-sdk/blob/master/CHANGELOG.md</releaseNotes>
-        <copyright>Copyright 2017-2019</copyright>
+        <releaseNotes>https://github.com/optimizely/csharp-sdk/blob/3.11.2/CHANGELOG.md</releaseNotes>
+        <copyright>Copyright 2017-2023</copyright>
         <tags>Optimizely</tags>
         <dependencies>
             <group targetFramework=".NETFramework4.5">
@@ -47,5 +47,6 @@
     <files>
         <file src="./../OptimizelySDK.png" target="OptimizelySDK.png" />
         <file src="lib\**" target="lib" />
+        <file src="./../README.md" target="README.md" />
     </files>
 </package>


### PR DESCRIPTION
## Summary
- Updated version from 3.2.0 to 3.11.2.
- Updated release notes link to https://github.com/optimizely/csharp-sdk/blob/3.11.2/CHANGELOG.md.
- Updated copyright year from 2019 to 2023.
- Added README.md file to package.

## Test plan

- All unit tests should pass

## Issues
- FSSDK-9006