### PR TITLE
[FSSDK-9039] Fix e2e ODP event response

### DIFF
--- a/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
@@ -515,7 +515,7 @@ namespace OptimizelySDK.Tests.OdpTests
             Assert.IsNotNull(actualEvent);
             Assert.AreEqual(Constants.ODP_EVENT_TYPE, actualEvent.Type);
             Assert.AreEqual("identified", actualEvent.Action);
-            Assert.AreEqual(USER_ID, actualEvent.Identifiers[OdpUserKeyType.FS_USER_ID.ToString()]);
+            Assert.AreEqual(USER_ID, actualEvent.Identifiers[Constants.FS_USER_ID]);
             var eventData = actualEvent.Data;
             Assert.AreEqual(Guid.NewGuid().ToString().Length,
                 eventData["idempotence_id"].ToString().Length);

--- a/OptimizelySDK.Tests/OdpTests/OdpSegmentApiManagerTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpSegmentApiManagerTest.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2022 Optimizely
+ * Copyright 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -158,7 +158,7 @@ namespace OptimizelySDK.Tests.OdpTests
             var segments = manager.FetchSegments(
                 VALID_ODP_PUBLIC_KEY,
                 ODP_GRAPHQL_HOST,
-                OdpUserKeyType.FS_USER_ID,
+                Constants.FS_USER_ID,
                 "tester-101",
                 _segmentsToCheck);
 
@@ -180,7 +180,7 @@ namespace OptimizelySDK.Tests.OdpTests
             var segments = manager.FetchSegments(
                 VALID_ODP_PUBLIC_KEY,
                 ODP_GRAPHQL_HOST,
-                OdpUserKeyType.FS_USER_ID,
+                Constants.FS_USER_ID,
                 "tester-101",
                 _segmentsToCheck);
 
@@ -204,7 +204,7 @@ namespace OptimizelySDK.Tests.OdpTests
             var segments = manager.FetchSegments(
                 VALID_ODP_PUBLIC_KEY,
                 ODP_GRAPHQL_HOST,
-                OdpUserKeyType.FS_USER_ID,
+                Constants.FS_USER_ID,
                 "invalid-user",
                 _segmentsToCheck);
 
@@ -224,7 +224,7 @@ namespace OptimizelySDK.Tests.OdpTests
             var segments = manager.FetchSegments(
                 VALID_ODP_PUBLIC_KEY,
                 ODP_GRAPHQL_HOST,
-                OdpUserKeyType.FS_USER_ID,
+                Constants.FS_USER_ID,
                 "tester-101",
                 _segmentsToCheck);
 
@@ -246,7 +246,7 @@ namespace OptimizelySDK.Tests.OdpTests
             var segments = manager.FetchSegments(
                 VALID_ODP_PUBLIC_KEY,
                 ODP_GRAPHQL_HOST,
-                OdpUserKeyType.FS_USER_ID,
+                Constants.FS_USER_ID,
                 "tester-101",
                 _segmentsToCheck);
 
@@ -266,7 +266,7 @@ namespace OptimizelySDK.Tests.OdpTests
             var segments = manager.FetchSegments(
                 VALID_ODP_PUBLIC_KEY,
                 ODP_GRAPHQL_HOST,
-                OdpUserKeyType.FS_USER_ID,
+                Constants.FS_USER_ID,
                 "tester-101",
                 _segmentsToCheck);
 
@@ -285,7 +285,7 @@ namespace OptimizelySDK.Tests.OdpTests
             var segments = manager.FetchSegments(
                 VALID_ODP_PUBLIC_KEY,
                 ODP_GRAPHQL_HOST,
-                OdpUserKeyType.FS_USER_ID,
+                Constants.FS_USER_ID,
                 "tester-101",
                 _segmentsToCheck);
 

