### PR TITLE
[FSSDK-9128] fix: Handle ODP INVALID_IDENTIFIER_EXCEPTION code

### DIFF
--- a/OptimizelySDK.Tests/OdpTests/OdpSegmentApiManagerTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpSegmentApiManagerTest.cs
@@ -147,7 +147,7 @@ namespace OptimizelySDK.Tests.OdpTests
                 response.Errors[0].Extensions.Code
             );
         }
-        
+
         [Test]
         public void ShouldParseOnlyFirstErrorInvalidIdentifierExceptionResponse()
         {
@@ -204,9 +204,11 @@ namespace OptimizelySDK.Tests.OdpTests
 
 
             Assert.IsNull(segments);
-            _mockLogger.Verify(l=>l.Log(LogLevel.WARN, "Audience segments fetch failed (invalid identifier)"), Times.Once);
+            _mockLogger.Verify(
+                l => l.Log(LogLevel.WARN, "Audience segments fetch failed (invalid identifier)"),
+                Times.Once);
         }
-        
+
         [Test]
         public void ShouldParseOnlyFirstErrorThatOdpThrowsAtUsResponse()
         {
@@ -263,7 +265,10 @@ namespace OptimizelySDK.Tests.OdpTests
 
 
             Assert.IsNull(segments);
-            _mockLogger.Verify(l=>l.Log(LogLevel.ERROR, "Audience segments fetch failed (Exception while fetching data (/chairs) : Exception: could not the chair = musical)"), Times.Once);
+            _mockLogger.Verify(
+                l => l.Log(LogLevel.ERROR,
+                    "Audience segments fetch failed (Exception while fetching data (/chairs) : Exception: could not the chair = musical)"),
+                Times.Once);
         }
 
         [Test]

