### PR TITLE
[FSSDK-11150] cmab client implementation

### DIFF
--- a/OptimizelySDK.NetStandard20/OptimizelySDK.NetStandard20.csproj
+++ b/OptimizelySDK.NetStandard20/OptimizelySDK.NetStandard20.csproj
@@ -181,6 +181,21 @@
     <Compile Include="..\OptimizelySDK\Entity\Cmab.cs">
       <Link>Entity\Cmab.cs</Link>
     </Compile>
+    <Compile Include="..\OptimizelySDK\Cmab\ICmabClient.cs">
+      <Link>Cmab\ICmabClient.cs</Link>
+    </Compile>
+    <Compile Include="..\OptimizelySDK\Cmab\DefaultCmabClient.cs">
+      <Link>Cmab\DefaultCmabClient.cs</Link>
+    </Compile>
+    <Compile Include="..\OptimizelySDK\Cmab\CmabRetryConfig.cs">
+      <Link>Cmab\CmabRetryConfig.cs</Link>
+    </Compile>
+    <Compile Include="..\OptimizelySDK\Cmab\CmabModels.cs">
+      <Link>Cmab\CmabModels.cs</Link>
+    </Compile>
+    <Compile Include="..\OptimizelySDK\Cmab\CmabConstants.cs">
+      <Link>Cmab\CmabConstants.cs</Link>
+    </Compile>
     <Compile Include="..\OptimizelySDK\Entity\Holdout.cs">
       <Link>Entity\Holdout.cs</Link>
     </Compile>

