### PR TITLE
[FSSDK-9526] refact: Implements a warning log for polling interval less than 30s

### DIFF
--- a/OptimizelySDK.Tests/ConfigTest/PollingProjectConfigManagerTest.cs
+++ b/OptimizelySDK.Tests/ConfigTest/PollingProjectConfigManagerTest.cs
@@ -140,6 +140,26 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         }
 
         [Test]
+        public void TestWarnLogIfPollingTimeIsLessThanThirty()
+        {
+            // period to call is 29 milliseconds
+            var configManager = new TestPollingProjectConfigManager(TimeSpan.FromMilliseconds(29),
+                TimeSpan.FromMilliseconds(20), true, LoggerMock.Object, new int[] { });
+            LoggerMock.Verify(l => l.Log(LogLevel.WARN,
+                "Polling intervals below 30 seconds are not recommended."), Times.Once);
+        }
+
+        [Test]
+        public void TestWarnLogNotTriggeredIfPollingTimeIsGreaterThanThirty()
+        {
+            // period to call is 32 second
+            var configManager = new TestPollingProjectConfigManager(TimeSpan.FromSeconds(32),
+                TimeSpan.FromMilliseconds(31), true, LoggerMock.Object, new int[] { });
+            LoggerMock.Verify(l => l.Log(LogLevel.WARN,
+                "Polling intervals below 30 seconds are not recommended."), Times.Once);
+        }
+
+        [Test]
         public void TestDontTimedoutIfSchedulerNotStarted()
         {
             // period to call is 3 second

--- a/OptimizelySDK.Tests/ConfigTest/PollingProjectConfigManagerTest.cs
+++ b/OptimizelySDK.Tests/ConfigTest/PollingProjectConfigManagerTest.cs
@@ -142,21 +142,20 @@ namespace OptimizelySDK.Tests.DatafileManagement_Tests
         [Test]
         public void TestWarnLogIfPollingTimeIsLessThanThirty()
         {
-            // period to call is 29 milliseconds
-            var configManager = new TestPollingProjectConfigManager(TimeSpan.FromMilliseconds(29),
-                TimeSpan.FromMilliseconds(20), true, LoggerMock.Object, new int[] { });
+            var below30Seconds = TimeSpan.FromSeconds(29);
+            _ = new TestPollingProjectConfigManager(below30Seconds,
+                TimeSpan.FromSeconds(10), true, LoggerMock.Object, new int[] { });
             LoggerMock.Verify(l => l.Log(LogLevel.WARN,
                 "Polling intervals below 30 seconds are not recommended."), Times.Once);
         }
-
         [Test]
         public void TestWarnLogNotTriggeredIfPollingTimeIsGreaterThanThirty()
         {
-            // period to call is 32 second
-            var configManager = new TestPollingProjectConfigManager(TimeSpan.FromSeconds(32),
-                TimeSpan.FromMilliseconds(31), true, LoggerMock.Object, new int[] { });
+            var above30Seconds = TimeSpan.FromMinutes(1);
+            _ = new TestPollingProjectConfigManager(above30Seconds,
+                TimeSpan.FromMilliseconds(10), true, LoggerMock.Object, new int[] { });
             LoggerMock.Verify(l => l.Log(LogLevel.WARN,
-                "Polling intervals below 30 seconds are not recommended."), Times.Once);
+                "Polling intervals below 30 seconds are not recommended."), Times.Never);
         }
 
         [Test]

--- a/OptimizelySDK/Config/PollingProjectConfigManager.cs
+++ b/OptimizelySDK/Config/PollingProjectConfigManager.cs
@@ -65,7 +65,7 @@ namespace OptimizelySDK.Config
             Logger = logger;
             ErrorHandler = errorHandler;
             BlockingTimeout = blockingTimeout;
-            if (period.Seconds < 30) 
+            if (period.Seconds < 30)
             {
                 Logger?.Log(LogLevel.WARN, "Polling intervals below 30 seconds are not recommended.");
             }

--- a/OptimizelySDK/Config/PollingProjectConfigManager.cs
+++ b/OptimizelySDK/Config/PollingProjectConfigManager.cs
@@ -65,7 +65,7 @@ namespace OptimizelySDK.Config
             Logger = logger;
             ErrorHandler = errorHandler;
             BlockingTimeout = blockingTimeout;
-            if (period.Seconds < 30)
+            if (period.TotalSeconds < 30)
             {
                 Logger?.Log(LogLevel.WARN, "Polling intervals below 30 seconds are not recommended.");
             }

--- a/OptimizelySDK/Config/PollingProjectConfigManager.cs
+++ b/OptimizelySDK/Config/PollingProjectConfigManager.cs
@@ -65,6 +65,10 @@ namespace OptimizelySDK.Config
             Logger = logger;
             ErrorHandler = errorHandler;
             BlockingTimeout = blockingTimeout;
+            if (period.TotalMilliseconds < 30) 
+            {
+                Logger?.Log(LogLevel.WARN, "Polling intervals below 30 seconds are not recommended.");
+            }
             PollingInterval = period;
             AutoUpdate = autoUpdate;
 

--- a/OptimizelySDK/Config/PollingProjectConfigManager.cs
+++ b/OptimizelySDK/Config/PollingProjectConfigManager.cs
@@ -65,7 +65,7 @@ namespace OptimizelySDK.Config
             Logger = logger;
             ErrorHandler = errorHandler;
             BlockingTimeout = blockingTimeout;
-            if (period.TotalMilliseconds < 30) 
+            if (period.Seconds < 30) 
             {
                 Logger?.Log(LogLevel.WARN, "Polling intervals below 30 seconds are not recommended.");
             }


### PR DESCRIPTION
### Summary
-  Implements a warning log for polling interval less than 30s

## Issues
- [FSSDK-9526](https://jira.sso.episerver.net/browse/FSSDK-9526)