### PR TITLE
[FSSDK-9538] bug: Fix last modified formatting

### DIFF
--- a/OptimizelySDK.Tests/ConfigTest/HttpProjectConfigManagerTest.cs
+++ b/OptimizelySDK.Tests/ConfigTest/HttpProjectConfigManagerTest.cs
@@ -36,9 +36,11 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
 
         private Mock<TestNotificationCallbacks> NotificationCallbackMock =
             new Mock<TestNotificationCallbacks>();
-        
+
         private const string ExpectedRfc1123DateTime = "Thu, 03 Nov 2022 16:00:00 GMT";
-        private readonly DateTime _pastLastModified = new DateTimeOffset(new DateTime(2022, 11, 3, 16, 0, 0, DateTimeKind.Utc)).UtcDateTime;
+
+        private readonly DateTime _pastLastModified =
+            new DateTimeOffset(new DateTime(2022, 11, 3, 16, 0, 0, DateTimeKind.Utc)).UtcDateTime;
 
         [SetUp]
         public void Setup()
@@ -120,10 +122,12 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
             HttpClientMock.Verify(_ => _.SendAsync(
                 It.Is<HttpRequestMessage>(requestMessage =>
                     requestMessage.Headers.IfModifiedSince.HasValue &&
-                    requestMessage.Headers.IfModifiedSince.Value.UtcDateTime.ToString("r") == ExpectedRfc1123DateTime
+                    requestMessage.Headers.IfModifiedSince.Value.UtcDateTime.ToString("r") ==
+                    ExpectedRfc1123DateTime
                 )), Times.Once);
             LoggerMock.Verify(
-                _ => _.Log(LogLevel.DEBUG, $"Set If-Modified-Since in request header: {ExpectedRfc1123DateTime}"),
+                _ => _.Log(LogLevel.DEBUG,
+                    $"Set If-Modified-Since in request header: {ExpectedRfc1123DateTime}"),
                 Times.AtLeastOnce);
 
             httpManager.Dispose();
@@ -147,9 +151,10 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
                 .WithBlockingTimeoutPeriod(TimeSpan.FromMilliseconds(500))
                 .WithStartByDefault()
                 .Build();
-            
+
             LoggerMock.Verify(
-                _ => _.Log(LogLevel.DEBUG, $"Set LastModifiedSince from response header: {ExpectedRfc1123DateTime}"),
+                _ => _.Log(LogLevel.DEBUG,
+                    $"Set LastModifiedSince from response header: {ExpectedRfc1123DateTime}"),
                 Times.AtLeastOnce);
 
             httpManager.Dispose();

--- a/OptimizelySDK/Config/HttpProjectConfigManager.cs
+++ b/OptimizelySDK/Config/HttpProjectConfigManager.cs
@@ -119,7 +119,7 @@ namespace OptimizelySDK.Config
             if (!string.IsNullOrEmpty(LastModifiedSince))
             {
                 request.Headers.Add("If-Modified-Since", LastModifiedSince);
-                Logger.Log(LogLevel.DEBUG, $"Set If-Modified-Since in request header.");
+                Logger.Log(LogLevel.DEBUG, $"Set If-Modified-Since in request header: {LastModifiedSince}");
             }
 
             if (!string.IsNullOrEmpty(DatafileAccessToken))
@@ -149,8 +149,8 @@ namespace OptimizelySDK.Config
             // Update Last-Modified header if provided.
             if (result.Content.Headers.LastModified.HasValue)
             {
-                LastModifiedSince = result.Content.Headers.LastModified.ToString();
-                Logger.Log(LogLevel.DEBUG, $"Set LastModifiedSince from response header.");
+                LastModifiedSince = result.Content.Headers.LastModified?.UtcDateTime.ToString("r");
+                Logger.Log(LogLevel.DEBUG, $"Set LastModifiedSince from response header: {LastModifiedSince}");
             }
 
             var content = result.Content.ReadAsStringAsync();

--- a/OptimizelySDK/Config/HttpProjectConfigManager.cs
+++ b/OptimizelySDK/Config/HttpProjectConfigManager.cs
@@ -119,7 +119,8 @@ namespace OptimizelySDK.Config
             if (!string.IsNullOrEmpty(LastModifiedSince))
             {
                 request.Headers.Add("If-Modified-Since", LastModifiedSince);
-                Logger.Log(LogLevel.DEBUG, $"Set If-Modified-Since in request header: {LastModifiedSince}");
+                Logger.Log(LogLevel.DEBUG,
+                    $"Set If-Modified-Since in request header: {LastModifiedSince}");
             }
 
             if (!string.IsNullOrEmpty(DatafileAccessToken))
@@ -150,7 +151,8 @@ namespace OptimizelySDK.Config
             if (result.Content.Headers.LastModified.HasValue)
             {
                 LastModifiedSince = result.Content.Headers.LastModified?.UtcDateTime.ToString("r");
-                Logger.Log(LogLevel.DEBUG, $"Set LastModifiedSince from response header: {LastModifiedSince}");
+                Logger.Log(LogLevel.DEBUG,
+                    $"Set LastModifiedSince from response header: {LastModifiedSince}");
             }
 
             var content = result.Content.ReadAsStringAsync();


### PR DESCRIPTION
## Summary
- Last-Modified was not following the RFC 1123 spec for date and time formatting
- Relates to #360 

## Test plan
- Updated existing unit tests to look for correct formatting
- All other existing tests should continue to pass.

## Issues
- FSSDK-9538