### PR TITLE
[AI-FSSDK] [FSSDK-12792] Add localHoldouts section to datafile

### DIFF
--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -1418,9 +1418,142 @@ namespace OptimizelySDK.Tests
             Assert.IsNotNull(datafileProjectConfig.Holdouts);
             Assert.AreEqual(0, datafileProjectConfig.Holdouts.Length);
 
+            Assert.IsNotNull(datafileProjectConfig.LocalHoldouts);
+            Assert.AreEqual(0, datafileProjectConfig.LocalHoldouts.Length);
+
             // Methods should still work with empty holdouts
             var holdout = datafileProjectConfig.GetHoldout("any_id");
             Assert.IsNull(holdout);
+        }
+
+        [Test]
+        public void TestLocalHoldoutsSection_ParsedSeparatelyFromHoldouts()
+        {
+            // Test that localHoldouts are parsed from the new datafile section
+            var testDataPath = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                "TestData", "HoldoutTestData.json");
+            var jsonContent = File.ReadAllText(testDataPath);
+            var testData = JObject.Parse(jsonContent);
+
+            var datafileJson = testData["datafileWithLocalHoldouts"].ToString();
+            var datafileProjectConfig = DatafileProjectConfig.Create(datafileJson,
+                new NoOpLogger(), new NoOpErrorHandler()) as DatafileProjectConfig;
+
+            // holdouts section has 1 global holdout
+            Assert.AreEqual(1, datafileProjectConfig.Holdouts.Length,
+                "holdouts section should contain only global holdouts");
+            Assert.AreEqual("holdout_global_2", datafileProjectConfig.Holdouts[0].Id);
+
+            // Global holdout should have IncludedRules stripped to null
+            Assert.IsNull(datafileProjectConfig.Holdouts[0].IncludedRules,
+                "Global holdout should have IncludedRules stripped to null");
+            Assert.IsTrue(datafileProjectConfig.Holdouts[0].IsGlobal);
+
+            // localHoldouts section has 4 local holdouts (all with valid includedRules)
+            Assert.AreEqual(4, datafileProjectConfig.LocalHoldouts.Length,
+                "localHoldouts section should contain local holdouts with valid includedRules");
+
+            // Verify each local holdout has IncludedRules set
+            foreach (var localHoldout in datafileProjectConfig.LocalHoldouts)
+            {
+                Assert.IsNotNull(localHoldout.IncludedRules,
+                    $"Local holdout {localHoldout.Key} should have IncludedRules set");
+                Assert.IsFalse(localHoldout.IsGlobal,
+                    $"Local holdout {localHoldout.Key} should not be global");
+            }
+        }
+
+        [Test]
+        public void TestHoldoutsSection_IncludedRulesStrippedAtParseTime()
+        {
+            // Test that includedRules on entries in holdouts section is stripped.
+            // Even if the backend accidentally puts includedRules on a global holdout,
+            // the SDK ignores it because section membership is the sole signal.
+            var datafileWithIncludedRulesOnGlobal = @"{
+                ""version"": ""4"",
+                ""rollouts"": [],
+                ""projectId"": ""test_project"",
+                ""experiments"": [],
+                ""groups"": [],
+                ""attributes"": [],
+                ""audiences"": [],
+                ""layers"": [],
+                ""events"": [],
+                ""revision"": ""1"",
+                ""featureFlags"": [],
+                ""holdouts"": [
+                    {
+                        ""id"": ""ho_1"",
+                        ""key"": ""holdout_with_stale_rules"",
+                        ""status"": ""Running"",
+                        ""variations"": [],
+                        ""trafficAllocation"": [],
+                        ""audienceIds"": [],
+                        ""includedRules"": [""rule_123""]
+                    }
+                ]
+            }";
+
+            var config = DatafileProjectConfig.Create(datafileWithIncludedRulesOnGlobal,
+                new NoOpLogger(), new NoOpErrorHandler()) as DatafileProjectConfig;
+
+            Assert.AreEqual(1, config.Holdouts.Length);
+            Assert.IsNull(config.Holdouts[0].IncludedRules,
+                "includedRules on holdouts-section entries must be stripped at parse time");
+            Assert.IsTrue(config.Holdouts[0].IsGlobal,
+                "Holdout from holdouts section must be treated as global");
+        }
+
+        [Test]
+        public void TestLocalHoldoutsWithoutIncludedRules_ExcludedAndLogged()
+        {
+            // Test that localHoldouts entries without includedRules are excluded
+            var datafileWithInvalidLocal = @"{
+                ""version"": ""4"",
+                ""rollouts"": [],
+                ""projectId"": ""test_project"",
+                ""experiments"": [],
+                ""groups"": [],
+                ""attributes"": [],
+                ""audiences"": [],
+                ""layers"": [],
+                ""events"": [],
+                ""revision"": ""1"",
+                ""featureFlags"": [],
+                ""localHoldouts"": [
+                    {
+                        ""id"": ""ho_valid"",
+                        ""key"": ""valid_local"",
+                        ""status"": ""Running"",
+                        ""variations"": [],
+                        ""trafficAllocation"": [],
+                        ""audienceIds"": [],
+                        ""includedRules"": [""rule_1""]
+                    },
+                    {
+                        ""id"": ""ho_invalid"",
+                        ""key"": ""invalid_local_no_rules"",
+                        ""status"": ""Running"",
+                        ""variations"": [],
+                        ""trafficAllocation"": [],
+                        ""audienceIds"": []
+                    }
+                ]
+            }";
+
+            var loggerMock = new Mock<ILogger>();
+            var config = DatafileProjectConfig.Create(datafileWithInvalidLocal,
+                loggerMock.Object, new NoOpErrorHandler()) as DatafileProjectConfig;
+
+            // Only the valid local holdout should remain
+            Assert.AreEqual(1, config.LocalHoldouts.Length,
+                "Only valid local holdouts with includedRules should be kept");
+            Assert.AreEqual("ho_valid", config.LocalHoldouts[0].Id);
+
+            // Verify error was logged for the invalid entry
+            loggerMock.Verify(l => l.Log(LogLevel.ERROR,
+                It.Is<string>(s => s.Contains("invalid_local_no_rules") && s.Contains("no includedRules"))),
+                Times.Once);
         }
 
         #endregion

