### PR TITLE
[FSSDK-9533] Log error & reject on track event with null, empty or whitespace event key

### DIFF
--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -5673,7 +5673,7 @@ namespace OptimizelySDK.Tests
                 "Event key cannot be null, empty, or whitespace string. Failing 'Track'.";
             const string GOOD_USER = "test_user";
             const string EXPECTED_USER_ID_ERROR_MESSAGE = "Provided User Id is in invalid format.";
-
+            
             Optimizely.Track(GOOD_EVENT_KEY, GOOD_USER);
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, EXPECTED_USER_ID_ERROR_MESSAGE),
                 Times.Never);
@@ -5681,25 +5681,25 @@ namespace OptimizelySDK.Tests
                 l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
                 Times.Never);
             LoggerMock.ResetCalls();
-
+            
             Optimizely.Track("", GOOD_USER);
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
                 Times.Once);
             LoggerMock.ResetCalls();
-
+            
             Optimizely.Track("    ", GOOD_USER);
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
                 Times.Once);
             LoggerMock.ResetCalls();
-
+            
             Optimizely.Track(null, GOOD_USER);
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
                 Times.Once);
             LoggerMock.ResetCalls();
-
+            
             Optimizely.Track(GOOD_EVENT_KEY, null);
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, EXPECTED_USER_ID_ERROR_MESSAGE),
                 Times.Once);

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -5669,33 +5669,39 @@ namespace OptimizelySDK.Tests
         public void TestTrackValidateInputValues()
         {
             const string GOOD_EVENT_KEY = "purchase";
+            const string EXPECTED_EVENT_KEY_ERROR_MESSAGE =
+                "Event key cannot be null, empty, or whitespace string. Failing 'Track'.";
             const string GOOD_USER = "test_user";
+            const string EXPECTED_USER_ID_ERROR_MESSAGE = "Provided User Id is in invalid format.";
             
-            // Verify that ValidateStringInputs does not log error for valid values.
             Optimizely.Track(GOOD_EVENT_KEY, GOOD_USER);
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Provided User Id is in invalid format."),
+            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, EXPECTED_USER_ID_ERROR_MESSAGE),
                 Times.Never);
             LoggerMock.Verify(
-                l => l.Log(LogLevel.ERROR, "Event key cannot be null or empty string. Failing 'Track'."),
+                l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
                 Times.Never);
+            LoggerMock.ResetCalls();
 
-            // Verify logs error for invalid empty string event key.
-            Optimizely.Track(GOOD_EVENT_KEY, GOOD_USER);
+            Optimizely.Track("", GOOD_USER);
             LoggerMock.Verify(
-                l => l.Log(LogLevel.ERROR,
-                    "Event key cannot be null, empty or whitespace string. Failing 'Track'."),
+                l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
                 Times.Once);
+            LoggerMock.ResetCalls();
 
-            // Verify logs error for invalid whitespace string event key.
             Optimizely.Track("    ", GOOD_USER);
             LoggerMock.Verify(
-                l => l.Log(LogLevel.ERROR,
-                    "Event key cannot be null, empty or whitespace string. Failing 'Track'."),
+                l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
                 Times.Once);
+            LoggerMock.ResetCalls();
             
-            // Verify that ValidateStringInputs logs error for invalid user id.
+            Optimizely.Track(null, GOOD_USER);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
+                Times.Once);
+            LoggerMock.ResetCalls();
+            
             Optimizely.Track(GOOD_EVENT_KEY, null);
-            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Provided User Id is in invalid format."),
+            LoggerMock.Verify(l => l.Log(LogLevel.ERROR, EXPECTED_USER_ID_ERROR_MESSAGE),
                 Times.Once);
         }
 

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -5673,7 +5673,7 @@ namespace OptimizelySDK.Tests
                 "Event key cannot be null, empty, or whitespace string. Failing 'Track'.";
             const string GOOD_USER = "test_user";
             const string EXPECTED_USER_ID_ERROR_MESSAGE = "Provided User Id is in invalid format.";
-            
+
             Optimizely.Track(GOOD_EVENT_KEY, GOOD_USER);
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, EXPECTED_USER_ID_ERROR_MESSAGE),
                 Times.Never);
