### PR TITLE
[AI-FSSDK] [FSSDK-12418] Remove experiment type validation from config parsing

### DIFF
--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -1736,6 +1736,19 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual("fr", rolloutExperiment.Type);
         }
 
+        [Test]
+        public void TestUnknownExperimentTypeAccepted()
+        {
+            var datafile = BuildFeatureRolloutDatafile(experimentType: "new_unknown_type");
+            var config = DatafileProjectConfig.Create(datafile, LoggerMock.Object,
+                ErrorHandlerMock.Object);
+
+            Assert.IsNotNull(config);
+            var experiment = config.GetExperimentFromKey("rollout_experiment");
+            Assert.IsNotNull(experiment);
+            Assert.AreEqual("new_unknown_type", experiment.Type);
+        }
+
         #endregion
     }
 }

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -375,26 +375,8 @@ namespace OptimizelySDK.Config
                 }
             }
 
-            var validExperimentTypes = new HashSet<string>
-            {
-                Experiment.EXPERIMENT_TYPE_AB,
-                Experiment.EXPERIMENT_TYPE_MAB,
-                Experiment.EXPERIMENT_TYPE_CMAB,
-                Experiment.EXPERIMENT_TYPE_TD,
-                Experiment.EXPERIMENT_TYPE_FR,
-            };
-
             foreach (var experiment in _ExperimentIdMap.Values)
             {
-                if (experiment.Type != null && !validExperimentTypes.Contains(experiment.Type))
-                {
-                    Logger.Log(LogLevel.ERROR,
-                        $@"Experiment ""{experiment.Key}"" has invalid type ""{experiment.Type}"".");
-                    ErrorHandler.HandleError(
-                        new InvalidExperimentException(
-                            $"Invalid experiment type: {experiment.Type}"));
-                }
-
                 _VariationKeyMap[experiment.Key] = new Dictionary<string, Variation>();
                 _VariationIdMap[experiment.Key] = new Dictionary<string, Variation>();
                 _VariationIdMapByExperimentId[experiment.Id] = new Dictionary<string, Variation>();

--- a/OptimizelySDK/Entity/Experiment.cs
+++ b/OptimizelySDK/Entity/Experiment.cs
@@ -23,10 +23,6 @@ namespace OptimizelySDK.Entity
     {
         private const string MUTEX_GROUP_POLICY = "random";
 
-        public const string EXPERIMENT_TYPE_AB = "ab";
-        public const string EXPERIMENT_TYPE_MAB = "mab";
-        public const string EXPERIMENT_TYPE_CMAB = "cmab";
-        public const string EXPERIMENT_TYPE_TD = "td";
         public const string EXPERIMENT_TYPE_FR = "fr";
 
         /// <summary>


### PR DESCRIPTION
## Summary

Removes experiment type validation from config parsing to ensure forward compatibility. Previously, unknown experiment type values caused errors and could reject the entire datafile, which would break existing SDK versions when new experiment types are added in the future.

## Changes

- Removed type validation block that rejected experiments with unknown type values
- Unknown experiment types are now silently accepted and stored as-is
- Added test verifying unknown experiment types are accepted during config parsing

## Jira Ticket
[FSSDK-12418](https://optimizely-ext.atlassian.net/browse/FSSDK-12418)

[FSSDK-12418]: https://optimizely-ext.atlassian.net/browse/FSSDK-12418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