### PR TITLE
[FSSDK-9055] fix: add config check in odp methods

### DIFF
--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2017-2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -6172,7 +6172,7 @@ namespace OptimizelySDK.Tests
         public void TestSendOdpEventInvalidOptimizelyObject()
         {
             var optly = new Optimizely("Random datafile", null, LoggerMock.Object);
-            optly.SendOdpEvent("some_event", "some_action", new Dictionary<string, string>() { { "some_key", "some_value" } }, null);
+            optly.SendOdpEvent("some_event", "some_action", new Dictionary<string, string>(){{"some_key", "some_value"}}, null);
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'SendOdpEvent'."),
                 Times.Once);

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -6187,7 +6187,7 @@ namespace OptimizelySDK.Tests
         public void TestSendOdpEventInvalidOptimizelyObject()
         {
             var optly = new Optimizely("Random datafile", null, LoggerMock.Object);
-            optly.SendOdpEvent("some_event", "some_action", new Dictionary<string, string>() { { "some_key", "some_value" } }, null);
+            optly.SendOdpEvent("some_action", new Dictionary<string, string>() { { "some_key", "some_value" } }, "some_event");
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'SendOdpEvent'."),
                 Times.Once);

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2017-2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -6172,13 +6172,13 @@ namespace OptimizelySDK.Tests
         public void TestSendOdpEventInvalidOptimizelyObject()
         {
             var optly = new Optimizely("Random datafile", null, LoggerMock.Object);
-            optly.SendOdpEvent("some_event", "some_action", new Dictionary<string, string>(){{"some_key", "some_value"}}, null);
+            optly.SendOdpEvent("some_event", "some_action", new Dictionary<string, string>() { { "some_key", "some_value" } }, null);
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'SendOdpEvent'."),
                 Times.Once);
         }
 
-        #endregion Test FetchQualifiedSegments
+        #endregion Test SendOdpEvent
 
         #region Test FetchQualifiedSegments
         [Test]

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -6166,5 +6166,45 @@ namespace OptimizelySDK.Tests
         }
 
         #endregion Test Culture
+
+        #region Test SendOdpEvent
+        [Test]
+        public void TestSendOdpEventInvalidOptimizelyObject()
+        {
+            var optly = new Optimizely("Random datafile", null, LoggerMock.Object);
+            optly.SendOdpEvent("some_event", "some_action", new Dictionary<string, string>(){{"some_key", "some_value"}}, null);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'SendOdpEvent'."),
+                Times.Once);
+        }
+
+        #endregion Test FetchQualifiedSegments
+
+        #region Test FetchQualifiedSegments
+        [Test]
+        public void TestFetchQualifiedSegmentsInvalidOptimizelyObject()
+        {
+            var optly = new Optimizely("Random datafile", null, LoggerMock.Object);
+            optly.FetchQualifiedSegments("some_user", null);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'FetchQualifiedSegments'."),
+                Times.Once);
+        }
+
+        #endregion Test FetchQualifiedSegments
+
+        #region Test IdentifyUser
+        [Test]
+        public void TestIdentifyUserInvalidOptimizelyObject()
+        {
+            var optly = new Optimizely("Random datafile", null, LoggerMock.Object);
+            optly.IdentifyUser("some_user");
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'IdentifyUser'."),
+                Times.Once);
+        }
+
+        #endregion Test IdentifyUser
+
     }
 }

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Copyright 2017-2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright 2017-2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -6172,7 +6172,7 @@ namespace OptimizelySDK.Tests
         public void TestSendOdpEventInvalidOptimizelyObject()
         {
             var optly = new Optimizely("Random datafile", null, LoggerMock.Object);
-            optly.SendOdpEvent("some_event", "some_action", new Dictionary<string, string>(){{"some_key", "some_value"}}, null);
+            optly.SendOdpEvent("some_event", "some_action", new Dictionary<string, string>() { { "some_key", "some_value" } }, null);
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'SendOdpEvent'."),
                 Times.Once);

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -1360,7 +1360,7 @@ namespace OptimizelySDK
 
             if (config == null)
             {
-                Logger.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'Identify'.");
+                Logger.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'IdentifyUser'.");
                 return;
             }
 

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -1339,6 +1339,14 @@ namespace OptimizelySDK
             List<OdpSegmentOption> segmentOptions
         )
         {
+            var config = ProjectConfigManager?.GetConfig();
+
+            if (config == null)
+            {
+                Logger.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'FetchQualifiedSegments'.");
+                return null;
+            }
+
             return OdpManager?.FetchQualifiedSegments(userId, segmentOptions);
         }
 
@@ -1348,6 +1356,14 @@ namespace OptimizelySDK
         /// <param name="userId">FS User ID to send</param>
         internal void IdentifyUser(string userId)
         {
+            var config = ProjectConfigManager?.GetConfig();
+
+            if (config == null)
+            {
+                Logger.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'Identify'.");
+                return;
+            }
+
             OdpManager?.IdentifyUser(userId);
         }
 
@@ -1362,6 +1378,14 @@ namespace OptimizelySDK
             Dictionary<string, object> data
         )
         {
+            var config = ProjectConfigManager?.GetConfig();
+
+            if (config == null)
+            {
+                Logger.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'SendOdpEvent'.");
+                return;
+            }
+
             OdpManager?.SendEvent(type, action, identifiers, data);
         }
 #endif


### PR DESCRIPTION
## Summary
- Add check for ProjectConfig in odp methods.
This will ensure the datafile has been fetched first.

## Test plan
all tests pass

## Ticket
[FSSDK-9055](https://jira.sso.episerver.net/browse/FSSDK-9055)