--- a/OptimizelySDK.Tests/OdpTests/OdpSegmentApiManagerTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpSegmentApiManagerTest.cs
@@ -113,35 +113,39 @@ namespace OptimizelySDK.Tests.OdpTests
         public void ShouldParseErrorResponse()
         {
             const string RESPONSE_JSON = @"
-{
-   ""errors"": [
-        {
-            ""message"": ""Exception while fetching data (/customer) : Exception: could not resolve _fs_user_id = not-real-user-id"",
-            ""locations"": [
-                {
-                    ""line"": 2,
-                    ""column"": 3
+            {
+               ""errors"": [
+                    {
+                        ""message"": ""Exception while fetching data (/customer) : Exception: could not resolve _fs_user_id = not-real-user-id"",
+                        ""locations"": [
+                            {
+                                ""line"": 2,
+                                ""column"": 3
+                            }
+                        ],
+                        ""path"": [
+                            ""customer""
+                        ],
+                        ""extensions"": {
+                            ""code"": ""INVALID_IDENTIFIER_EXCEPTION"",
+                            ""classification"": ""DataFetchingException""
+                        }
+                    }
+                ],
+                ""data"": {
+                    ""customer"": null
                 }
-            ],
-            ""path"": [
-                ""customer""
-            ],
-            ""extensions"": {
-                ""classification"": ""InvalidIdentifierException""
-            }
-        }
-    ],
-    ""data"": {
-        ""customer"": null
-    }
-}";
+            }";
 
             var response = new OdpSegmentApiManager().DeserializeSegmentsFromJson(RESPONSE_JSON);
 
             Assert.IsNull(response.Data.Customer);
             Assert.IsNotNull(response.Errors);
-            Assert.AreEqual(response.Errors[0].Extensions.Classification,
-                "InvalidIdentifierException");
+            Assert.AreEqual("DataFetchingException",
+                response.Errors[0].Extensions.Classification);
+            Assert.AreEqual("INVALID_IDENTIFIER_EXCEPTION",
+                response.Errors[0].Extensions.Code
+            );
         }
 
         [Test]

--- a/OptimizelySDK/Odp/Entity/Extension.cs
+++ b/OptimizelySDK/Odp/Entity/Extension.cs
@@ -1,5 +1,5 @@
 ﻿/* 
- * Copyright 2022 Optimizely
+ * Copyright 2022-2023 Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,5 +25,10 @@ namespace OptimizelySDK.Odp.Entity
         /// Named exception type from the error
         /// </summary>
         public string Classification { get; set; }
+
+        /// <summary>
+        /// Code of exception
+        /// </summary>
+        public string Code { get; set; }
     }
 }

--- a/OptimizelySDK/Odp/OdpSegmentApiManager.cs
+++ b/OptimizelySDK/Odp/OdpSegmentApiManager.cs
@@ -118,14 +118,15 @@ namespace OptimizelySDK.Odp
             if (segments.HasErrors)
             {
                 var firstError = segments.Errors.First();
-                if (firstError.Extensions.Code == "INVALID_IDENTIFIER_EXCEPTION")
+                if (firstError.Extensions?.Code == "INVALID_IDENTIFIER_EXCEPTION")
                 {
                     var message = $"{AUDIENCE_FETCH_FAILURE_MESSAGE} (invalid identifier)";
                     _logger.Log(LogLevel.WARN, message);
                 }
                 else
                 {
-                    _logger.Log(LogLevel.ERROR, $"{AUDIENCE_FETCH_FAILURE_MESSAGE} ({firstError})");
+                    var errorMessage = firstError.Extensions?.Classification ?? "decode error";
+                    _logger.Log(LogLevel.ERROR, $"{AUDIENCE_FETCH_FAILURE_MESSAGE} ({errorMessage})");
                 }
 
                 return null;

--- a/OptimizelySDK/Odp/OdpSegmentApiManager.cs
+++ b/OptimizelySDK/Odp/OdpSegmentApiManager.cs
@@ -117,9 +117,16 @@ namespace OptimizelySDK.Odp
 
             if (segments.HasErrors)
             {
-                var errors = string.Join(";", segments.Errors.Select(e => e.ToString()));
-
-                _logger.Log(LogLevel.ERROR, $"{AUDIENCE_FETCH_FAILURE_MESSAGE} ({errors})");
+                var firstError = segments.Errors.First();
+                if (firstError.Extensions.Code == "INVALID_IDENTIFIER_EXCEPTION")
+                {
+                    var message = $"{AUDIENCE_FETCH_FAILURE_MESSAGE} (invalid identifier)";
+                    _logger.Log(LogLevel.WARN, message);
+                }
+                else
+                {
+                    _logger.Log(LogLevel.ERROR, $"{AUDIENCE_FETCH_FAILURE_MESSAGE} ({firstError})");
+                }
 
                 return null;
             }
@@ -131,10 +138,10 @@ namespace OptimizelySDK.Odp
                 return null;
             }
 
-            return segments.Data.Customer.Audiences.Edges.
-                Where(e => e.Node.State == BaseCondition.QUALIFIED).
-                Select(e => e.Node.Name).
-                ToArray();
+            return segments.Data.Customer.Audiences.Edges
+                .Where(e => e.Node.State == BaseCondition.QUALIFIED)
+                .Select(e => e.Node.Name)
+                .ToArray();
         }
 
         /// <summary>
@@ -155,9 +162,9 @@ namespace OptimizelySDK.Odp
                         ""userId"": ""{userValue}"",
                         ""audiences"": {audiences}
                     }
-                }".Replace("{userKey}", userKey).
-                    Replace("{userValue}", userValue).
-                    Replace("{audiences}", JsonConvert.SerializeObject(segmentsToCheck));
+                }".Replace("{userKey}", userKey)
+                    .Replace("{userValue}", userValue)
+                    .Replace("{audiences}", JsonConvert.SerializeObject(segmentsToCheck));
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Support a new format for ODP `InvalidIdentifierException` (when SDK fetches segments with a non-registered userId).

```
       "extensions": {
            "code": "INVALID_IDENTIFIER_EXCEPTION",
            "classification": "DataFetchingException"
       }
```

## Test plan
- Added unit tests to cover the new response format.
- Existing unit tests should pass
- FSC should continue to pass

## Issues
- FSSDK-9128