@@ -5693,13 +5693,13 @@ namespace OptimizelySDK.Tests
                 l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
                 Times.Once);
             LoggerMock.ResetCalls();
-            
+
             Optimizely.Track(null, GOOD_USER);
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
                 Times.Once);
             LoggerMock.ResetCalls();
-            
+
             Optimizely.Track(GOOD_EVENT_KEY, null);
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, EXPECTED_USER_ID_ERROR_MESSAGE),
                 Times.Once);

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -5668,23 +5668,33 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestTrackValidateInputValues()
         {
+            const string GOOD_EVENT_KEY = "purchase";
+            const string GOOD_USER = "test_user";
+            
             // Verify that ValidateStringInputs does not log error for valid values.
-            Optimizely.Track("purchase", "test_user");
+            Optimizely.Track(GOOD_EVENT_KEY, GOOD_USER);
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Provided User Id is in invalid format."),
                 Times.Never);
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, "Event key cannot be null or empty string. Failing 'Track'."),
                 Times.Never);
 
-            // Verify that ValidateStringInputs logs error for invalid event key.
-            Optimizely.Track("", "test_user");
+            // Verify logs error for invalid empty string event key.
+            Optimizely.Track(GOOD_EVENT_KEY, GOOD_USER);
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR,
-                    "Event key cannot be null or empty string. Failing 'Track'."),
+                    "Event key cannot be null, empty or whitespace string. Failing 'Track'."),
+                Times.Once);
+
+            // Verify logs error for invalid whitespace string event key.
+            Optimizely.Track("    ", GOOD_USER);
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.ERROR,
+                    "Event key cannot be null, empty or whitespace string. Failing 'Track'."),
                 Times.Once);
             
             // Verify that ValidateStringInputs logs error for invalid user id.
-            Optimizely.Track("purchase", null);
+            Optimizely.Track(GOOD_EVENT_KEY, null);
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Provided User Id is in invalid format."),
                 Times.Once);
         }

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -624,7 +624,7 @@ namespace OptimizelySDK.Tests
                 Times.Once);
             LoggerMock.Verify(
                 log => log.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'Track'."),
-                Times.Once);
+                Times.Never); // Erroring on null or empty event key takes priority over invalid datafile.
             LoggerMock.Verify(
                 log => log.Log(LogLevel.ERROR,
                     "Datafile has invalid format. Failing 'IsFeatureEnabled'."), Times.Once);
@@ -5673,15 +5673,20 @@ namespace OptimizelySDK.Tests
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Provided User Id is in invalid format."),
                 Times.Never);
             LoggerMock.Verify(
-                l => l.Log(LogLevel.ERROR, "Provided Event Key is in invalid format."),
+                l => l.Log(LogLevel.ERROR, "Event key cannot be null or empty string. Failing 'Track'."),
                 Times.Never);
 
-            // Verify that ValidateStringInputs logs error for invalid values.
-            Optimizely.Track("", null);
+            // Verify that ValidateStringInputs logs error for invalid event key.
+            Optimizely.Track("", "test_user");
+            LoggerMock.Verify(
+                l => l.Log(LogLevel.ERROR,
+                    "Event key cannot be null or empty string. Failing 'Track'."),
+                Times.Once);
+            
+            // Verify that ValidateStringInputs logs error for invalid user id.
+            Optimizely.Track("purchase", null);
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, "Provided User Id is in invalid format."),
                 Times.Once);
-            LoggerMock.Verify(
-                l => l.Log(LogLevel.ERROR, "Provided Event Key is in invalid format."), Times.Once);
         }
 
         #endregion Test ValidateStringInputs
@@ -6139,8 +6144,10 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestSendOdpEventNullAction()
         {
-            var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object, odpManager: OdpManagerMock.Object);
-            optly.SendOdpEvent(action: null, identifiers: new Dictionary<string, string>(), type: "type");
+            var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object,
+                odpManager: OdpManagerMock.Object);
+            optly.SendOdpEvent(action: null, identifiers: new Dictionary<string, string>(),
+                type: "type");
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, Constants.ODP_INVALID_ACTION_MESSAGE),
                 Times.Exactly(1));
 