--- a/OptimizelySDK.Tests/OdpTests/OdpSegmentManagerTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpSegmentManagerTest.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2022, 2023 Optimizely
+ * Copyright 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,14 +14,10 @@
  * limitations under the License.
  */
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
 using Moq;
 using NUnit.Framework;
-using OptimizelySDK.AudienceConditions;
-using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Odp;
 
@@ -64,7 +60,7 @@ namespace OptimizelySDK.Tests.OdpTests
             _mockCache.Setup(c => c.Lookup(Capture.In(keyCollector))).
                 Returns(default(List<string>));
             _mockApiManager.Setup(a => a.FetchSegments(It.IsAny<string>(), It.IsAny<string>(),
-                    It.IsAny<OdpUserKeyType>(), It.IsAny<string>(), It.IsAny<List<string>>())).
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>>())).
                 Returns(segmentsToCheck.ToArray());
             var manager = new OdpSegmentManager(_mockApiManager.Object, _mockCache.Object,
                 _mockLogger.Object);
@@ -82,7 +78,7 @@ namespace OptimizelySDK.Tests.OdpTests
                 a => a.FetchSegments(
                     API_KEY,
                     API_HOST,
-                    OdpUserKeyType.FS_USER_ID,
+                    Constants.FS_USER_ID,
                     FS_USER_ID,
                     _odpConfig.SegmentsToCheck), Times.Once);
             _mockCache.Verify(c => c.Save(cacheKey, It.IsAny<List<string>>()), Times.Once);
@@ -95,7 +91,7 @@ namespace OptimizelySDK.Tests.OdpTests
             var keyCollector = new List<string>();
             _mockCache.Setup(c => c.Lookup(Capture.In(keyCollector))).Returns(segmentsToCheck);
             _mockApiManager.Setup(a => a.FetchSegments(It.IsAny<string>(), It.IsAny<string>(),
-                It.IsAny<OdpUserKeyType>(), It.IsAny<string>(), It.IsAny<List<string>>()));
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>>()));
             var manager = new OdpSegmentManager(_mockApiManager.Object, _mockCache.Object,
                 _mockLogger.Object);
             manager.UpdateSettings(_odpConfig);
@@ -110,7 +106,7 @@ namespace OptimizelySDK.Tests.OdpTests
                 l.Log(LogLevel.DEBUG, "ODP Cache Hit. Returning segments from Cache."), Times.Once);
             _mockApiManager.Verify(
                 a => a.FetchSegments(It.IsAny<string>(), It.IsAny<string>(),
-                    It.IsAny<OdpUserKeyType>(), It.IsAny<string>(), It.IsAny<List<string>>()),
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>>()),
                 Times.Never);
             _mockCache.Verify(c => c.Save(expectedCacheKey, It.IsAny<List<string>>()), Times.Never);
             Assert.AreEqual(segmentsToCheck, segments);
@@ -121,7 +117,7 @@ namespace OptimizelySDK.Tests.OdpTests
         {
             // OdpSegmentApiManager.FetchSegments() return null on any error
             _mockApiManager.Setup(a => a.FetchSegments(It.IsAny<string>(), It.IsAny<string>(),
-                    It.IsAny<OdpUserKeyType>(), It.IsAny<string>(), It.IsAny<List<string>>())).
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>>())).
                 Returns(null as string[]);
             var manager = new OdpSegmentManager(_mockApiManager.Object, _mockCache.Object,
                 _mockLogger.Object);
@@ -133,7 +129,7 @@ namespace OptimizelySDK.Tests.OdpTests
             _mockCache.Verify(c => c.Lookup(expectedCacheKey), Times.Once);
             _mockApiManager.Verify(
                 a => a.FetchSegments(It.IsAny<string>(), It.IsAny<string>(),
-                    It.IsAny<OdpUserKeyType>(), It.IsAny<string>(), It.IsAny<List<string>>()),
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>>()),
                 Times.Once);
             _mockCache.Verify(c => c.Save(expectedCacheKey, It.IsAny<List<string>>()), Times.Never);
             Assert.IsNull(segments);
