### PR TITLE
[FSSDK-9551] Add GitHub Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/BUG-REPORT.yml
@@ -1,0 +1,88 @@
+name: 🐞 Bug
+description: File a bug/issue
+title: "[BUG] <title>"
+labels: ["bug", "needs-triage"]
+body:
+- type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+- type: textarea
+  attributes:
+    label: SDK Version
+    description: Version of the SDK in use?
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Current Behavior
+    description: A concise description of what you're experiencing.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Expected Behavior
+    description: A concise description of what you expected to happen.
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: Steps To Reproduce
+    description: Steps to reproduce the behavior.
+    placeholder: |
+      1. In this environment...
+      1. With this config...
+      1. Run '...'
+      1. See error...
+  validations:
+    required: true
+- type: textarea
+  attributes:
+    label: .NET Version
+    description: What version of .NET are you using?
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Link
+    description: Link to code demonstrating the problem.
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Logs
+    description: Logs/stack traces related to the problem (⚠️do not include sensitive information).
+  validations:
+    required: false
+- type: dropdown
+  attributes:
+    label: Severity
+    description: What is the severity of the problem?
+    multiple: true
+    options:
+      - Blocking development
+      - Affecting users
+      - Minor issue
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Workaround/Solution
+    description: Do you have any workaround or solution in mind for the problem?
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: "Recent Change"
+    description: Has this issue started happening after an update or experiment change?
+  validations:
+    required: false
+- type: textarea
+  attributes:
+    label: Conflicts
+    description: Are there other libraries/dependencies potentially in conflict?
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/ENHANCEMENT.yml
+++ b/.github/ISSUE_TEMPLATE/ENHANCEMENT.yml
@@ -1,0 +1,45 @@
+name: ✨Enhancement
+description: Create a new ticket for a Enhancement/Tech-initiative for the benefit of the SDK which would be considered for a minor version update.
+title: "[ENHANCEMENT] <title>"
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: "Description"
+      description: Briefly describe the enhancement in a few sentences.
+      placeholder: Short description...
+    validations:
+      required: true
+  - type: textarea
+    id: benefits
+    attributes:
+      label: "Benefits"
+      description: How would the enhancement benefit to your product or usage?
+      placeholder: Benefits...
+    validations:
+      required: true
+  - type: textarea
+    id: detail
+    attributes:
+      label: "Detail"
+      description: How would you like the enhancement to work? Please provide as much detail as possible
+      placeholder: Detailed description...
+    validations:
+      required: false
+  - type: textarea
+    id: examples
+    attributes:
+      label: "Examples"
+      description: Are there any examples of this enhancement in other products/services? If so, please provide links or references.
+      placeholder: Links/References...
+    validations:
+      required: false
+  - type: textarea
+    id: risks
+    attributes:
+      label: "Risks/Downsides"
+      description: Do you think this enhancement could have any potential downsides or risks?
+      placeholder: Risks/Downsides...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.md
+++ b/.github/ISSUE_TEMPLATE/FEATURE-REQUEST.md
@@ -1,0 +1,4 @@
+<!--
+  Thanks for filing in issue! Are you requesting a new feature? If so, please share your feedback with us on the following link.
+-->
+## Feedback requesting a new feature can be shared [here.](https://feedback.optimizely.com/)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💡Feature Requests
+    url: https://feedback.optimizely.com/
+    about: Feedback requesting a new feature can be shared here.


### PR DESCRIPTION
## Summary
- Add GitHub issues templates

## Test plan
- Review via https://github.com/mikechu-optimizely/csharp-sdk/issues/new/choose
- No C# code changed.  Existing unit and e2e tests are expected to pass.

## Issues
- FSSDK-9551