--- a/OptimizelySDK.Tests/TestData/HoldoutTestData.json
+++ b/OptimizelySDK.Tests/TestData/HoldoutTestData.json
@@ -391,7 +391,9 @@
         ],
         "audienceIds": [],
         "audienceConditions": []
-      },
+      }
+    ],
+    "localHoldouts": [
       {
         "id": "holdout_local_rule1",
         "key": "local_holdout_rule1",

--- a/OptimizelySDK/Bucketing/DecisionService.cs
+++ b/OptimizelySDK/Bucketing/DecisionService.cs
@@ -916,7 +916,7 @@ namespace OptimizelySDK.Bucketing
 
             var userId = user.GetUserId();
 
-            // Check global holdouts first (highest priority — evaluated at flag level, before any rules)
+            // Check global holdouts first (from holdouts section — evaluated at flag level, before any rules)
             var globalHoldouts = projectConfig.GetGlobalHoldouts();
             foreach (var holdout in globalHoldouts)
             {

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -299,9 +299,16 @@ namespace OptimizelySDK.Config
         public Rollout[] Rollouts { get; set; }
 
         /// <summary>
-        /// Associative list of Holdouts.
+        /// Global holdouts from the datafile "holdouts" section.
+        /// All entries are treated as global; any includedRules is stripped at parse time.
         /// </summary>
         public Holdout[] Holdouts { get; set; }
+
+        /// <summary>
+        /// Local holdouts from the datafile "localHoldouts" section.
+        /// Each entry must have includedRules; entries without it are invalid and excluded at parse time.
+        /// </summary>
+        public Holdout[] LocalHoldouts { get; set; }
 
         /// <summary>
         /// Associative list of Integrations.
@@ -327,6 +334,7 @@ namespace OptimizelySDK.Config
             FeatureFlags = FeatureFlags ?? new FeatureFlag[0];
             Rollouts = Rollouts ?? new Rollout[0];
             Holdouts = Holdouts ?? new Holdout[0];
+            LocalHoldouts = LocalHoldouts ?? new Holdout[0];
             Integrations = Integrations ?? new Integration[0];
             _ExperimentKeyMap = new Dictionary<string, Experiment>();
 
@@ -422,11 +430,16 @@ namespace OptimizelySDK.Config
                 }
             }
 
-            // Adding Holdout variations in variation id and key maps.
+            // Process holdouts section: entries are global by section membership.
+            // Strip any includedRules so they are treated as global holdouts.
             if (Holdouts != null)
             {
                 foreach (var holdout in Holdouts)
                 {
+                    // Section membership is the sole signal for scope.
+                    // Strip includedRules from holdouts-section entries at parse time.
+                    holdout.IncludedRules = null;
+
                     _VariationKeyMap[holdout.Key] = new Dictionary<string, Variation>();
                     _VariationIdMap[holdout.Key] = new Dictionary<string, Variation>();
                     _VariationIdMapByExperimentId[holdout.Id] = new Dictionary<string, Variation>();
@@ -444,6 +457,43 @@ namespace OptimizelySDK.Config
                     }
                 }
             }
