### PR TITLE
[FSSDK-9079] fix: send odp event empty values

### DIFF
--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -6176,7 +6176,7 @@ namespace OptimizelySDK.Tests
         public void TestSendOdpEventNullAction()
         {
             var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object, odpManager: OdpManagerMock.Object);
-            optly.SendOdpEvent("type", null, identifiers: new Dictionary<string, string>(), data: new Dictionary<string, object>());
+            optly.SendOdpEvent(action: null, identifiers: new Dictionary<string, string>(), type: "type");
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, Constants.ODP_INVALID_ACTION_MESSAGE),
                 Times.Exactly(1));
 
@@ -6187,7 +6187,7 @@ namespace OptimizelySDK.Tests
         public void TestSendOdpEventEmptyStringAction()
         {
             var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object, odpManager: OdpManagerMock.Object);
-            optly.SendOdpEvent("type", "", identifiers: new Dictionary<string, string>(), data: new Dictionary<string, object>());
+            optly.SendOdpEvent(action: "", identifiers: new Dictionary<string, string>(), type: "type");
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, Constants.ODP_INVALID_ACTION_MESSAGE),
                 Times.Exactly(1));
 
@@ -6197,14 +6197,13 @@ namespace OptimizelySDK.Tests
         public void TestSendOdpEventNullType()
         {
             var identifiers = new Dictionary<string, string>();
-            var data = new Dictionary<string, object>();
             var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object, odpManager: OdpManagerMock.Object);
 
-            optly.SendOdpEvent(null, "action", identifiers: identifiers, data: data);
+            optly.SendOdpEvent(action: "action", identifiers: identifiers, type: null);
 
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, It.IsAny<string>()),
                 Times.Never);
-            OdpManagerMock.Verify(e => e.SendEvent("fullstack", "action", identifiers, data),
+            OdpManagerMock.Verify(e => e.SendEvent("fullstack", "action", identifiers, null),
                 Times.Once);
 
             optly.Dispose();
@@ -6214,14 +6213,13 @@ namespace OptimizelySDK.Tests
         public void TestSendOdpEventEmptyStringType()
         {
             var identifiers = new Dictionary<string, string>();
-            var data = new Dictionary<string, object>();
             var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object, odpManager: OdpManagerMock.Object);
 
-            optly.SendOdpEvent("", "action", identifiers: identifiers, data: data);
+            optly.SendOdpEvent(action: "action", identifiers: identifiers, type: "");
 
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, It.IsAny<string>()),
                 Times.Never);
-            OdpManagerMock.Verify(e => e.SendEvent("fullstack", "action", identifiers, data),
+            OdpManagerMock.Verify(e => e.SendEvent("fullstack", "action", identifiers, null),
                 Times.Once);
 
             optly.Dispose();

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -6177,7 +6177,7 @@ namespace OptimizelySDK.Tests
         {
             var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object, odpManager: OdpManagerMock.Object);
             optly.SendOdpEvent("type", null, identifiers: new Dictionary<string, string>(), data: new Dictionary<string, object>());
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "ODP action is not valid (cannot be empty)."),
+            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, Constants.ODP_INVALID_ACTION_MESSAGE),
                 Times.Exactly(1));
 
             optly.Dispose();
@@ -6188,7 +6188,7 @@ namespace OptimizelySDK.Tests
         {
             var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object, odpManager: OdpManagerMock.Object);
             optly.SendOdpEvent("type", "", identifiers: new Dictionary<string, string>(), data: new Dictionary<string, object>());
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "ODP action is not valid (cannot be empty)."),
+            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, Constants.ODP_INVALID_ACTION_MESSAGE),
                 Times.Exactly(1));
 
             optly.Dispose();

--- a/OptimizelySDK/IOptimizely.cs
+++ b/OptimizelySDK/IOptimizely.cs
@@ -83,7 +83,7 @@ namespace OptimizelySDK
         bool SetForcedVariation(string experimentKey, string userId, string variationKey);
 
         /// <summary>
-        /// Gets the forced variation key for the given user and experiment.  
+        /// Gets the forced variation key for the given user and experiment.
         /// </summary>
         /// <param name="experimentKey">The experiment key</param>
         /// <param name="userId">The user ID</param>
@@ -162,7 +162,7 @@ namespace OptimizelySDK
         #endregion
 
 #if USE_ODP
