### PR TITLE
[AI-FSSDK] [FSSDK-12670] Block ODP identify events with single identifier

### DIFF
--- a/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
@@ -203,11 +203,15 @@ namespace OptimizelySDK.Tests.OdpTests
             eventManager.UpdateSettings(mockOdpConfig.
                 Object); // auto-start after update; Logs 1x here
 
-            eventManager.IdentifyUser(FS_USER_ID); // Logs 1x here too
+            eventManager.IdentifyUser(FS_USER_ID); // Blocked by single identifier check
 
             _mockLogger.Verify(
                 l => l.Log(LogLevel.WARN, Constants.ODP_NOT_INTEGRATED_MESSAGE),
-                Times.Exactly(3)); // during Start() and SendEvent()
+                Times.Exactly(2)); // during Start() and UpdateSettings()
+            _mockLogger.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    "ODP identify event is not dispatched (only one identifier provided)."),
+                Times.Once); // IdentifyUser blocked before reaching SendEvent
         }
 
         [Test]
@@ -606,14 +610,12 @@ namespace OptimizelySDK.Tests.OdpTests
         }
 
         [Test]
-        public void ShouldPrepareCorrectPayloadForIdentifyUser()
+        public void ShouldNotSendIdentifyEventWithSingleIdentifier()
         {
             const string USER_ID = "test_fs_user_id";
-            var cde = new CountdownEvent(1);
             var eventsCollector = new List<List<OdpEvent>>();
             _mockApiManager.Setup(api => api.SendEvents(It.IsAny<string>(), It.IsAny<string>(),
-                    Capture.In(eventsCollector))).
-                Callback(() => cde.Signal());
+                    Capture.In(eventsCollector)));
             var eventManager = new OdpEventManager.Builder().
                 WithOdpEventApiManager(_mockApiManager.Object).
                 WithLogger(_mockLogger.Object).
@@ -623,20 +625,16 @@ namespace OptimizelySDK.Tests.OdpTests
             eventManager.UpdateSettings(_odpConfig);
 
             eventManager.IdentifyUser(USER_ID);
-            cde.Wait(MAX_COUNT_DOWN_EVENT_WAIT_MS);
 
-            var eventsSentToApi = eventsCollector.FirstOrDefault();
-            var actualEvent = eventsSentToApi?.FirstOrDefault();
-            Assert.IsNotNull(actualEvent);
-            Assert.AreEqual(Constants.ODP_EVENT_TYPE, actualEvent.Type);
-            Assert.AreEqual("identified", actualEvent.Action);
-            Assert.AreEqual(USER_ID, actualEvent.Identifiers[Constants.FS_USER_ID]);
-            var eventData = actualEvent.Data;
-            Assert.AreEqual(Guid.NewGuid().ToString().Length,
-                eventData["idempotence_id"].ToString().Length);
-            Assert.AreEqual("sdk", eventData["data_source_type"]);
-            Assert.AreEqual("csharp-sdk", eventData["data_source"]);
-            Assert.IsNotNull(eventData["data_source_version"]);
+            // Allow time for any async processing
+            Thread.Sleep(500);
+
+            // No events should be sent since only one identifier (fs_user_id) was provided
+            Assert.IsEmpty(eventsCollector);
+            _mockLogger.Verify(
+                l => l.Log(LogLevel.DEBUG,
+                    "ODP identify event is not dispatched (only one identifier provided)."),
+                Times.Once);
         }
 
         [Test]

--- a/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
@@ -210,7 +210,7 @@ namespace OptimizelySDK.Tests.OdpTests
                 Times.Exactly(2)); // during Start() and UpdateSettings()
             _mockLogger.Verify(
                 l => l.Log(LogLevel.DEBUG,
-                    "ODP identify event is not dispatched (only one identifier provided)."),
+                    "ODP identify event is not dispatched (fewer than 2 valid identifiers)."),
                 Times.Once); // IdentifyUser blocked before reaching SendEvent
         }
 
@@ -633,7 +633,7 @@ namespace OptimizelySDK.Tests.OdpTests
             Assert.IsEmpty(eventsCollector);
             _mockLogger.Verify(
                 l => l.Log(LogLevel.DEBUG,
-                    "ODP identify event is not dispatched (only one identifier provided)."),
+                    "ODP identify event is not dispatched (fewer than 2 valid identifiers)."),
                 Times.Once);
         }
 

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -383,6 +383,8 @@ namespace OptimizelySDK.Odp
                 .Where(kvp => !string.IsNullOrEmpty(kvp.Value))
                 .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
 
+            // Identify requires 2+ identifiers to link (e.g., vuid + fs_user_id).
+            // A single identifier has no cross-reference value and generates unnecessary traffic.
             if (validIdentifiers.Count < 2)
             {
                 _logger.Log(LogLevel.DEBUG,

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -378,7 +378,19 @@ namespace OptimizelySDK.Odp
                 { Constants.FS_USER_ID, userId },
             };
 
-            var odpEvent = new OdpEvent(Constants.ODP_EVENT_TYPE, "identified", identifiers);
+            // Filter out null/empty identifier values and require 2+ valid identifiers
+            var validIdentifiers = identifiers
+                .Where(kvp => !string.IsNullOrEmpty(kvp.Value))
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value);
+
+            if (validIdentifiers.Count < 2)
+            {
+                _logger.Log(LogLevel.DEBUG,
+                    "ODP identify event is not dispatched (only one identifier provided).");
+                return;
+            }
+
+            var odpEvent = new OdpEvent(Constants.ODP_EVENT_TYPE, "identified", validIdentifiers);
             SendEvent(odpEvent);
         }
 

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -386,7 +386,7 @@ namespace OptimizelySDK.Odp
             if (validIdentifiers.Count < 2)
             {
                 _logger.Log(LogLevel.DEBUG,
-                    "ODP identify event is not dispatched (only one identifier provided).");
+                    "ODP identify event is not dispatched (fewer than 2 valid identifiers).");
                 return;
             }
 


### PR DESCRIPTION
## Summary

Block ODP identify events when only a single valid identifier is provided. Identify events exist to link multiple user identifiers together; sending them with a single identifier provides no value and wastes network calls.

**Jira:** [FSSDK-12670](https://optimizely-ext.atlassian.net/browse/FSSDK-12670)

## Changes

### `OptimizelySDK/Odp/OdpEventManager.cs`
- Added filtering of null/empty identifier values using LINQ in `IdentifyUser`
- Added guard: requires 2+ valid identifiers to dispatch identify event
- Added debug log message when skipping: "ODP identify event is not dispatched (only one identifier provided)."

### Tests (`OdpEventManagerTests.cs`)
- Updated `ShouldLogWhenOdpNotIntegratedAndIdentifyUserCalled` to expect 2 ODP_NOT_INTEGRATED logs (instead of 3) since IdentifyUser now returns before reaching SendEvent
- Replaced `ShouldPrepareCorrectPayloadForIdentifyUser` with `ShouldNotSendIdentifyEventWithSingleIdentifier` to verify single-identifier identify events are blocked

## Notes
- C# SDK is server-side only (no VUID), so `IdentifyUser` always has a single `fs_user_id` identifier and identify events will be correctly skipped
- The public `IdentifyUser(string userId)` API is unchanged for backward compatibility
- The count check matches behavior across all SDKs per the spec

[FSSDK-12670]: https://optimizely-ext.atlassian.net/browse/FSSDK-12670?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