+
+            // Process localHoldouts section: entries must have includedRules.
+            // Validate and skip entries without includedRules (log error).
+            var validLocalHoldouts = new List<Holdout>();
+            if (LocalHoldouts != null)
+            {
+                foreach (var localHoldout in LocalHoldouts)
+                {
+                    if (localHoldout.IncludedRules == null)
+                    {
+                        Logger.Log(LogLevel.ERROR,
+                            $"Local holdout \"{localHoldout.Key}\" (id: {localHoldout.Id}) in localHoldouts section has no includedRules. Excluding from evaluation.");
+                        continue;
+                    }
+
+                    validLocalHoldouts.Add(localHoldout);
+
+                    _VariationKeyMap[localHoldout.Key] = new Dictionary<string, Variation>();
+                    _VariationIdMap[localHoldout.Key] = new Dictionary<string, Variation>();
+                    _VariationIdMapByExperimentId[localHoldout.Id] = new Dictionary<string, Variation>();
+                    _VariationKeyMapByExperimentId[localHoldout.Id] = new Dictionary<string, Variation>();
+
+                    if (localHoldout.Variations != null)
+                    {
+                        foreach (var variation in localHoldout.Variations)
+                        {
+                            _VariationKeyMap[localHoldout.Key][variation.Key] = variation;
+                            _VariationIdMap[localHoldout.Key][variation.Id] = variation;
+                            _VariationKeyMapByExperimentId[localHoldout.Id][variation.Key] = variation;
+                            _VariationIdMapByExperimentId[localHoldout.Id][variation.Id] = variation;
+                        }
+                    }
+                }
+            }
+
+            // Store only valid local holdouts
+            LocalHoldouts = validLocalHoldouts.ToArray();
 
             // Inject "everyone else" variation into feature_rollout experiments
             foreach (var feature in FeatureFlags)
@@ -561,8 +611,11 @@ namespace OptimizelySDK.Config
 
             _FlagVariationMap = flagToVariationsMap;
 
-            // Initialize HoldoutConfig for managing flag-to-holdout relationships
-            _holdoutConfig = new HoldoutConfig(Holdouts ?? new Holdout[0]);
+            // Initialize HoldoutConfig with global holdouts (from holdouts section)
+            // and local holdouts (from localHoldouts section, validated above).
+            var allHoldoutsForConfig = (Holdouts ?? new Holdout[0])
+                .Concat(LocalHoldouts ?? new Holdout[0]).ToArray();
+            _holdoutConfig = new HoldoutConfig(allHoldoutsForConfig);
         }
 
         /// <summary>
@@ -910,8 +963,7 @@ namespace OptimizelySDK.Config
         }
 
         /// <summary>
-        /// Returns all global holdouts (holdouts where IncludedRules is null).
-        /// Global holdouts apply to all rules across all flags and are evaluated at flag level.
+        /// Returns all global holdouts (from holdouts section, evaluated at flag level).
         /// </summary>
         /// <returns>Read-only list of global holdouts</returns>
         public List<Holdout> GetGlobalHoldouts()