-        void SendOdpEvent(string type, string action, Dictionary<string, string> identifiers,
+        void SendOdpEvent(string action, Dictionary<string, string> identifiers, string type,
             Dictionary<string, object> data
         );
 #endif

--- a/OptimizelySDK/Odp/Constants.cs
+++ b/OptimizelySDK/Odp/Constants.cs
@@ -1,4 +1,4 @@
-/* 
+﻿/* 
  * Copyright 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/OptimizelySDK/Odp/Constants.cs
+++ b/OptimizelySDK/Odp/Constants.cs
@@ -121,5 +121,10 @@ namespace OptimizelySDK.Odp
         /// Type of ODP key used for fetching segments & sending events
         /// </summary>
         public const string FS_USER_ID = "fs_user_id";
+
+        /// <summary>
+        /// Unique identifier used for ODP events
+        /// </summary>
+        public const string IDEMPOTENCE_ID = "idempotence_id";
     }
 }

--- a/OptimizelySDK/Odp/Constants.cs
+++ b/OptimizelySDK/Odp/Constants.cs
@@ -123,6 +123,11 @@ namespace OptimizelySDK.Odp
         public const string FS_USER_ID = "fs_user_id";
 
         /// <summary>
+        /// Alternate form of ODP key that is auto-converted to FS_USER_ID
+        /// </summary>
+        public const string FS_USER_ID_ALIAS = "fs-user-id";
+
+        /// <summary>
         /// Unique identifier used for ODP events
         /// </summary>
         public const string IDEMPOTENCE_ID = "idempotence_id";

--- a/OptimizelySDK/Odp/Constants.cs
+++ b/OptimizelySDK/Odp/Constants.cs
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
  * Copyright 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -66,6 +66,11 @@ namespace OptimizelySDK.Odp
         /// Default message to log when an ODP Event contains invalid data
         /// </summary>
         public const string ODP_INVALID_DATA_MESSAGE = "ODP event send failed.";
+
+        /// <summary>
+        /// Default message to log when an ODP Event contains invalid action
+        /// </summary>
+        public const string ODP_INVALID_ACTION_MESSAGE = "ODP action is not valid (cannot be empty).";
 
         /// <summary>
         /// Default message to log when sending ODP event fails

--- a/OptimizelySDK/Odp/Entity/OdpEvent.cs
+++ b/OptimizelySDK/Odp/Entity/OdpEvent.cs
@@ -1,4 +1,4 @@
-/* 
+﻿/* 
  * Copyright 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/OptimizelySDK/Odp/Entity/OdpEvent.cs
+++ b/OptimizelySDK/Odp/Entity/OdpEvent.cs
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
  * Copyright 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,7 +36,7 @@ namespace OptimizelySDK.Odp.Entity
         /// <summary>
         /// Dictionary for identifiers. The caller must provide at least one key-value pair.
         /// </summary>
-        public Dictionary<string, string> Identifiers { get; }
+        public Dictionary<string, string> Identifiers { get; set; }
 
         /// <summary>
         /// Event data in a key-value pair format

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -1,4 +1,4 @@
-/* 
+﻿/* 
  * Copyright 2022-2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -432,7 +432,7 @@ namespace OptimizelySDK.Odp
         )
         {
             sourceData.MergeInPlace<string, object>(_commonData);
-            if(!sourceData.ContainsKey(Constants.IDEMPOTENCE_ID))
+            if (!sourceData.ContainsKey(Constants.IDEMPOTENCE_ID))
             {
                 sourceData.Add(Constants.IDEMPOTENCE_ID, Guid.NewGuid());
             }
@@ -458,7 +458,7 @@ namespace OptimizelySDK.Odp
             foreach (var kvp in identList)
             {
                 var lowerCaseKey = kvp.Key.ToLower();
-                if (lowerCaseKey == Constants.FS_USER_ID_ALIAS || lowerCaseKey ==  Constants.FS_USER_ID)
+                if (lowerCaseKey == Constants.FS_USER_ID_ALIAS || lowerCaseKey == Constants.FS_USER_ID)
                 {
                     identifiers.Remove(kvp.Key);
                     identifiers[Constants.FS_USER_ID] = kvp.Value;

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -1,4 +1,4 @@
-﻿/* 
+/* 
  * Copyright 2022-2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -429,7 +429,12 @@ namespace OptimizelySDK.Odp
             Dictionary<string, dynamic> sourceData
         )
         {
-            return sourceData.MergeInPlace<string, object>(_commonData);
+            sourceData.MergeInPlace<string, object>(_commonData);
+            if(!sourceData.ContainsKey(Constants.IDEMPOTENCE_ID))
+            {
+                sourceData.Add(Constants.IDEMPOTENCE_ID, Guid.NewGuid());
+            }
+            return sourceData;
         }
 
         /// <summary>

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -1362,6 +1362,17 @@ namespace OptimizelySDK
             Dictionary<string, object> data
         )
         {
+            if (String.IsNullOrEmpty(action))
+            {
+                Logger.Log(LogLevel.ERROR, Constants.ODP_INVALID_ACTION_MESSAGE);
+                return;
+            }
+
+            if (String.IsNullOrEmpty(type))
+            {
+                type = Constants.ODP_EVENT_TYPE;
+            }
+
             OdpManager?.SendEvent(type, action, identifiers, data);
         }
 #endif

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -1354,12 +1354,12 @@ namespace OptimizelySDK
         /// <summary>
         /// Add event to queue for sending to ODP
         /// </summary>
-        /// <param name="type">Type of event (typically `fullstack` from server-side SDK events)</param>
         /// <param name="action">Subcategory of the event type</param>
         /// <param name="identifiers">Dictionary for identifiers. The caller must provide at least one key-value pair.</param>
-        /// <param name="data">Event data in a key-value pair format</param>
-        public void SendOdpEvent(string type, string action, Dictionary<string, string> identifiers,
-            Dictionary<string, object> data
+        /// <param name="type">Type of event (defaults to `fullstack`)</param>
+        /// <param name="data">Optional event data in a key-value pair format</param>
+        public void SendOdpEvent(string action, Dictionary<string, string> identifiers, string type = Constants.ODP_EVENT_TYPE,
+            Dictionary<string, object> data = null
         )
         {
             if (String.IsNullOrEmpty(action))

--- a/OptimizelySDK/Utils/CollectionExtensions.cs
+++ b/OptimizelySDK/Utils/CollectionExtensions.cs
@@ -1,4 +1,4 @@
-﻿/* 
+﻿/*
  * Copyright 2022-2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -45,6 +45,7 @@ namespace OptimizelySDK.Utils
                 return;
             }
 
+            // Only update the left dictionary when the key doesn't exist
             foreach (var kvp in right.Where(
                          kvp => !left.ContainsKey(kvp.Key)))
             {

--- a/OptimizelySDK/Utils/CollectionExtensions.cs
+++ b/OptimizelySDK/Utils/CollectionExtensions.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2022, Optimizely
+ * Copyright 2022-2023, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,10 +29,9 @@ namespace OptimizelySDK.Utils
         /// <param name="right">Dictionary to merge into another</param>
         /// <typeparam name="TKey">Key type</typeparam>
         /// <typeparam name="TValue">Value type</typeparam>
-        /// <returns>Merged Dictionary</returns>
         /// <exception cref="ArgumentNullException">Thrown if target Dictionary is null</exception>
-        public static Dictionary<TKey, TValue> MergeInPlace<TKey, TValue>(
-            this Dictionary<TKey, TValue> left, Dictionary<TKey, TValue> right
+        public static void MergeInPlace<TKey, TValue>(this Dictionary<TKey, TValue> left,
+            Dictionary<TKey, TValue> right
         )
         {
             if (left == null)
@@ -43,7 +42,7 @@ namespace OptimizelySDK.Utils
 
             if (right == null)
             {
-                return left;
+                return;
             }
 
             foreach (var kvp in right.Where(
@@ -51,8 +50,6 @@ namespace OptimizelySDK.Utils
             {
                 left.Add(kvp.Key, kvp.Value);
             }
-
-            return left;
         }
     }
 }


### PR DESCRIPTION
## Summary
- Validate SendOdpEvent empty action and type parameters
- Generate new idempotence_id for every OdpEvent

## Test plan
added tests to:
- OdpEventManagerTests.cs
- OptimizelyTest.cs

## Ticket
[FSSDK-9079](https://jira.sso.episerver.net/browse/FSSDK-9079)