### PR TITLE
[FSSDK-9093] Add return Task handle for async FetchQualifiedSegments

### DIFF
--- a/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
@@ -1071,7 +1071,6 @@ namespace OptimizelySDK.Tests
         public void ShouldFetchQualifiedSegmentsAsyncThenCallCallback()
         {
             var odpManager = new OdpManager.Builder().Build();
-            var cde = new CountdownEvent(1);
             var callbackResult = false;
             var optimizely = new Optimizely(TestData.OdpIntegrationDatafile,
                 EventDispatcherMock.Object, LoggerMock.Object, ErrorHandlerMock.Object,
@@ -1079,12 +1078,11 @@ namespace OptimizelySDK.Tests
             var context = new OptimizelyUserContext(optimizely, UserID, null,
                 ErrorHandlerMock.Object, LoggerMock.Object);
 
-            context.FetchQualifiedSegments(success =>
+            var task = context.FetchQualifiedSegments(success =>
             {
                 callbackResult = success;
-                cde.Signal();
             });
-            cde.Wait(5000);
+            task.Wait();
             context.Dispose();
 
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, Constants.ODP_NOT_ENABLED_MESSAGE),

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2020-2022, Optimizely
+ * Copyright 2020-2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -199,12 +199,12 @@ namespace OptimizelySDK
         /// </summary>
         /// <param name="callback">Callback function to invoke when results are available</param>
         /// <param name="segmentOptions">Options used during segment cache handling</param>
-        /// <returns>True if ODP segments were fetched successfully otherwise False</returns>
-        public void FetchQualifiedSegments(Action<bool> callback,
+        /// <returns>Handle to the Task/thread to be .Wait-ed on</returns>
+        public Task FetchQualifiedSegments(Action<bool> callback,
             List<OdpSegmentOption> segmentOptions = null
         )
         {
-            Task.Run(() =>
+            return Task.Run(() =>
             {
                 var success = FetchQualifiedSegments(segmentOptions);
 


### PR DESCRIPTION
## Summary
Async FetchQualifiedSegments should return a thread handle and is guaranteed to run to completion when `.Wait()` is used by the consumer.

## Test plan
- Existing unit and FSC tests should pass

## Issues
- FSSDK-9093