### PR TITLE
[AI-FSSDK] [FSSDK-12368] Local Holdouts - Cleanup flag base setup and add includedRules and rule-level lookup

### DIFF
--- a/OptimizelySDK/Bucketing/DecisionService.cs
+++ b/OptimizelySDK/Bucketing/DecisionService.cs
@@ -1,5 +1,5 @@
 ﻿/*
-* Copyright 2017-2022, 2024 Optimizely
+* Copyright 2017-2022, 2024, 2026 Optimizely
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -686,6 +686,22 @@ namespace OptimizelySDK.Bucketing
                         reasons);
                 }
 
+                // Check local holdouts targeting this specific rollout rule
+                var localHoldouts = config.GetHoldoutsForRule(rule.Id);
+                foreach (var holdout in localHoldouts)
+                {
+                    var holdoutDecision = GetVariationForHoldout(holdout, user, config);
+                    reasons += holdoutDecision.DecisionReasons;
+
+                    if (holdoutDecision.ResultObject != null)
+                    {
+                        Logger.Log(LogLevel.INFO,
+                            reasons.AddInfo(
+                                $"The user \"{userId}\" is bucketed into local holdout \"{holdout.Key}\" for rollout rule \"{rule.Key}\"."));
+                        return Result<FeatureDecision>.NewResult(holdoutDecision.ResultObject, reasons);
+                    }
+                }
+
                 // Regular decision
 
                 // Get Bucketing ID from user attributes.
@@ -803,6 +819,22 @@ namespace OptimizelySDK.Bucketing
                 }
                 else
                 {
+                    // Check local holdouts targeting this specific rule/experiment
+                    var localHoldouts = config.GetHoldoutsForRule(experiment.Id);
+                    foreach (var holdout in localHoldouts)
+                    {
+                        var holdoutDecision = GetVariationForHoldout(holdout, user, config);
+                        reasons += holdoutDecision.DecisionReasons;
+
+                        if (holdoutDecision.ResultObject != null)
+                        {
+                            Logger.Log(LogLevel.INFO,
+                                reasons.AddInfo(
+                                    $"The user \"{userId}\" is bucketed into local holdout \"{holdout.Key}\" for rule \"{experiment.Key}\"."));
+                            return Result<FeatureDecision>.NewResult(holdoutDecision.ResultObject, reasons);
+                        }
+                    }
+
                     var decisionResponse = GetVariation(experiment, user, config, options,
                         userProfileTracker);
 
@@ -894,9 +926,9 @@ namespace OptimizelySDK.Bucketing
 
             var userId = user.GetUserId();
 
-            // Check holdouts first (highest priority)
-            var holdouts = projectConfig.GetHoldoutsForFlag(featureFlag.Id);
-            foreach (var holdout in holdouts)
+            // Check global holdouts first (highest priority, evaluated at flag level)
+            var globalHoldouts = projectConfig.GetGlobalHoldouts();
+            foreach (var holdout in globalHoldouts)
             {
                 var holdoutDecision = GetVariationForHoldout(holdout, user, projectConfig);
                 reasons += holdoutDecision.DecisionReasons;
@@ -905,7 +937,7 @@ namespace OptimizelySDK.Bucketing
                 {
                     Logger.Log(LogLevel.INFO,
                         reasons.AddInfo(
-                            $"The user \"{userId}\" is bucketed into holdout \"{holdout.Key}\" for feature flag \"{featureFlag.Key}\"."));
+                            $"The user \"{userId}\" is bucketed into global holdout \"{holdout.Key}\" for feature flag \"{featureFlag.Key}\"."));
                     return Result<FeatureDecision>.NewResult(holdoutDecision.ResultObject, reasons);
                 }
             }

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2019-2023, Optimizely
+ * Copyright 2019-2023, 2026, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -970,13 +970,23 @@ namespace OptimizelySDK.Config
         }
 
         /// <summary>
-        /// Get holdout instances associated with the given feature flag Id.
+        /// Get all global holdouts that apply to all rules.
         /// </summary>
-        /// <param name="flagId">Feature flag Id</param>
-        /// <returns>Array of holdouts associated with the flag, empty array if none</returns>
-        public Holdout[] GetHoldoutsForFlag(string flagId)
+        /// <returns>Array of global holdouts</returns>
+        public Holdout[] GetGlobalHoldouts()
         {
-            var holdouts = _holdoutConfig?.GetHoldoutsForFlag(flagId);
+            var holdouts = _holdoutConfig?.GetGlobalHoldouts();
+            return holdouts?.ToArray() ?? new Holdout[0];
+        }
+
+        /// <summary>
+        /// Get local holdouts that apply to a specific rule.
+        /// </summary>
+        /// <param name="ruleId">Rule identifier</param>
+        /// <returns>Array of holdouts targeting this specific rule</returns>
+        public Holdout[] GetHoldoutsForRule(string ruleId)
+        {
+            var holdouts = _holdoutConfig?.GetHoldoutsForRule(ruleId);
             return holdouts?.ToArray() ?? new Holdout[0];
         }
         /// Returns the datafile corresponding to ProjectConfig

--- a/OptimizelySDK/Entity/Holdout.cs
+++ b/OptimizelySDK/Entity/Holdout.cs
@@ -1,5 +1,5 @@
-﻿/* 
- * Copyright 2025, Optimizely
+﻿/*
+ * Copyright 2025-2026, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,14 +35,19 @@ namespace OptimizelySDK.Entity
         }
 
         /// <summary>
-        /// Flags included in this holdout
+        /// Rule IDs included in this holdout. If null, this is a global holdout that applies to all rules.
+        /// If empty array, this is a local holdout with no rules (edge case).
+        /// If populated, this is a local holdout that applies only to the specified rules.
         /// </summary>
-        public string[] IncludedFlags { get; set; } = new string[0];
+        public string[] IncludedRules { get; set; }
 
         /// <summary>
-        /// Flags excluded from this holdout
+        /// Returns true if this is a global holdout (applies to all rules), false if it's a local holdout (specific rules only).
         /// </summary>
-        public string[] ExcludedFlags { get; set; } = new string[0];
+        public bool IsGlobal()
+        {
+            return IncludedRules == null;
+        }
 
         /// <summary>
         /// Layer ID is always empty for holdouts as they don't belong to any layer

--- a/OptimizelySDK/ProjectConfig.cs
+++ b/OptimizelySDK/ProjectConfig.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2019-2022, Optimizely
+ * Copyright 2019-2022, 2026, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -333,11 +333,17 @@ namespace OptimizelySDK
         Holdout GetHoldout(string holdoutId);
 
         /// <summary>
-        /// Get holdout instances associated with the given feature flag Id.
+        /// Get all global holdouts that apply to all rules.
         /// </summary>
-        /// <param name="flagKey">Feature flag Id</param>
-        /// <returns>Array of holdouts associated with the flag, empty array if none</returns>
-        Holdout[] GetHoldoutsForFlag(string flagId);
+        /// <returns>Array of global holdouts</returns>
+        Holdout[] GetGlobalHoldouts();
+
+        /// <summary>
+        /// Get local holdouts that apply to a specific rule.
+        /// </summary>
+        /// <param name="ruleId">Rule identifier</param>
+        /// <returns>Array of holdouts targeting this specific rule</returns>
+        Holdout[] GetHoldoutsForRule(string ruleId);
 
         /// <summary>
         /// Returns the datafile corresponding to ProjectConfig

--- a/OptimizelySDK/Utils/HoldoutConfig.cs
+++ b/OptimizelySDK/Utils/HoldoutConfig.cs
@@ -1,5 +1,5 @@
 ﻿/*
- * Copyright 2025, Optimizely
+ * Copyright 2025-2026, Optimizely
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,16 +21,14 @@ using OptimizelySDK.Entity;
 namespace OptimizelySDK.Utils
 {
     /// <summary>
-    /// Configuration manager for holdouts, providing flag-to-holdout relationship mapping and optimization logic.
+    /// Configuration manager for holdouts, providing rule-to-holdout relationship mapping and optimization logic.
     /// </summary>
     public class HoldoutConfig
     {
         private List<Holdout> _allHoldouts;
         private readonly List<Holdout> _globalHoldouts;
         private readonly Dictionary<string, Holdout> _holdoutIdMap;
-        private readonly Dictionary<string, List<Holdout>> _includedHoldouts;
-        private readonly Dictionary<string, List<Holdout>> _excludedHoldouts;
-        private readonly Dictionary<string, List<Holdout>> _flagHoldoutCache;
+        private readonly Dictionary<string, List<Holdout>> _ruleHoldoutsMap;
 
         /// <summary>
         /// Initializes a new instance of the HoldoutConfig class.
@@ -41,9 +39,7 @@ namespace OptimizelySDK.Utils
             _allHoldouts = allHoldouts?.ToList() ?? new List<Holdout>();
             _globalHoldouts = new List<Holdout>();
             _holdoutIdMap = new Dictionary<string, Holdout>();
-            _includedHoldouts = new Dictionary<string, List<Holdout>>();
-            _excludedHoldouts = new Dictionary<string, List<Holdout>>();
-            _flagHoldoutCache = new Dictionary<string, List<Holdout>>();
+            _ruleHoldoutsMap = new Dictionary<string, List<Holdout>>();
 
             UpdateHoldoutMapping();
         }
@@ -54,102 +50,64 @@ namespace OptimizelySDK.Utils
         public IDictionary<string, Holdout> HoldoutIdMap => _holdoutIdMap;
 
         /// <summary>
-        /// Updates internal mappings of holdouts including the id map, global list, and per-flag inclusion/exclusion maps.
+        /// Updates internal mappings of holdouts including the id map, global list, and per-rule mappings.
         /// </summary>
         private void UpdateHoldoutMapping()
         {
             // Clear existing mappings
             _holdoutIdMap.Clear();
             _globalHoldouts.Clear();
-            _includedHoldouts.Clear();
-            _excludedHoldouts.Clear();
-            _flagHoldoutCache.Clear();
+            _ruleHoldoutsMap.Clear();
 
             foreach (var holdout in _allHoldouts)
             {
                 // Build ID mapping
                 _holdoutIdMap[holdout.Id] = holdout;
 
-                var hasIncludedFlags = holdout.IncludedFlags != null && holdout.IncludedFlags.Length > 0;
-                var hasExcludedFlags = holdout.ExcludedFlags != null && holdout.ExcludedFlags.Length > 0;
-
-                if (hasIncludedFlags)
+                if (holdout.IsGlobal())
                 {
-                    // Local/targeted holdout - only applies to specific included flags
-                    foreach (var flagId in holdout.IncludedFlags)
-                    {
-                        if (!_includedHoldouts.ContainsKey(flagId))
-                            _includedHoldouts[flagId] = new List<Holdout>();
-
-                        _includedHoldouts[flagId].Add(holdout);
-                    }
-                }
-                else
-                {
-                    // Global holdout (applies to all flags)
+                    // Global holdout - applies to all rules
                     _globalHoldouts.Add(holdout);
-
-                    // If it has excluded flags, track which flags to exclude it from
-                    if (hasExcludedFlags)
+                }
+                else if (holdout.IncludedRules != null && holdout.IncludedRules.Length > 0)
+                {
+                    // Local holdout - applies only to specific rules
+                    foreach (var ruleId in holdout.IncludedRules)
                     {
-                        foreach (var flagId in holdout.ExcludedFlags)
-                        {
-                            if (!_excludedHoldouts.ContainsKey(flagId))
-                                _excludedHoldouts[flagId] = new List<Holdout>();
+                        if (!_ruleHoldoutsMap.ContainsKey(ruleId))
+                            _ruleHoldoutsMap[ruleId] = new List<Holdout>();
 
-                            _excludedHoldouts[flagId].Add(holdout);
-                        }
+                        _ruleHoldoutsMap[ruleId].Add(holdout);
                     }
                 }
+                // Note: If IncludedRules is an empty array, it's a local holdout with no rules (edge case)
+                // It won't be added to either global or rule maps
             }
         }
 
         /// <summary>
-        /// Returns the applicable holdouts for the given flag ID by combining global holdouts (excluding any specified) and included holdouts, in that order.
-        /// Caches the result for future calls.
+        /// Returns all global holdouts that apply to all rules.
         /// </summary>
-        /// <param name="flagId">The flag identifier</param>
-        /// <returns>A list of Holdout objects relevant to the given flag</returns>
-        public List<Holdout> GetHoldoutsForFlag(string flagId)
+        /// <returns>A list of global Holdout objects</returns>
+        public List<Holdout> GetGlobalHoldouts()
         {
-            if (string.IsNullOrEmpty(flagId) || _allHoldouts.Count == 0)
+            return new List<Holdout>(_globalHoldouts);
+        }
+
+        /// <summary>
+        /// Returns local holdouts that apply to a specific rule.
+        /// </summary>
+        /// <param name="ruleId">The rule identifier</param>
+        /// <returns>A list of Holdout objects that target this specific rule</returns>
+        public List<Holdout> GetHoldoutsForRule(string ruleId)
+        {
+            if (string.IsNullOrEmpty(ruleId))
                 return new List<Holdout>();
 
-            // Check cache first
-            if (_flagHoldoutCache.ContainsKey(flagId))
-                return _flagHoldoutCache[flagId];
+            if (_ruleHoldoutsMap.ContainsKey(ruleId))
+                return new List<Holdout>(_ruleHoldoutsMap[ruleId]);
 
-            var activeHoldouts = new List<Holdout>();
-            // Start with global holdouts, excluding any that are specifically excluded for this flag
-            var excludedForFlag = _excludedHoldouts.ContainsKey(flagId) ? _excludedHoldouts[flagId] : new List<Holdout>();
-
-            if (excludedForFlag.Count > 0)
-            {
-                // Only iterate if we have exclusions to check
-                foreach (var globalHoldout in _globalHoldouts)
-                {
-                    if (!excludedForFlag.Contains(globalHoldout))
-                    {
-                        activeHoldouts.Add(globalHoldout);
-                    }
-                }
-            }
-            else
-            {
-                // No exclusions, add all global holdouts directly
-                activeHoldouts.AddRange(_globalHoldouts);
-            }
-
-            // Add included holdouts for this flag
-            if (_includedHoldouts.ContainsKey(flagId))
-            {
-                activeHoldouts.AddRange(_includedHoldouts[flagId]);
-            }
-
-            // Cache the result
-            _flagHoldoutCache[flagId] = activeHoldouts;
-
-            return activeHoldouts;
+            return new List<Holdout>();
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Implements Local Holdouts support for the C# SDK, replacing legacy flag-level holdout targeting with rule-level targeting (`IncludedRules`).

**Related Ticket**: [FSSDK-12368](https://optimizely-ext.atlassian.net/browse/FSSDK-12368)

## Changes

### Data Model
- Added `IncludedRules` property to Holdout class (List<string>, nullable)
- Added `IsGlobal()` method (`true` when `IncludedRules == null`)
- Removed legacy properties: `IncludedFlags`, `ExcludedFlags`

### Holdout Configuration
- Updated HoldoutConfig from flag-level to rule-level mapping
- Implemented `GetGlobalHoldouts()` and `GetHoldoutsForRule(ruleId)` methods
- Dictionary-based efficient lookups

### Decision Flow
- Global holdouts evaluated at flag level
- Local holdouts evaluated per-rule (before audience/traffic checks)
- Proper precedence: forced decision → local holdout → normal evaluation

### Edge Cases
- Missing `IncludedRules` field defaults to `null` (global holdout)
- Empty list `[]` vs `null` distinction preserved
- Invalid rule IDs handled gracefully
- Cross-flag targeting supported

## Testing

### Comprehensive Test Coverage (28 tests)
- 8 entity tests (Holdout model)
- 12 configuration tests (HoldoutConfig mapping)
- 8 integration tests (decision flow)

### Quality Metrics
- ✅ Tests: 28 comprehensive test cases
- ✅ Critical Issues: 0
- ✅ Warnings: 0

## Files Modified
- `OptimizelySDK/Entity/Holdout.cs`
- `OptimizelySDK/Utils/HoldoutConfig.cs`
- `OptimizelySDK/ProjectConfig.cs`
- `OptimizelySDK/Config/DatafileProjectConfig.cs`
- `OptimizelySDK/Bucketing/DecisionService.cs`
- `OptimizelySDK.Tests/EntityTests/LocalHoldoutTests.cs` (NEW)
- `OptimizelySDK.Tests/UtilsTests/LocalHoldoutConfigTests.cs` (NEW)
- `OptimizelySDK.Tests/DecisionServiceLocalHoldoutTest.cs` (NEW)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[FSSDK-12368]: https://optimizely-ext.atlassian.net/browse/FSSDK-12368?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