### PR TITLE
[FSSDK-8948] fix(odp): check odp identifiers not null or empty before sending

### DIFF
--- a/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
@@ -304,7 +304,7 @@ namespace OptimizelySDK.Tests.OdpTests
             eventManager.SendEvent(eventWithemptyIdentifiers);
             eventManager.SendEvent(eventWithNullIdentifiers);
 
-            _mockLogger.Verify(l => l.Log(LogLevel.ERROR, Constants.ODP_INVALID_IDENTIFIERS_MESSAGE),
+            _mockLogger.Verify(l => l.Log(LogLevel.ERROR, Constants.ODP_INVALID_DATA_MESSAGE),
                 Times.Exactly(2));
         }
 

--- a/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
@@ -272,6 +272,43 @@ namespace OptimizelySDK.Tests.OdpTests
         }
 
         [Test]
+        public void ShouldDiscardEventsWithInvalidIdentifiersDictionary()
+        {
+            var eventWithemptyIdentifiers = new OdpEvent("t3", "a3",
+                new Dictionary<string, string>(),
+                new Dictionary<string, object>
+                {
+                    {
+                        "data1", $"data1-value1-1"
+                    },
+                    {
+                        "data2", 1
+                    },
+                });
+            var eventWithNullIdentifiers = new OdpEvent("t3", "a3",
+                null, new Dictionary<string, object>
+                {
+                    {
+                        "data1", $"data1-value1-1"
+                    },
+                    {
+                        "data2", 1
+                    },
+                });
+            var eventManager = new OdpEventManager.Builder().
+                WithOdpEventApiManager(_mockApiManager.Object).
+                WithLogger(_mockLogger.Object).
+                Build();
+            eventManager.UpdateSettings(_odpConfig);
+
+            eventManager.SendEvent(eventWithemptyIdentifiers);
+            eventManager.SendEvent(eventWithNullIdentifiers);
+
+            _mockLogger.Verify(l => l.Log(LogLevel.ERROR, Constants.ODP_INVALID_IDENTIFIERS_MESSAGE),
+                Times.Exactly(2));
+        }
+
+        [Test]
         public void ShouldAddAdditionalInformationToEachEvent()
         {
             var expectedEvent = _processedEvents[0];

--- a/OptimizelySDK/Odp/Constants.cs
+++ b/OptimizelySDK/Odp/Constants.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2022 Optimizely
+ * Copyright 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,12 @@ namespace OptimizelySDK.Odp
         /// <summary>
         /// Default message to log when an ODP Event contains invalid data
         /// </summary>
-        public const string ODP_INVALID_DATA_MESSAGE = "ODP data is not valid.";
+        public const string ODP_INVALID_DATA_MESSAGE = "ODP event send failed (event data is not valid).";
+
+        /// <summary>
+        /// Default message to log when an ODP Identifiers is invalid
+        /// </summary>
+        public const string ODP_INVALID_IDENTIFIERS_MESSAGE = "ODP event send failed (event identifiers must have at least one key-value pair).";
 
         /// <summary>
         /// Default message to log when sending ODP event fails

--- a/OptimizelySDK/Odp/Constants.cs
+++ b/OptimizelySDK/Odp/Constants.cs
@@ -65,12 +65,7 @@ namespace OptimizelySDK.Odp
         /// <summary>
         /// Default message to log when an ODP Event contains invalid data
         /// </summary>
-        public const string ODP_INVALID_DATA_MESSAGE = "ODP event send failed (event data is not valid).";
-
-        /// <summary>
-        /// Default message to log when an ODP Identifiers is invalid
-        /// </summary>
-        public const string ODP_INVALID_IDENTIFIERS_MESSAGE = "ODP event send failed (event identifiers must have at least one key-value pair).";
+        public const string ODP_INVALID_DATA_MESSAGE = "ODP event send failed.";
 
         /// <summary>
         /// Default message to log when sending ODP event fails

--- a/OptimizelySDK/Odp/Entity/OdpEvent.cs
+++ b/OptimizelySDK/Odp/Entity/OdpEvent.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2022 Optimizely
+ * Copyright 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ namespace OptimizelySDK.Odp.Entity
         public string Action { get; }
 
         /// <summary>
-        /// Key-value map of user identifiers
+        /// Dictionary for identifiers. The caller must provide at least one key-value pair.
         /// </summary>
         public Dictionary<string, string> Identifiers { get; }
 

--- a/OptimizelySDK/Odp/IOdpManager.cs
+++ b/OptimizelySDK/Odp/IOdpManager.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2022 Optimizely
+ * Copyright 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,7 +51,7 @@ namespace OptimizelySDK.Odp
         /// </summary>
         /// <param name="type">Type of event (typically `fullstack` from server-side SDK events)</param>
         /// <param name="action">Subcategory of the event type</param>
-        /// <param name="identifiers">Key-value map of user identifiers</param>
+        /// <param name="identifiers">Dictionary for identifiers. The caller must provide at least one key-value pair.</param>
         /// <param name="data">Event data in a key-value pair format</param>
         void SendEvent(string type, string action, Dictionary<string, string> identifiers,
             Dictionary<string, object> data

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -296,13 +296,7 @@ namespace OptimizelySDK.Odp
                 return;
             }
 
-            if (!IsIdentifiersValid(odpEvent.Identifiers))
-            {
-                _logger.Log(LogLevel.ERROR, Constants.ODP_INVALID_IDENTIFIERS_MESSAGE);
-                return;
-            }
-
-            if (InvalidDataFound(odpEvent.Data))
+            if (InvalidDataFound(odpEvent.Data) || !IsIdentifiersValid(odpEvent.Identifiers))
             {
                 _logger.Log(LogLevel.ERROR, Constants.ODP_INVALID_DATA_MESSAGE);
                 return;

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -391,13 +391,9 @@ namespace OptimizelySDK.Odp
         /// </summary>
         /// <param name="Identifiers">Identifiers to be analyzed</param>
         /// <returns>True if identifiers dictionary is not null or empty otherwise False</returns>
-        private bool IsIdentifiersValid(Dictionary<string, string> Identifiers) 
+        private bool IsIdentifiersValid(Dictionary<string, string> Identifiers)
         {
-            if (Identifiers == null || Identifiers.Count == 0)
-            {
-                return false;
-            }
-            return true;
+            return Identifiers?.Count > 0;
         }
 
         /// <summary>

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -296,6 +296,12 @@ namespace OptimizelySDK.Odp
                 return;
             }
 
+            if (!IsIdentifiersValid(odpEvent.Identifiers))
+            {
+                _logger.Log(LogLevel.ERROR, Constants.ODP_INVALID_IDENTIFIERS_MESSAGE);
+                return;
+            }
+
             if (InvalidDataFound(odpEvent.Data))
             {
                 _logger.Log(LogLevel.ERROR, Constants.ODP_INVALID_DATA_MESSAGE);
@@ -378,6 +384,20 @@ namespace OptimizelySDK.Odp
             {
                 Start();
             }
+        }
+
+        /// <summary>
+        /// ODP event identifiers should not be null or empty
+        /// </summary>
+        /// <param name="Identifiers">Identifiers to be analyzed</param>
+        /// <returns>True if identifiers dictionary is not null or empty otherwise False</returns>
+        private bool IsIdentifiersValid(Dictionary<string, string> Identifiers) 
+        {
+            if (Identifiers == null || Identifiers.Count == 0)
+            {
+                return false;
+            }
+            return true;
         }
 
         /// <summary>

--- a/OptimizelySDK/Odp/OdpManager.cs
+++ b/OptimizelySDK/Odp/OdpManager.cs
@@ -116,7 +116,7 @@ namespace OptimizelySDK.Odp
         /// </summary>
         /// <param name="type">Type of event (typically `fullstack` from server-side SDK events)</param>
         /// <param name="action">Subcategory of the event type</param>
-        /// <param name="identifiers">Key-value map of user identifiers</param>
+        /// <param name="identifiers">Dictionary for identifiers. The caller must provide at least one key-value pair.</param>
         /// <param name="data">Event data in a key-value pair format</param>
         public void SendEvent(string type, string action, Dictionary<string, string> identifiers,
             Dictionary<string, object> data

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -1356,7 +1356,7 @@ namespace OptimizelySDK
         /// </summary>
         /// <param name="type">Type of event (typically `fullstack` from server-side SDK events)</param>
         /// <param name="action">Subcategory of the event type</param>
-        /// <param name="identifiers">Key-value map of user identifiers</param>
+        /// <param name="identifiers">Dictionary for identifiers. The caller must provide at least one key-value pair.</param>
         /// <param name="data">Event data in a key-value pair format</param>
         public void SendOdpEvent(string type, string action, Dictionary<string, string> identifiers,
             Dictionary<string, object> data


### PR DESCRIPTION
## Summary
- Check if ODP events have at least one key-value pair for identifiers.
If not, discard the request without sending to the ODP server.

## Test plan
- Add a test with empty identifiers and null identifier.
- All tests should pass. 

## Issues
- [FSSDK-8948](https://jira.sso.episerver.net/browse/FSSDK-8948)