@@ -6151,7 +6158,8 @@ namespace OptimizelySDK.Tests
         public void TestSendOdpEventInvalidOptimizelyObject()
         {
             var optly = new Optimizely("Random datafile", null, LoggerMock.Object);
-            optly.SendOdpEvent("some_action", new Dictionary<string, string>() { { "some_key", "some_value" } }, "some_event");
+            optly.SendOdpEvent("some_action",
+                new Dictionary<string, string>() { { "some_key", "some_value" } }, "some_event");
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'SendOdpEvent'."),
                 Times.Once);
@@ -6160,8 +6168,10 @@ namespace OptimizelySDK.Tests
         [Test]
         public void TestSendOdpEventEmptyStringAction()
         {
-            var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object, odpManager: OdpManagerMock.Object);
-            optly.SendOdpEvent(action: "", identifiers: new Dictionary<string, string>(), type: "type");
+            var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object,
+                odpManager: OdpManagerMock.Object);
+            optly.SendOdpEvent(action: "", identifiers: new Dictionary<string, string>(),
+                type: "type");
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, Constants.ODP_INVALID_ACTION_MESSAGE),
                 Times.Exactly(1));
 
@@ -6172,7 +6182,8 @@ namespace OptimizelySDK.Tests
         public void TestSendOdpEventNullType()
         {
             var identifiers = new Dictionary<string, string>();
-            var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object, odpManager: OdpManagerMock.Object);
+            var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object,
+                odpManager: OdpManagerMock.Object);
 
             optly.SendOdpEvent(action: "action", identifiers: identifiers, type: null);
 
@@ -6188,7 +6199,8 @@ namespace OptimizelySDK.Tests
         public void TestSendOdpEventEmptyStringType()
         {
             var identifiers = new Dictionary<string, string>();
-            var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object, odpManager: OdpManagerMock.Object);
+            var optly = new Optimizely(TestData.OdpIntegrationDatafile, logger: LoggerMock.Object,
+                odpManager: OdpManagerMock.Object);
 
             optly.SendOdpEvent(action: "action", identifiers: identifiers, type: "");
 
@@ -6210,7 +6222,8 @@ namespace OptimizelySDK.Tests
             var optly = new Optimizely("Random datafile", null, LoggerMock.Object);
             optly.FetchQualifiedSegments("some_user", null);
             LoggerMock.Verify(
-                l => l.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'FetchQualifiedSegments'."),
+                l => l.Log(LogLevel.ERROR,
+                    "Datafile has invalid format. Failing 'FetchQualifiedSegments'."),
                 Times.Once);
         }
 

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -5673,7 +5673,7 @@ namespace OptimizelySDK.Tests
                 "Event key cannot be null, empty, or whitespace string. Failing 'Track'.";
             const string GOOD_USER = "test_user";
             const string EXPECTED_USER_ID_ERROR_MESSAGE = "Provided User Id is in invalid format.";
-            
+
             Optimizely.Track(GOOD_EVENT_KEY, GOOD_USER);
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, EXPECTED_USER_ID_ERROR_MESSAGE),
                 Times.Never);
@@ -5681,25 +5681,25 @@ namespace OptimizelySDK.Tests
                 l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
                 Times.Never);
             LoggerMock.ResetCalls();
-            
+
             Optimizely.Track("", GOOD_USER);
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
                 Times.Once);
             LoggerMock.ResetCalls();
-            
+
             Optimizely.Track("    ", GOOD_USER);
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
                 Times.Once);
             LoggerMock.ResetCalls();
-            
+
             Optimizely.Track(null, GOOD_USER);
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, EXPECTED_EVENT_KEY_ERROR_MESSAGE),
                 Times.Once);
             LoggerMock.ResetCalls();
-            
+
             Optimizely.Track(GOOD_EVENT_KEY, null);
             LoggerMock.Verify(l => l.Log(LogLevel.ERROR, EXPECTED_USER_ID_ERROR_MESSAGE),
                 Times.Once);

--- a/OptimizelySDK/Config/HttpProjectConfigManager.cs
+++ b/OptimizelySDK/Config/HttpProjectConfigManager.cs
@@ -19,6 +19,7 @@
 #endif
 
 using System;