@@ -187,7 +183,7 @@ namespace OptimizelySDK.Tests.OdpTests
             _mockCache.Verify(c => c.Lookup(It.IsAny<string>()), Times.Never);
             _mockApiManager.Verify(
                 a => a.FetchSegments(It.IsAny<string>(), It.IsAny<string>(),
-                    It.IsAny<OdpUserKeyType>(), It.IsAny<string>(), It.IsAny<List<string>>()),
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>>()),
                 Times.Once);
             _mockCache.Verify(c => c.Save(expectedCacheKey, It.IsAny<List<string>>()), Times.Never);
         }
@@ -206,7 +202,7 @@ namespace OptimizelySDK.Tests.OdpTests
             _mockCache.Verify(c => c.Lookup(It.IsAny<string>()), Times.Once);
             _mockApiManager.Verify(
                 a => a.FetchSegments(It.IsAny<string>(), It.IsAny<string>(),
-                    It.IsAny<OdpUserKeyType>(), It.IsAny<string>(), It.IsAny<List<string>>()),
+                    It.IsAny<string>(), It.IsAny<string>(), It.IsAny<List<string>>()),
                 Times.Once);
             _mockCache.Verify(c => c.Save(expectedCacheKey, It.IsAny<List<string>>()), Times.Once);
         }

--- a/OptimizelySDK/Odp/Constants.cs
+++ b/OptimizelySDK/Odp/Constants.cs
@@ -111,5 +111,10 @@ namespace OptimizelySDK.Odp
         /// Default number of seconds to cache
         /// </summary>
         public const int DEFAULT_CACHE_SECONDS = 600;
+
+        /// <summary>
+        /// Type of ODP key used for fetching segments & sending events
+        /// </summary>
+        public const string FS_USER_ID = "fs_user_id";
     }
 }

--- a/OptimizelySDK/Odp/Enums.cs
+++ b/OptimizelySDK/Odp/Enums.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2022 Optimizely
+ * Copyright 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,17 +16,6 @@
 
 namespace OptimizelySDK.Odp
 {
-    /// <summary>
-    /// Type of ODP key used for fetching segments & sending events
-    /// </summary>
-    public enum OdpUserKeyType
-    {
-        // ReSharper disable InconsistentNaming
-        // ODP expects these names in UPPERCASE; .ToString() used
-        VUID = 0, // kept for SDK consistency and awareness
-        FS_USER_ID = 1,
-    }
-
     /// <summary>
     /// Options used during segment cache handling
     /// </summary>

--- a/OptimizelySDK/Odp/IOdpSegmentApiManager.cs
+++ b/OptimizelySDK/Odp/IOdpSegmentApiManager.cs
@@ -25,13 +25,13 @@ namespace OptimizelySDK.Odp
         /// </summary>
         /// <param name="apiKey">ODP public key</param>
         /// <param name="apiHost">Fully-qualified URL of ODP</param>
-        /// <param name="userKey">'vuid' or 'fs_user_id key'</param>
+        /// <param name="userKey">Server-side should be 'fs_user_id key'</param>
         /// <param name="userValue">Associated value to query for the user key</param>
         /// <param name="segmentsToCheck">Audience segments to check for experiment inclusion</param>
         /// <returns>Array of audience segments</returns>
         string[] FetchSegments(string apiKey,
             string apiHost,
-            OdpUserKeyType userKey,
+            string userKey,
             string userValue,
             List<string> segmentsToCheck
         );

--- a/OptimizelySDK/Odp/OdpEventApiManager.cs
+++ b/OptimizelySDK/Odp/OdpEventApiManager.cs
@@ -92,7 +92,10 @@ namespace OptimizelySDK.Odp
             var endpoint = $"{apiHost}{Constants.ODP_EVENTS_API_ENDPOINT_PATH}";
             var data = JsonConvert.SerializeObject(events, settings: new JsonSerializerSettings
             {
-                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+                ContractResolver = new DefaultContractResolver
+                {
+                    NamingStrategy = new SnakeCaseNamingStrategy(),
+                },
             });
             var shouldRetry = false;
 

--- a/OptimizelySDK/Odp/OdpEventApiManager.cs
+++ b/OptimizelySDK/Odp/OdpEventApiManager.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2022 Optimizely
+ * Copyright 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using OptimizelySDK.ErrorHandler;
 using OptimizelySDK.Logger;
 using OptimizelySDK.Odp.Entity;
@@ -89,7 +90,10 @@ namespace OptimizelySDK.Odp
             }
 
             var endpoint = $"{apiHost}{Constants.ODP_EVENTS_API_ENDPOINT_PATH}";