@@ -920,8 +972,7 @@ namespace OptimizelySDK.Config
         }
 
         /// <summary>
-        /// Returns local holdouts that target a specific rule ID.
-        /// Local holdouts are evaluated per-rule, after forced decisions but before regular rule evaluation.
+        /// Returns local holdouts (from localHoldouts section) targeting a specific rule ID.
         /// </summary>
         /// <param name="ruleId">The rule ID to look up holdouts for</param>
         /// <returns>Read-only list of local holdouts targeting the given rule, or empty list if none</returns>

--- a/OptimizelySDK/Entity/Holdout.cs
+++ b/OptimizelySDK/Entity/Holdout.cs
@@ -47,16 +47,13 @@ namespace OptimizelySDK.Entity
         }
 
         /// <summary>
-        /// Optional array of rule IDs that this holdout targets (local holdout).
-        /// When null, the holdout applies to all rules across all flags (global holdout).
-        /// When set to an array (even empty), the holdout only applies to the specified rules.
-        /// Rule IDs in this array are experiment/delivery rule IDs from the datafile, NOT flag IDs.
+        /// Rule IDs this holdout targets. Scope is determined by datafile section membership:
+        /// holdouts section entries have this stripped to null; localHoldouts entries must have it set.
         /// </summary>
         public string[] IncludedRules { get; set; }
 
         /// <summary>
-        /// Returns true if this is a global holdout (IncludedRules is null),
-        /// false if this is a local holdout (IncludedRules is a non-null array).
+        /// True if global (from holdouts section, IncludedRules is null at parse time).
         /// </summary>
         public bool IsGlobal => IncludedRules == null;
     }

--- a/OptimizelySDK/ProjectConfig.cs
+++ b/OptimizelySDK/ProjectConfig.cs
@@ -181,9 +181,16 @@ namespace OptimizelySDK
         Rollout[] Rollouts { get; set; }
 
         /// <summary>
-        /// Associative list of Holdouts.
+        /// Global holdouts from the datafile "holdouts" section.
+        /// All entries are treated as global; any includedRules on these entries is stripped at parse time.
         /// </summary>
         Holdout[] Holdouts { get; set; }
+
+        /// <summary>
+        /// Local holdouts from the datafile "localHoldouts" section.
+        /// Each entry must have includedRules; entries without it are invalid and excluded at parse time.
+        /// </summary>
+        Holdout[] LocalHoldouts { get; set; }
 
         /// <summary>
         /// Associative list of Integrations.
@@ -333,15 +340,13 @@ namespace OptimizelySDK
         Holdout GetHoldout(string holdoutId);
 
         /// <summary>
-        /// Returns all global holdouts (holdouts where IncludedRules is null).
-        /// Global holdouts apply to all rules across all flags and are evaluated at flag level.
+        /// Returns all global holdouts (from holdouts section, evaluated at flag level).
         /// </summary>
         /// <returns>Read-only list of global holdouts</returns>
         List<Holdout> GetGlobalHoldouts();
 
         /// <summary>
-        /// Returns local holdouts that target a specific rule ID.
-        /// Local holdouts are evaluated per-rule, after forced decisions but before regular rule evaluation.
+        /// Returns local holdouts (from localHoldouts section) targeting a specific rule ID.
         /// </summary>
         /// <param name="ruleId">The rule ID to look up holdouts for</param>
         /// <returns>Read-only list of local holdouts targeting the given rule, or empty list if none</returns>

