### PR TITLE
[FSSDK-11837] legacy api adjustment with key null support in decide

### DIFF
--- a/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyUserContextTest.cs
@@ -406,6 +406,23 @@ namespace OptimizelySDK.Tests
         }
 
         [Test]
+        public void DecideNullFlagKey()
+        {
+            var user = Optimizely.CreateUserContext(UserID);
+            user.SetAttribute("browser_type", "chrome");
+
+            var decisionExpected = OptimizelyDecision.NewErrorDecision(
+                null,
+                user,
+                DecisionMessage.Reason(DecisionMessage.FLAG_KEY_INVALID, "null"),
+                ErrorHandlerMock.Object,
+                LoggerMock.Object);
+            var decision = user.Decide(null);
+
+            Assert.IsTrue(TestData.CompareObjects(decision, decisionExpected));
+        }
+
+        [Test]
         public void DecideWhenConfigIsNull()
         {
             var optimizely = new Optimizely(TestData.UnsupportedVersionDatafile,

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -870,6 +870,13 @@ namespace OptimizelySDK
                     ErrorHandler, Logger);
             }
 
+            if (key == null)
+            {
+                return OptimizelyDecision.NewErrorDecision(key, user,
+                    DecisionMessage.Reason(DecisionMessage.FLAG_KEY_INVALID, "null"),
+                    ErrorHandler, Logger);
+            }
+
             var allOptions = GetAllOptions(options).
                 Where(opt => opt != OptimizelyDecideOption.ENABLED_FLAGS_ONLY).
                 ToArray();
@@ -930,6 +937,7 @@ namespace OptimizelySDK
             foreach (var key in keys)
             {
                 var flag = projectConfig.GetFeatureFlagFromKey(key);
+
                 if (flag.Key == null)
                 {
                     decisionDictionary.Add(key,

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -937,7 +937,6 @@ namespace OptimizelySDK
             foreach (var key in keys)
             {
                 var flag = projectConfig.GetFeatureFlagFromKey(key);
-
                 if (flag.Key == null)
                 {
                     decisionDictionary.Add(key,


### PR DESCRIPTION
## Summary
This pull request adds a new validation for null flag keys in the decision logic, ensuring that passing a null flag key to the `Decide` method returns a proper error decision. It also introduces a corresponding unit test to verify this behavior.

**Error handling improvements:**

* Added a check in `Optimizely.cs` to return an error decision if the flag key passed to `Decide` is null, using a specific error message (`FLAG_KEY_INVALID`).

**Testing enhancements:**

* Added a new test, `DecideNullFlagKey`, in `OptimizelyUserContextTest.cs` to verify that passing a null flag key returns the expected error decision.
## Issues
[FSSDK-11837](https://jira.sso.episerver.net/browse/FSSDK-11837)