### PR TITLE
[AI-FSSDK] [TESTING] do not review

### DIFF
--- a/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpEventManagerTests.cs
@@ -203,7 +203,11 @@ namespace OptimizelySDK.Tests.OdpTests
             eventManager.UpdateSettings(mockOdpConfig.
                 Object); // auto-start after update; Logs 1x here
 
-            eventManager.IdentifyUser(FS_USER_ID); // Logs 1x here too
+            eventManager.IdentifyUser(new Dictionary<string, string>
+            {
+                { FS_USER_ID, "test-user" },
+                { "email", "test@example.com" },
+            }); // Logs 1x here too
 
             _mockLogger.Verify(
                 l => l.Log(LogLevel.WARN, Constants.ODP_NOT_INTEGRATED_MESSAGE),
@@ -622,7 +626,12 @@ namespace OptimizelySDK.Tests.OdpTests
                 Build();
             eventManager.UpdateSettings(_odpConfig);
 
-            eventManager.IdentifyUser(USER_ID);
+            var identifiers = new Dictionary<string, string>
+            {
+                { Constants.FS_USER_ID, USER_ID },
+                { "email", "test@example.com" },
+            };
+            eventManager.IdentifyUser(identifiers);
             cde.Wait(MAX_COUNT_DOWN_EVENT_WAIT_MS);
 
             var eventsSentToApi = eventsCollector.FirstOrDefault();
@@ -631,6 +640,7 @@ namespace OptimizelySDK.Tests.OdpTests
             Assert.AreEqual(Constants.ODP_EVENT_TYPE, actualEvent.Type);
             Assert.AreEqual("identified", actualEvent.Action);
             Assert.AreEqual(USER_ID, actualEvent.Identifiers[Constants.FS_USER_ID]);
+            Assert.AreEqual("test@example.com", actualEvent.Identifiers["email"]);
             var eventData = actualEvent.Data;
             Assert.AreEqual(Guid.NewGuid().ToString().Length,
                 eventData["idempotence_id"].ToString().Length);

--- a/OptimizelySDK.Tests/OdpTests/OdpManagerTest.cs
+++ b/OptimizelySDK.Tests/OdpTests/OdpManagerTest.cs
@@ -283,9 +283,9 @@ namespace OptimizelySDK.Tests.OdpTests
         }
 
         [Test]