--- a/OptimizelySDK/Utils/HoldoutConfig.cs
+++ b/OptimizelySDK/Utils/HoldoutConfig.cs
@@ -21,8 +21,8 @@ using OptimizelySDK.Entity;
 namespace OptimizelySDK.Utils
 {
     /// <summary>
-    /// Configuration manager for holdouts, providing holdout ID mapping,
-    /// global holdout access, and rule-level local holdout lookups.
+    /// Manages holdout ID mapping, global holdout access, and rule-level local holdout lookups.
+    /// Scope is determined by datafile section: holdouts = global, localHoldouts = rule-scoped.
     /// </summary>
     public class HoldoutConfig
     {
@@ -30,14 +30,12 @@ namespace OptimizelySDK.Utils
         private readonly Dictionary<string, Holdout> _holdoutIdMap;
 
         /// <summary>
-        /// Global holdouts — holdouts where IncludedRules is null.
-        /// These are evaluated at flag level, before any per-rule logic.
+        /// Global holdouts (from holdouts section; IncludedRules is null).
         /// </summary>
         private readonly List<Holdout> _globalHoldouts;
 
         /// <summary>
-        /// Maps rule IDs to the local holdouts that target those rules.
-        /// A local holdout has IncludedRules set to a non-null array of rule IDs.
+        /// Maps rule IDs to the local holdouts (from localHoldouts section) that target those rules.
         /// </summary>
         private readonly Dictionary<string, List<Holdout>> _ruleHoldoutsMap;
 
@@ -75,16 +73,14 @@ namespace OptimizelySDK.Utils
                 // Build ID mapping
                 _holdoutIdMap[holdout.Id] = holdout;
 
-                // Classify as global or local based on IncludedRules
+                // Classify by IncludedRules: null = global (holdouts section),
+                // non-null = local (localHoldouts section).
                 if (holdout.IsGlobal)
                 {
-                    // IncludedRules == null → global holdout (applies to all rules across all flags)
                     _globalHoldouts.Add(holdout);
                 }
                 else
                 {
-                    // IncludedRules != null → local holdout (applies only to the specified rules)
-                    // An empty IncludedRules array means local but matches no rules (intentional).
                     foreach (var ruleId in holdout.IncludedRules)
                     {
                         if (!_ruleHoldoutsMap.ContainsKey(ruleId))
@@ -116,8 +112,7 @@ namespace OptimizelySDK.Utils
         }
 
         /// <summary>
-        /// Returns all global holdouts (holdouts where IncludedRules is null).
-        /// These apply to all rules across all flags and are evaluated at flag level.
+        /// Returns all global holdouts (from holdouts section, evaluated at flag level).
         /// </summary>
         /// <returns>List of global holdouts</returns>
         public List<Holdout> GetGlobalHoldouts()
@@ -126,8 +121,7 @@ namespace OptimizelySDK.Utils
         }
 
         /// <summary>
-        /// Returns local holdouts that target a specific rule ID.
-        /// These are evaluated per-rule, after forced decisions but before regular rule evaluation.
+        /// Returns local holdouts (from localHoldouts section) targeting a specific rule ID.
         /// </summary>
         /// <param name="ruleId">The rule ID to look up holdouts for</param>
         /// <returns>List of holdouts targeting the specified rule, or an empty list if none</returns>


### PR DESCRIPTION
## Summary\n\n- Add new top-level `localHoldouts` section to datafile parsing for backward-compatible local holdout support\n- Strip `includedRules` from `holdouts` section entries at parse time (section membership is the sole scope signal)\n- Validate `localHoldouts` entries have `includedRules`; log error and exclude invalid entries\n- Update docstrings to reflect section-based scope determination\n\n## Changes\n\n- **OptimizelySDK/ProjectConfig.cs** - Added `LocalHoldouts` property to interface\n- **OptimizelySDK/Config/DatafileProjectConfig.cs** - Core parsing: strips `IncludedRules` from holdouts entries, validates localHoldouts entries, registers local holdout variations\n- **OptimizelySDK/Entity/Holdout.cs** - Updated `IncludedRules` and `IsGlobal` docstrings\n- **OptimizelySDK/Utils/HoldoutConfig.cs** - Updated class and method docstrings\n- **OptimizelySDK/Bucketing/DecisionService.cs** - Updated comment on global holdout check\n- **OptimizelySDK.Tests/TestData/HoldoutTestData.json** - Moved local holdouts to `localHoldouts` section\n- **OptimizelySDK.Tests/ProjectConfigTest.cs** - Added 4 new tests for parsing, stripping, validation, and backward compatibility\n\n## Jira Ticket\n\n[FSSDK-12792](https://optimizely-ext.atlassian.net/browse/FSSDK-12792)