-            var data = JsonConvert.SerializeObject(events);
+            var data = JsonConvert.SerializeObject(events, settings: new JsonSerializerSettings
+            {
+                ContractResolver = new CamelCasePropertyNamesContractResolver(),
+            });
             var shouldRetry = false;
 
             HttpResponseMessage response = default;

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -352,7 +352,7 @@ namespace OptimizelySDK.Odp
         {
             var identifiers = new Dictionary<string, string>
             {
-                { OdpUserKeyType.FS_USER_ID.ToString(), userId },
+                { Constants.FS_USER_ID, userId },
             };
 
             var odpEvent = new OdpEvent(Constants.ODP_EVENT_TYPE, "identified", identifiers);

--- a/OptimizelySDK/Odp/OdpSegmentApiManager.cs
+++ b/OptimizelySDK/Odp/OdpSegmentApiManager.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2022 Optimizely
+ * Copyright 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -74,11 +74,11 @@ namespace OptimizelySDK.Odp
         /// </summary>
         /// <param name="apiKey">ODP public key</param>
         /// <param name="apiHost">Host of ODP endpoint</param>
-        /// <param name="userKey">Either `vuid` or `fs_user_id key`</param>
+        /// <param name="userKey">`fs_user_id key` for server-side SDKs</param>
         /// <param name="userValue">Associated value to query for the user key</param>
         /// <param name="segmentsToCheck">Audience segments to check for experiment inclusion</param>
         /// <returns>Array of audience segments</returns>
-        public string[] FetchSegments(string apiKey, string apiHost, OdpUserKeyType userKey,
+        public string[] FetchSegments(string apiKey, string apiHost, string userKey,
             string userValue, List<string> segmentsToCheck
         )
         {

--- a/OptimizelySDK/Odp/OdpSegmentManager.cs
+++ b/OptimizelySDK/Odp/OdpSegmentManager.cs
@@ -99,7 +99,7 @@ namespace OptimizelySDK.Odp
             options = options ?? new List<OdpSegmentOption>();
 
             List<string> qualifiedSegments;
-            var cacheKey = GetCacheKey(OdpUserKeyType.FS_USER_ID.ToString().ToLower(), fsUserId);
+            var cacheKey = GetCacheKey(Constants.FS_USER_ID, fsUserId);
 
             if (options.Contains(OdpSegmentOption.RESET_CACHE))
             {
@@ -121,7 +121,7 @@ namespace OptimizelySDK.Odp
             qualifiedSegments = _apiManager.FetchSegments(
                     _odpConfig.ApiKey,
                     _odpConfig.ApiHost,
-                    OdpUserKeyType.FS_USER_ID,
+                    Constants.FS_USER_ID,
                     fsUserId,
                     _odpConfig.SegmentsToCheck)?.
                 ToList();


### PR DESCRIPTION
## Summary
As a bug bash engineer, I would like ODP events being sent from the C# SDK to not return an HTTP Status 400.

## Test plan
- Existing unit and integration test should pass
- Bug bash engineer's test app should pass end-to-end testing

## Issues
- FSSDK-9039