-        public void ShouldIdentifyUserWhenOdpIsIntegrated()
+        public void ShouldIdentifyUserWhenMultipleIdentifiersProvided()
         {
-            _mockOdpEventManager.Setup(e => e.IdentifyUser(It.IsAny<string>()));
+            _mockOdpEventManager.Setup(e => e.IdentifyUser(It.IsAny<Dictionary<string, string>>()));
             _mockOdpEventManager.Setup(e => e.IsStarted).Returns(true);
             var manager = new OdpManager.Builder().
                 WithEventManager(_mockOdpEventManager.Object).
@@ -293,17 +293,70 @@ namespace OptimizelySDK.Tests.OdpTests
                 Build();
             manager.UpdateSettings(API_KEY, API_HOST, _emptySegmentsToCheck);
 
-            manager.IdentifyUser(VALID_FS_USER_ID);
+            var identifiers = new Dictionary<string, string>
+            {
+                { "fs_user_id", VALID_FS_USER_ID },
+                { "email", "user@example.com" },
+            };
+            manager.IdentifyUser(identifiers);
             manager.Dispose();
 
             _mockLogger.Verify(l => l.Log(It.IsAny<LogLevel>(), It.IsAny<string>()), Times.Never);
-            _mockOdpEventManager.Verify(e => e.IdentifyUser(It.IsAny<string>()), Times.Once);
+            _mockOdpEventManager.Verify(e => e.IdentifyUser(It.IsAny<Dictionary<string, string>>()), Times.Once);
+        }
+
+        [Test]
+        public void ShouldNotIdentifyUserWhenSingleIdentifierProvided()
+        {
+            _mockOdpEventManager.Setup(e => e.IdentifyUser(It.IsAny<Dictionary<string, string>>()));
+            _mockOdpEventManager.Setup(e => e.IsStarted).Returns(true);
+            var manager = new OdpManager.Builder().
+                WithEventManager(_mockOdpEventManager.Object).
+                WithLogger(_mockLogger.Object).
+                Build();
+            manager.UpdateSettings(API_KEY, API_HOST, _emptySegmentsToCheck);
+
+            var identifiers = new Dictionary<string, string>
+            {
+                { "fs_user_id", VALID_FS_USER_ID },
+            };
+            manager.IdentifyUser(identifiers);
+            manager.Dispose();
+
+            _mockLogger.Verify(l =>
+                l.Log(LogLevel.DEBUG, "ODP identify event is not dispatched (only one identifier provided)."));
+            _mockOdpEventManager.Verify(e => e.IdentifyUser(It.IsAny<Dictionary<string, string>>()), Times.Never);
+        }
+
+        [Test]
+        public void ShouldNotIdentifyUserWhenEmptyValuesNotCounted()
+        {
+            _mockOdpEventManager.Setup(e => e.IdentifyUser(It.IsAny<Dictionary<string, string>>()));
+            _mockOdpEventManager.Setup(e => e.IsStarted).Returns(true);
+            var manager = new OdpManager.Builder().
+                WithEventManager(_mockOdpEventManager.Object).
+                WithLogger(_mockLogger.Object).
+                Build();
+            manager.UpdateSettings(API_KEY, API_HOST, _emptySegmentsToCheck);
+
+            var identifiers = new Dictionary<string, string>
+            {
+                { "fs_user_id", VALID_FS_USER_ID },
+                { "email", "" },
+                { "vuid", null },
+            };
+            manager.IdentifyUser(identifiers);
+            manager.Dispose();
+
+            _mockLogger.Verify(l =>
+                l.Log(LogLevel.DEBUG, "ODP identify event is not dispatched (only one identifier provided)."));
+            _mockOdpEventManager.Verify(e => e.IdentifyUser(It.IsAny<Dictionary<string, string>>()), Times.Never);
         }
 
         [Test]
         public void ShouldNotIdentifyUserWhenOdpDisabled()
         {
-            _mockOdpEventManager.Setup(e => e.IdentifyUser(It.IsAny<string>()));
+            _mockOdpEventManager.Setup(e => e.IdentifyUser(It.IsAny<Dictionary<string, string>>()));
             _mockOdpEventManager.Setup(e => e.IsStarted).Returns(true);
             var manager = new OdpManager.Builder().
                 WithEventManager(_mockOdpEventManager.Object).
@@ -311,12 +364,17 @@ namespace OptimizelySDK.Tests.OdpTests
                 Build(false);
             manager.UpdateSettings(API_KEY, API_HOST, _emptySegmentsToCheck);
 
-            manager.IdentifyUser(VALID_FS_USER_ID);
+            var identifiers = new Dictionary<string, string>
+            {
+                { "fs_user_id", VALID_FS_USER_ID },
+                { "email", "user@example.com" },
+            };
+            manager.IdentifyUser(identifiers);
             manager.Dispose();
 
             _mockLogger.Verify(l =>
                 l.Log(LogLevel.DEBUG, "ODP identify event not dispatched (ODP disabled)."));
-            _mockOdpEventManager.Verify(e => e.IdentifyUser(It.IsAny<string>()), Times.Never);
+            _mockOdpEventManager.Verify(e => e.IdentifyUser(It.IsAny<Dictionary<string, string>>()), Times.Never);
         }
 
         [Test]

--- a/OptimizelySDK.Tests/OptimizelyTest.cs
+++ b/OptimizelySDK.Tests/OptimizelyTest.cs
@@ -6232,7 +6232,11 @@ namespace OptimizelySDK.Tests
         public void TestIdentifyUserInvalidOptimizelyObject()
         {
             var optly = new Optimizely("Random datafile", null, LoggerMock.Object);
-            optly.IdentifyUser("some_user");
+            var identifiers = new Dictionary<string, string>
+            {
+                { "fs_user_id", "some_user" },
+            };
+            optly.IdentifyUser(identifiers);
             LoggerMock.Verify(
                 l => l.Log(LogLevel.ERROR, "Datafile has invalid format. Failing 'IdentifyUser'."),
                 Times.Once);

--- a/OptimizelySDK/Odp/IOdpEventManager.cs
+++ b/OptimizelySDK/Odp/IOdpEventManager.cs
@@ -15,6 +15,7 @@
  */
 
 using System;
+using System.Collections.Generic;
 using OptimizelySDK.Odp.Entity;
 
 namespace OptimizelySDK.Odp
@@ -52,10 +53,10 @@ namespace OptimizelySDK.Odp
         void Dispose();
 
         /// <summary>
-        /// Associate a full-stack userid with an established VUID
+        /// Send an identify event with the provided identifiers
         /// </summary>
-        /// <param name="userId">Full-stack User ID</param>
-        void IdentifyUser(string userId);
+        /// <param name="identifiers">Dictionary of identifier key-value pairs</param>
+        void IdentifyUser(Dictionary<string, string> identifiers);
 
         /// <summary>
         /// Update ODP configuration settings

--- a/OptimizelySDK/Odp/IOdpManager.cs
+++ b/OptimizelySDK/Odp/IOdpManager.cs
@@ -41,10 +41,10 @@ namespace OptimizelySDK.Odp
         string[] FetchQualifiedSegments(string userId, List<OdpSegmentOption> options);
 
         /// <summary>
-        /// Send identification event to ODP for a given full-stack User ID
+        /// Send identification event to ODP when 2+ valid identifiers are provided
         /// </summary>
-        /// <param name="userId">User ID to send</param>
-        void IdentifyUser(string userId);
+        /// <param name="identifiers">Dictionary of identifier key-value pairs</param>
+        void IdentifyUser(Dictionary<string, string> identifiers);
 
         /// <summary>
         /// Add event to queue for sending to ODP

--- a/OptimizelySDK/Odp/OdpEventManager.cs
+++ b/OptimizelySDK/Odp/OdpEventManager.cs
@@ -368,16 +368,11 @@ namespace OptimizelySDK.Odp
         }
 
         /// <summary>