--- a/OptimizelySDK.Tests/CmabTests/DefaultCmabClientTest.cs
+++ b/OptimizelySDK.Tests/CmabTests/DefaultCmabClientTest.cs
@@ -1,0 +1,186 @@
+﻿/* 
+* Copyright 2025, Optimizely
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using NUnit.Framework;
+using OptimizelySDK.Cmab;
+using OptimizelySDK.ErrorHandler;
+using OptimizelySDK.Exceptions;
+using OptimizelySDK.Logger;
+
+namespace OptimizelySDK.Tests.CmabTests
+{
+    [TestFixture]
+    public class DefaultCmabClientTest
+    {
+        private class ResponseStep
+        {
+            public HttpStatusCode Status { get; private set; }
+            public string Body { get; private set; }
+            public ResponseStep(HttpStatusCode status, string body)
+            {
+                Status = status;
+                Body = body;
+            }
+        }
+
+        private static HttpClient MakeClient(params ResponseStep[] sequence)
+        {
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var queue = new Queue<ResponseStep>(sequence);
+
+            handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()).Returns((HttpRequestMessage _, CancellationToken __) =>
+            {
+                if (queue.Count == 0)
+                    throw new InvalidOperationException("No more mocked responses available.");
+
+                var step = queue.Dequeue();
+                var response = new HttpResponseMessage(step.Status);
+                if (step.Body != null)
+                {
+                    response.Content = new StringContent(step.Body);
+                }
+                return Task.FromResult(response);
+            });
+
+            return new HttpClient(handler.Object);
+        }
+
+        private static HttpClient MakeClientExceptionSequence(params Exception[] sequence)
+        {
+            var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+            var queue = new Queue<Exception>(sequence);
+
+            handler.Protected().Setup<Task<HttpResponseMessage>>("SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>()).Returns((HttpRequestMessage _, CancellationToken __) =>
+            {
+                if (queue.Count == 0)
+                    throw new InvalidOperationException("No more mocked exceptions available.");
+
+                var ex = queue.Dequeue();
+                var tcs = new TaskCompletionSource<HttpResponseMessage>();
+                tcs.SetException(ex);
+                return tcs.Task;
+            });
+
+            return new HttpClient(handler.Object);
+        }
+
+        private static string ValidBody(string variationId = "v1")
+            => $"{{\"predictions\":[{{\"variation_id\":\"{variationId}\"}}]}}";
+
+        [Test]
+        public void FetchDecisionReturnsSuccessNoRetry()
+        {
+            var http = MakeClient(new ResponseStep(HttpStatusCode.OK, ValidBody("v1")));
+            var client = new DefaultCmabClient(http, retryConfig: null, logger: new NoOpLogger(), errorHandler: new NoOpErrorHandler());
+            var result = client.FetchDecision("rule-1", "user-1", null, "uuid-1");
+
+            Assert.AreEqual("v1", result);
+        }
+
+        [Test]
+        public void FetchDecisionHttpExceptionNoRetry()
+        {
+            var http = MakeClientExceptionSequence(new HttpRequestException("boom"));
+            var client = new DefaultCmabClient(http, retryConfig: null);
+
+            Assert.Throws<CmabFetchException>(() =>
+                client.FetchDecision("rule-1", "user-1", null, "uuid-1"));
+        }
+
+        [Test]
+        public void FetchDecisionNon2xxNoRetry()
+        {
+            var http = MakeClient(new ResponseStep(HttpStatusCode.InternalServerError, null));
+            var client = new DefaultCmabClient(http, retryConfig: null);
+
+            Assert.Throws<CmabFetchException>(() =>
+                client.FetchDecision("rule-1", "user-1", null, "uuid-1"));
+        }
+
+        [Test]
+        public void FetchDecisionInvalidJsonNoRetry()
+        {
+            var http = MakeClient(new ResponseStep(HttpStatusCode.OK, "not json"));
+            var client = new DefaultCmabClient(http, retryConfig: null);
+
+            Assert.Throws<CmabInvalidResponseException>(() =>
+                client.FetchDecision("rule-1", "user-1", null, "uuid-1"));
+        }
+
+        [Test]
+        public void FetchDecisionInvalidStructureNoRetry()
+        {
+            var http = MakeClient(new ResponseStep(HttpStatusCode.OK, "{\"predictions\":[]}"));
+            var client = new DefaultCmabClient(http, retryConfig: null);
+
+            Assert.Throws<CmabInvalidResponseException>(() =>
+                client.FetchDecision("rule-1", "user-1", null, "uuid-1"));
+        }
+
+        [Test]
+        public void FetchDecisionSuccessWithRetryFirstTry()
+        {
+            var http = MakeClient(new ResponseStep(HttpStatusCode.OK, ValidBody("v2")));
+            var retry = new CmabRetryConfig(maxRetries: 2, initialBackoff: TimeSpan.Zero, maxBackoff: TimeSpan.FromSeconds(1), backoffMultiplier: 2.0);
+            var client = new DefaultCmabClient(http, retry);
+            var result = client.FetchDecision("rule-1", "user-1", null, "uuid-1");
+
+            Assert.AreEqual("v2", result);
+        }
+
+        [Test]
+        public void FetchDecisionSuccessWithRetryThirdTry()
+        {
+            var http = MakeClient(
+                new ResponseStep(HttpStatusCode.InternalServerError, null),
+                new ResponseStep(HttpStatusCode.InternalServerError, null),
+                new ResponseStep(HttpStatusCode.OK, ValidBody("v3"))
+            );
+            var retry = new CmabRetryConfig(maxRetries: 2, initialBackoff: TimeSpan.Zero, maxBackoff: TimeSpan.FromSeconds(1), backoffMultiplier: 2.0);
+            var client = new DefaultCmabClient(http, retry);
+            var result = client.FetchDecision("rule-1", "user-1", null, "uuid-1");
+
+            Assert.AreEqual("v3", result);
+        }
+
+        [Test]
+        public void FetchDecisionExhaustsAllRetries()
+        {
+            var http = MakeClient(
+                new ResponseStep(HttpStatusCode.InternalServerError, null),
+                new ResponseStep(HttpStatusCode.InternalServerError, null),
+                new ResponseStep(HttpStatusCode.InternalServerError, null)
+            );
+            var retry = new CmabRetryConfig(maxRetries: 2, initialBackoff: TimeSpan.Zero, maxBackoff: TimeSpan.FromSeconds(1), backoffMultiplier: 2.0);
+            var client = new DefaultCmabClient(http, retry);
+
+            Assert.Throws<CmabFetchException>(() =>
+                client.FetchDecision("rule-1", "user-1", null, "uuid-1"));
+        }
+    }
+}

--- a/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
+++ b/OptimizelySDK.Tests/OptimizelySDK.Tests.csproj
@@ -70,6 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Assertions.cs"/>
+    <Compile Include="CmabTests\DefaultCmabClientTest.cs"/>
     <Compile Include="AudienceConditionsTests\ConditionEvaluationTest.cs"/>
     <Compile Include="AudienceConditionsTests\ConditionsTest.cs"/>
     <Compile Include="AudienceConditionsTests\SegmentsTests.cs"/>

--- a/OptimizelySDK/Cmab/CmabConstants.cs
+++ b/OptimizelySDK/Cmab/CmabConstants.cs
@@ -1,0 +1,31 @@
+﻿/* 
+* Copyright 2025, Optimizely
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+
+namespace OptimizelySDK.Cmab
+{
+    internal static class CmabConstants
+    {
+        public const string PredictionUrl = "https://prediction.cmab.optimizely.com/predict";
+        public static readonly TimeSpan MaxTimeout = TimeSpan.FromSeconds(10);
+
+        public const string ContentTypeJson = "application/json";
+
+        public const string ErrorFetchFailedFmt = "CMAB decision fetch failed with status: {0}";
+        public const string ErrorInvalidResponse = "Invalid CMAB fetch response";
+    }
+}

--- a/OptimizelySDK/Cmab/CmabConstants.cs
+++ b/OptimizelySDK/Cmab/CmabConstants.cs
@@ -27,5 +27,6 @@ namespace OptimizelySDK.Cmab
 
         public const string ErrorFetchFailedFmt = "CMAB decision fetch failed with status: {0}";
         public const string ErrorInvalidResponse = "Invalid CMAB fetch response";
+        public const string ExhaustRetryMessage = "Exhausted all retries for CMAB request";
     }
 }

--- a/OptimizelySDK/Cmab/CmabModels.cs
+++ b/OptimizelySDK/Cmab/CmabModels.cs
@@ -1,0 +1,41 @@
+﻿/* 
+* Copyright 2025, Optimizely
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace OptimizelySDK.Cmab
+{
+    internal class CmabAttribute
+    {
+        [JsonProperty("id")] public string Id { get; set; }
+        [JsonProperty("value")] public object Value { get; set; }
+        [JsonProperty("type")] public string Type { get; set; } = "custom_attribute";
+    }
+
+    internal class CmabInstance
+    {
+        [JsonProperty("visitorId")] public string VisitorId { get; set; }
+        [JsonProperty("experimentId")] public string ExperimentId { get; set; }
+        [JsonProperty("attributes")] public List<CmabAttribute> Attributes { get; set; }
+        [JsonProperty("cmabUUID")] public string CmabUUID { get; set; }
+    }
+
+    internal class CmabRequest
+    {
+        [JsonProperty("instances")] public List<CmabInstance> Instances { get; set; }
+    }
+}

--- a/OptimizelySDK/Cmab/CmabRetryConfig.cs
+++ b/OptimizelySDK/Cmab/CmabRetryConfig.cs
@@ -1,0 +1,43 @@
+﻿/* 
+* Copyright 2025, Optimizely
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+
+namespace OptimizelySDK.Cmab
+{
+    /// <summary>
+    /// Configuration for retrying CMAB requests (exponential backoff).
+    /// </summary>
+    public class CmabRetryConfig
+    {
+        public int MaxRetries { get; }
+        public TimeSpan InitialBackoff { get; }
+        public TimeSpan MaxBackoff { get; }
+        public double BackoffMultiplier { get; }
+
+        public CmabRetryConfig(
+            int maxRetries = 3,
+            TimeSpan? initialBackoff = null,
+            TimeSpan? maxBackoff = null,
+            double backoffMultiplier = 2.0)
+        {
+            MaxRetries = maxRetries;
+            InitialBackoff = initialBackoff ?? TimeSpan.FromMilliseconds(100);
+            MaxBackoff = maxBackoff ?? TimeSpan.FromSeconds(10);
+            BackoffMultiplier = backoffMultiplier;
+        }
+    }
+}

--- a/OptimizelySDK/Cmab/DefaultCmabClient.cs
+++ b/OptimizelySDK/Cmab/DefaultCmabClient.cs
@@ -151,12 +151,16 @@ namespace OptimizelySDK.Cmab
                     _logger.Log(LogLevel.ERROR, CmabConstants.ErrorInvalidResponse);
                     throw new CmabInvalidResponseException(ex.Message);
                 }
+                catch(CmabInvalidResponseException)
+                {
+                    throw;
+                }
                 catch (HttpRequestException ex)
                 {
                     _logger.Log(LogLevel.ERROR, string.Format(CmabConstants.ErrorFetchFailedFmt, ex.Message));
                     throw new CmabFetchException(string.Format(CmabConstants.ErrorFetchFailedFmt, ex.Message));
                 }
-                catch (Exception ex) when (!(ex is CmabInvalidResponseException))
+                catch (Exception ex)
                 {
                     _logger.Log(LogLevel.ERROR, string.Format(CmabConstants.ErrorFetchFailedFmt, ex.Message));
                     throw new CmabFetchException(string.Format(CmabConstants.ErrorFetchFailedFmt, ex.Message));

--- a/OptimizelySDK/Cmab/DefaultCmabClient.cs
+++ b/OptimizelySDK/Cmab/DefaultCmabClient.cs
@@ -116,7 +116,6 @@ namespace OptimizelySDK.Cmab
         {
             using (var cts = new CancellationTokenSource(timeout))
             {
-
                 try
                 {
                     var httpRequest = new HttpRequestMessage
@@ -179,8 +178,8 @@ namespace OptimizelySDK.Cmab
                 {
                     if (attempt >= _retryConfig.MaxRetries)
                     {
-                        _logger.Log(LogLevel.ERROR, string.Format(CmabConstants.ErrorFetchFailedFmt, "Exhausted all retries for CMAB request."));
-                        throw new CmabFetchException(string.Format(CmabConstants.ErrorFetchFailedFmt, "Exhausted all retries for CMAB request."));
+                        _logger.Log(LogLevel.ERROR, string.Format(CmabConstants.ErrorFetchFailedFmt, CmabConstants.ExhaustRetryMessage));
+                        throw new CmabFetchException(string.Format(CmabConstants.ErrorFetchFailedFmt, CmabConstants.ExhaustRetryMessage));
                     }
 
                     _logger.Log(LogLevel.INFO, $"Retrying CMAB request (attempt: {attempt + 1}) after {backoff.TotalSeconds} seconds...");

--- a/OptimizelySDK/Cmab/DefaultCmabClient.cs
+++ b/OptimizelySDK/Cmab/DefaultCmabClient.cs
@@ -1,0 +1,208 @@
+﻿/* 
+* Copyright 2025, Optimizely
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using OptimizelySDK.ErrorHandler;
+using OptimizelySDK.Exceptions;
+using OptimizelySDK.Logger;
+
+namespace OptimizelySDK.Cmab
+{
+    /// <summary>
+    /// Default client for interacting with the CMAB service via HttpClient.
+    /// </summary>
+    public class DefaultCmabClient : ICmabClient
+    {
+        private readonly HttpClient _httpClient;
+        private readonly CmabRetryConfig _retryConfig;
+        private readonly ILogger _logger;
+        private readonly IErrorHandler _errorHandler;
+
+        public DefaultCmabClient(
+            HttpClient httpClient = null,
+            CmabRetryConfig retryConfig = null,
+            ILogger logger = null,
+            IErrorHandler errorHandler = null)
+        {
+            _httpClient = httpClient ?? new HttpClient();
+            _retryConfig = retryConfig;
+            _logger = logger ?? new NoOpLogger();
+            _errorHandler = errorHandler ?? new NoOpErrorHandler();
+        }
+
+        private async Task<string> FetchDecisionAsync(
+            string ruleId,
+            string userId,
+            IDictionary<string, object> attributes,
+            string cmabUuid,
+            TimeSpan? timeout = null)
+        {
+            var url = $"{CmabConstants.PredictionUrl}/{ruleId}";
+            var body = BuildRequestBody(ruleId, userId, attributes, cmabUuid);
+            var perAttemptTimeout = timeout ?? CmabConstants.MaxTimeout;
+
+            if (_retryConfig == null)
+            {
+                return await DoFetchOnceAsync(url, body, perAttemptTimeout).ConfigureAwait(false);
+            }
+            return await DoFetchWithRetryAsync(url, body, perAttemptTimeout).ConfigureAwait(false);
+        }
+
+        public string FetchDecision(
+            string ruleId,
+            string userId,
+            IDictionary<string, object> attributes,
+            string cmabUuid,
+            TimeSpan? timeout = null)
+        {
+            try
+            {
+                return FetchDecisionAsync(ruleId, userId, attributes, cmabUuid, timeout).ConfigureAwait(false).GetAwaiter().GetResult();
+            }
+            catch (Exception ex)
+            {
+                _errorHandler.HandleError(ex);
+                throw;
+            }
+        }
+
+        private static StringContent BuildContent(object payload)
+        {
+            var json = JsonConvert.SerializeObject(payload);
+            return new StringContent(json, Encoding.UTF8, CmabConstants.ContentTypeJson);
+        }
+
+        private static CmabRequest BuildRequestBody(string ruleId, string userId, IDictionary<string, object> attributes, string cmabUuid)
+        {
+            var attrList = (attributes ?? new Dictionary<string, object>()).Select(kv => new CmabAttribute { Id = kv.Key, Value = kv.Value }).ToList();
+
+            return new CmabRequest
+            {
+                Instances = new List<CmabInstance>
+                {
+                    new CmabInstance
+                    {
+                        VisitorId = userId,
+                        ExperimentId = ruleId,
+                        Attributes = attrList,
+                        CmabUUID = cmabUuid,
+                    }
+                }
+            };
+        }
+
+        private async Task<string> DoFetchOnceAsync(string url, CmabRequest request, TimeSpan timeout)
+        {
+            using (var cts = new CancellationTokenSource(timeout))
+            {
+
+                try
+                {
+                    var httpRequest = new HttpRequestMessage
+                    {
+                        RequestUri = new Uri(url),
+                        Method = HttpMethod.Post,
+                        Content = BuildContent(request),
+                    };
+
+                    var response = await _httpClient.SendAsync(httpRequest, cts.Token).ConfigureAwait(false);
+
+                    if (!response.IsSuccessStatusCode)
+                    {
+                        var status = (int)response.StatusCode;
+                        _logger.Log(LogLevel.ERROR, string.Format(CmabConstants.ErrorFetchFailedFmt, status));
+                        throw new CmabFetchException(string.Format(CmabConstants.ErrorFetchFailedFmt, status));
+                    }
+
+                    var responseText = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
+
+                    var j = JObject.Parse(responseText);
+                    if (!ValidateResponse(j))
+                    {
+                        _logger.Log(LogLevel.ERROR, CmabConstants.ErrorInvalidResponse);
+                        throw new CmabInvalidResponseException(CmabConstants.ErrorInvalidResponse);
+                    }
+
+                    var variationIdToken = j["predictions"][0]["variation_id"];
+                    return variationIdToken?.ToString();
+                }
+                catch (JsonException ex)
+                {
+                    _logger.Log(LogLevel.ERROR, CmabConstants.ErrorInvalidResponse);
+                    throw new CmabInvalidResponseException(ex.Message);
+                }
+                catch (HttpRequestException ex)
+                {
+                    _logger.Log(LogLevel.ERROR, string.Format(CmabConstants.ErrorFetchFailedFmt, ex.Message));
+                    throw new CmabFetchException(string.Format(CmabConstants.ErrorFetchFailedFmt, ex.Message));
+                }
+                catch (Exception ex) when (!(ex is CmabInvalidResponseException))
+                {
+                    _logger.Log(LogLevel.ERROR, string.Format(CmabConstants.ErrorFetchFailedFmt, ex.Message));
+                    throw new CmabFetchException(string.Format(CmabConstants.ErrorFetchFailedFmt, ex.Message));
+                }
+            }
+        }
+
+        private async Task<string> DoFetchWithRetryAsync(string url, CmabRequest request, TimeSpan timeout)
+        {
+            var backoff = _retryConfig.InitialBackoff;
+            var attempt = 0;
+            while (true)
+            {
+                try
+                {
+                    return await DoFetchOnceAsync(url, request, timeout).ConfigureAwait(false);
+                }
+                catch (Exception)
+                {
+                    if (attempt >= _retryConfig.MaxRetries)
+                    {
+                        _logger.Log(LogLevel.ERROR, string.Format(CmabConstants.ErrorFetchFailedFmt, "Exhausted all retries for CMAB request."));
+                        throw new CmabFetchException(string.Format(CmabConstants.ErrorFetchFailedFmt, "Exhausted all retries for CMAB request."));
+                    }
+
+                    _logger.Log(LogLevel.INFO, $"Retrying CMAB request (attempt: {attempt + 1}) after {backoff.TotalSeconds} seconds...");
+                    await Task.Delay(backoff).ConfigureAwait(false);
+                    var nextMs = Math.Min(_retryConfig.MaxBackoff.TotalMilliseconds, backoff.TotalMilliseconds * _retryConfig.BackoffMultiplier);
+                    backoff = TimeSpan.FromMilliseconds(nextMs);
+                    attempt++;
+                }
+            }
+        }
+
+        private static bool ValidateResponse(JObject body)
+        {
+            if (body == null) return false;
+
+            var preds = body["predictions"] as JArray;
+            if (preds == null || preds.Count == 0) return false;
+
+            var first = preds[0] as JObject;
+            if (first == null) return false;
+
+            return first["variation_id"] != null;
+        }
+    }
+}

--- a/OptimizelySDK/Cmab/DefaultCmabClient.cs
+++ b/OptimizelySDK/Cmab/DefaultCmabClient.cs
@@ -95,7 +95,12 @@ namespace OptimizelySDK.Cmab
 
         private static CmabRequest BuildRequestBody(string ruleId, string userId, IDictionary<string, object> attributes, string cmabUuid)
         {
-            var attrList = (attributes ?? new Dictionary<string, object>()).Select(kv => new CmabAttribute { Id = kv.Key, Value = kv.Value }).ToList();
+            var attrList = new List<CmabAttribute>();
+
+            if (attributes != null)
+            {
+                attrList = attributes.Select(kv => new CmabAttribute { Id = kv.Key, Value = kv.Value }).ToList();
+            }
 
             return new CmabRequest
             {
@@ -151,7 +156,7 @@ namespace OptimizelySDK.Cmab
                     _logger.Log(LogLevel.ERROR, CmabConstants.ErrorInvalidResponse);
                     throw new CmabInvalidResponseException(ex.Message);
                 }
-                catch(CmabInvalidResponseException)
+                catch (CmabInvalidResponseException)
                 {
                     throw;
                 }

--- a/OptimizelySDK/Cmab/ICmabClient.cs
+++ b/OptimizelySDK/Cmab/ICmabClient.cs
@@ -1,0 +1,41 @@
+﻿/* 
+* Copyright 2025, Optimizely
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OptimizelySDK.Cmab
+{
+    /// <summary>
+    /// Interface for CMAB client that fetches decisions from the prediction service.
+    /// </summary>
+    public interface ICmabClient
+    {
+        /// <summary>
+        /// Fetch a decision (variation id) from CMAB prediction service.
+        /// Throws on failure (network/non-2xx/invalid response/exhausted retries).
+        /// </summary>
+        /// <returns>Variation ID as string.</returns>
+        string FetchDecision(
+            string ruleId,
+            string userId,
+            IDictionary<string, object> attributes,
+            string cmabUuid,
+            TimeSpan? timeout = null);
+    }
+}

--- a/OptimizelySDK/Exceptions/OptimizelyException.cs
+++ b/OptimizelySDK/Exceptions/OptimizelyException.cs
@@ -85,6 +85,33 @@ namespace OptimizelySDK.Exceptions
             : base(message) { }
     }
 
+    /// <summary>
+    /// Base exception for CMAB client errors.
+    /// </summary>
+    public class CmabException : OptimizelyException
+    {
+        public CmabException(string message)
+            : base(message) { }
+    }
+
+    /// <summary>
+    /// Exception thrown when CMAB decision fetch fails (network/non-2xx/exhausted retries).
+    /// </summary>
+    public class CmabFetchException : CmabException
+    {
+        public CmabFetchException(string message)
+            : base(message) { }
+    }
+
+    /// <summary>
+    /// Exception thrown when CMAB response is invalid or cannot be parsed.
+    /// </summary>
+    public class CmabInvalidResponseException : CmabException
+    {
+        public CmabInvalidResponseException(string message)
+            : base(message) { }
+    }
+
     public class InvalidRolloutException : OptimizelyException
     {
         public InvalidRolloutException(string message)

--- a/OptimizelySDK/OptimizelySDK.csproj
+++ b/OptimizelySDK/OptimizelySDK.csproj
@@ -204,6 +204,11 @@
     <Compile Include="AudienceConditions\SemanticVersion.cs"/>
     <Compile Include="Entity\Result.cs"/>
     <Compile Include="Notifications\NotificationCenterRegistry.cs"/>
+    <Compile Include="Cmab\ICmabClient.cs"/>
+    <Compile Include="Cmab\DefaultCmabClient.cs"/>
+    <Compile Include="Cmab\CmabRetryConfig.cs"/>
+    <Compile Include="Cmab\CmabModels.cs"/>
+    <Compile Include="Cmab\CmabConstants.cs"/>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Utils\schema.json"/>


### PR DESCRIPTION
## Summary
* Added `ICmabClient` interface defining the contract for fetching decisions from the CMAB prediction service.
* Implemented `DefaultCmabClient` class, which interacts with the CMAB service using `HttpClient`, handles request/response, supports retries, and validates responses.
* Introduced supporting classes: `CmabModels` for request/response structure, `CmabConstants` for endpoint and error messages, and `CmabRetryConfig` for exponential backoff configuration.
* Added new exception classes: `CmabException`, `CmabFetchException`, and `CmabInvalidResponseException` to represent various CMAB client error states.

## Test plan
* Added `DefaultCmabClientTest` unit tests covering success, error, invalid response, and retry scenarios for the CMAB client.
* Updated project files to include new CMAB client, models, constants, and test files for compilation.

## Issues
- [FSSDK-11150](https://jira.sso.episerver.net/browse/FSSDK-11150)