+using System.Linq;
 using System.Net;
 using System.Threading.Tasks;
 using OptimizelySDK.ErrorHandler;

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -338,7 +338,7 @@ namespace OptimizelySDK
         /// <summary>
         /// Sends conversion event to Optimizely.
         /// </summary>
-        /// <param name="eventKey">Event key representing the event which needs to be recorded</param>
+        /// <param name="eventKey">Event key representing the event (must not be null or empty)</param>
         /// <param name="userId">ID for user</param>
         /// <param name="userAttributes">Attributes of the user</param>
         /// <param name="eventTags">eventTags array Hash representing metadata associated with the event.</param>

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -87,7 +87,7 @@ namespace OptimizelySDK
         {
             get
             {
-                // Example output: "2.1.0" .  Should be kept in synch with NuGet package version.
+                // Example output: "2.1.0". Should be kept in sync with NuGet package version.
 #if NET35 || NET40
                 var assembly = Assembly.GetExecutingAssembly();
 #else
@@ -346,46 +346,52 @@ namespace OptimizelySDK
             EventTags eventTags = null
         )
         {
-            var config = ProjectConfigManager?.GetConfig();
-
-            if (config == null)
+            if (string.IsNullOrEmpty(eventKey))
             {
-                Logger.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'Track'.");
+                Logger.Log(LogLevel.ERROR,
+                    "Event key cannot be null or empty string. Failing 'Track'.");
                 return;
             }
 
             var inputValues = new Dictionary<string, string>
-                { { USER_ID, userId }, { EVENT_KEY, eventKey } };
+            {
+                { USER_ID, userId },
+                { EVENT_KEY, eventKey },
+            };
 
             if (!ValidateStringInputs(inputValues))
             {
                 return;
             }
 
-            var eevent = config.GetEvent(eventKey);
-
-            if (eevent.Key == null)
+            var config = ProjectConfigManager?.GetConfig();
+            if (config == null)
             {
-                Logger.Log(LogLevel.INFO,
-                    string.Format("Not tracking user {0} for event {1}.", userId, eventKey));
+                Logger.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'Track'.");
                 return;
             }
 
-            if (eventTags != null)
+            var eventToTrack = config.GetEvent(eventKey);
+            if (eventToTrack.Key == null)
             {
-                eventTags = eventTags.FilterNullValues(Logger);
+                Logger.Log(LogLevel.INFO, $"Not tracking user {userId} for event {eventKey}.");
+                return;
             }
+
+            eventTags = eventTags?.FilterNullValues(Logger);
 
             var userEvent = UserEventFactory.CreateConversionEvent(config, eventKey, userId,
                 userAttributes, eventTags);
+
             EventProcessor.Process(userEvent);
-            Logger.Log(LogLevel.INFO,
-                string.Format("Tracking event {0} for user {1}.", eventKey, userId));
+
+            Logger.Log(LogLevel.INFO, $"Tracking event {eventKey} for user {userId}.");
 
             if (NotificationCenter.GetNotificationCount(NotificationCenter.NotificationType.Track) >
                 0)
             {
                 var conversionEvent = EventFactory.CreateLogEvent(userEvent, Logger);
+
                 NotificationCenter.SendNotifications(NotificationCenter.NotificationType.Track,
                     eventKey, userId,
                     userAttributes, eventTags, conversionEvent);
@@ -1347,7 +1353,8 @@ namespace OptimizelySDK
 
             if (config == null)
             {
-                Logger.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'FetchQualifiedSegments'.");
+                Logger.Log(LogLevel.ERROR,
+                    "Datafile has invalid format. Failing 'FetchQualifiedSegments'.");
                 return null;
             }
 
@@ -1378,7 +1385,8 @@ namespace OptimizelySDK
         /// <param name="identifiers">Dictionary for identifiers. The caller must provide at least one key-value pair.</param>
         /// <param name="type">Type of event (defaults to `fullstack`)</param>
         /// <param name="data">Optional event data in a key-value pair format</param>
-        public void SendOdpEvent(string action, Dictionary<string, string> identifiers, string type = Constants.ODP_EVENT_TYPE,
+        public void SendOdpEvent(string action, Dictionary<string, string> identifiers, string type
+                = Constants.ODP_EVENT_TYPE,
             Dictionary<string, object> data = null
         )
         {

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -349,7 +349,7 @@ namespace OptimizelySDK
             if (string.IsNullOrWhiteSpace(eventKey))
             {
                 Logger.Log(LogLevel.ERROR,
-                    "Event key cannot be null or empty string. Failing 'Track'.");
+                    "Event key cannot be null, empty or whitespace string. Failing 'Track'.");
                 return;
             }
 

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -346,7 +346,7 @@ namespace OptimizelySDK
             EventTags eventTags = null
         )
         {
-            if (string.IsNullOrEmpty(eventKey))
+            if (string.IsNullOrWhiteSpace(eventKey))
             {
                 Logger.Log(LogLevel.ERROR,
                     "Event key cannot be null or empty string. Failing 'Track'.");

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -35,6 +35,7 @@ using OptimizelySDK.Event;
 using OptimizelySDK.OptlyConfig;
 using OptimizelySDK.OptimizelyDecisions;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 #if USE_ODP
 using OptimizelySDK.Odp;
@@ -346,7 +347,7 @@ namespace OptimizelySDK
             EventTags eventTags = null
         )
         {
-            if (string.IsNullOrWhiteSpace(eventKey))
+            if (eventKey == null || Regex.IsMatch(eventKey, @"^\s*$"))
             {
                 Logger.Log(LogLevel.ERROR,
                     "Event key cannot be null, empty, or whitespace string. Failing 'Track'.");

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -349,7 +349,7 @@ namespace OptimizelySDK
             if (string.IsNullOrWhiteSpace(eventKey))
             {
                 Logger.Log(LogLevel.ERROR,
-                    "Event key cannot be null, empty or whitespace string. Failing 'Track'.");
+                    "Event key cannot be null, empty, or whitespace string. Failing 'Track'.");
                 return;
             }
 

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -338,7 +338,7 @@ namespace OptimizelySDK
         /// <summary>
         /// Sends conversion event to Optimizely.
         /// </summary>
-        /// <param name="eventKey">Event key representing the event (must not be null or empty)</param>
+        /// <param name="eventKey">Event key representing the event (must not be null, empty, or whitespace)</param>
         /// <param name="userId">ID for user</param>
         /// <param name="userAttributes">Attributes of the user</param>
         /// <param name="eventTags">eventTags array Hash representing metadata associated with the event.</param>

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -348,7 +348,7 @@ namespace OptimizelySDK
         /// <summary>
         /// Track an event.
         /// </summary>
-        /// <param name="eventName">The event name (must not be null or empty).</param>
+        /// <param name="eventName">The event name (must not be null, empty, or whitespace).</param>
         public virtual void TrackEvent(string eventName)
         {
             TrackEvent(eventName, new EventTags());
@@ -357,7 +357,7 @@ namespace OptimizelySDK
         /// <summary>
         /// Track an event.
         /// </summary>
-        /// <param name="eventName">The event name (must not be null or empty).</param>
+        /// <param name="eventName">The event name (must not be null, empty, or whitespace).</param>
         /// <param name="eventTags">A map of event tag names to event tag values.</param>
         public virtual void TrackEvent(string eventName,
             EventTags eventTags

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -348,7 +348,7 @@ namespace OptimizelySDK
         /// <summary>
         /// Track an event.
         /// </summary>
-        /// <param name="eventName">The event name.</param>
+        /// <param name="eventName">The event name (must not be null or empty).</param>
         public virtual void TrackEvent(string eventName)
         {
             TrackEvent(eventName, new EventTags());
@@ -357,7 +357,7 @@ namespace OptimizelySDK
         /// <summary>
         /// Track an event.
         /// </summary>
-        /// <param name="eventName">The event name.</param>
+        /// <param name="eventName">The event name (must not be null or empty).</param>
         /// <param name="eventTags">A map of event tag names to event tag values.</param>
         public virtual void TrackEvent(string eventName,
             EventTags eventTags


### PR DESCRIPTION
## Summary
- Prevent track events from being sent without a name/key 
- Update method docs to highlight that this param must not be whitespace, null, or empty string values

## Test plan
- Updated existing tests to check for invalid event keys
- All other existing tests should also pass

## Issues
- FSSDK-9533