-        /// Associate a full-stack userid with an established VUID
+        /// Send an identify event with the provided identifiers
         /// </summary>
-        /// <param name="userId">Full-stack User ID</param>
-        public void IdentifyUser(string userId)
+        /// <param name="identifiers">Dictionary of identifier key-value pairs</param>
+        public void IdentifyUser(Dictionary<string, string> identifiers)
         {
-            var identifiers = new Dictionary<string, string>
-            {
-                { Constants.FS_USER_ID, userId },
-            };
-
             var odpEvent = new OdpEvent(Constants.ODP_EVENT_TYPE, "identified", identifiers);
             SendEvent(odpEvent);
         }

--- a/OptimizelySDK/Odp/OdpManager.cs
+++ b/OptimizelySDK/Odp/OdpManager.cs
@@ -97,10 +97,10 @@ namespace OptimizelySDK.Odp
         }
 
         /// <summary>
-        /// Send identification event to ODP for a given full-stack User ID
+        /// Send identification event to ODP when 2+ valid identifiers are provided
         /// </summary>
-        /// <param name="userId">User ID to send</param>
-        public void IdentifyUser(string userId)
+        /// <param name="identifiers">Dictionary of identifier key-value pairs</param>
+        public void IdentifyUser(Dictionary<string, string> identifiers)
         {
             if (EventManagerOrConfigNotReady())
             {
@@ -108,7 +108,23 @@ namespace OptimizelySDK.Odp
                 return;
             }
 
-            EventManager.IdentifyUser(userId);
+            var validIdentifiers = new Dictionary<string, string>();
+            foreach (var kvp in identifiers)
+            {
+                if (!string.IsNullOrEmpty(kvp.Value))
+                {
+                    validIdentifiers[kvp.Key] = kvp.Value;
+                }
+            }
+
+            if (validIdentifiers.Count < 2)
+            {
+                _logger.Log(LogLevel.DEBUG,
+                    "ODP identify event is not dispatched (only one identifier provided).");
+                return;
+            }
+
+            EventManager.IdentifyUser(validIdentifiers);
         }
 
         /// <summary>

--- a/OptimizelySDK/Optimizely.cs
+++ b/OptimizelySDK/Optimizely.cs
@@ -1499,8 +1499,8 @@ namespace OptimizelySDK
         /// <summary>
         /// Send identification event to Optimizely Data Platform
         /// </summary>
-        /// <param name="userId">FS User ID to send</param>
-        internal void IdentifyUser(string userId)
+        /// <param name="identifiers">Dictionary of identifier key-value pairs</param>
+        internal void IdentifyUser(Dictionary<string, string> identifiers)
         {
             var config = ProjectConfigManager?.GetConfig();
 
@@ -1510,7 +1510,7 @@ namespace OptimizelySDK
                 return;
             }
 
-            OdpManager?.IdentifyUser(userId);
+            OdpManager?.IdentifyUser(identifiers);
         }
 
         /// <summary>

--- a/OptimizelySDK/OptimizelyUserContext.cs
+++ b/OptimizelySDK/OptimizelyUserContext.cs
@@ -91,7 +91,11 @@ namespace OptimizelySDK
 #if USE_ODP
             if (shouldIdentifyUser)
             {
-                optimizely.IdentifyUser(UserId);
+                var identifiers = new Dictionary<string, string>
+                {
+                    { Odp.Constants.FS_USER_ID, UserId },
+                };
+                optimizely.IdentifyUser(identifiers);
             }
 #endif
         }


### PR DESCRIPTION
## Summary

Skip ODP identify event dispatch when only a single identifier is provided (e.g., just `fs_user_id`). Send ODP identify event only when 2+ valid (non-null, non-empty) identifiers exist, and propagate identifiers as a Dictionary through the full IdentifyUser call chain instead of a plain userId string.

## Changes

- Skip ODP identify event when fewer than 2 valid identifiers are present
- Change IdentifyUser call chain to accept and forward an identifiers dictionary instead of a single userId string
- Filter out null and empty identifier values before counting
- Update tests to reflect dictionary-based identifier propagation

## Jira Ticket

[FSSDK-12721](https://optimizely-ext.atlassian.net/browse/FSSDK-12721)

[FSSDK-12721]: https://optimizely-ext.atlassian.net/browse/FSSDK-12721?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