### PR TITLE
[AI-FSSDK] [FSSDK-12792] Add localHoldouts datafile section for backward-compatible local holdout support

### DIFF
--- a/OptimizelySDK.Tests/DecisionServiceHoldoutTest.cs
+++ b/OptimizelySDK.Tests/DecisionServiceHoldoutTest.cs
@@ -370,9 +370,13 @@ namespace OptimizelySDK.Tests
             Assert.AreEqual(1, globalHoldouts.Count, "Should have exactly one global holdout");
             Assert.AreEqual("holdout_global_2", globalHoldouts[0].Id, "Global holdout id should match");
 
-            // Verify that the global holdout is classified correctly
+            // Verify that the global holdout is classified correctly by section membership
             Assert.IsTrue(globalHoldouts[0].IsGlobal,
-                "holdout_global_2 should be global (IncludedRules is null)");
+                "holdout_global_2 should be global (from holdouts section)");
+
+            // Verify that IncludedRules is stripped from global holdout at parse time
+            Assert.IsNull(globalHoldouts[0].IncludedRules,
+                "IncludedRules should be stripped from global holdouts at parse time");
 
             // Verify GetHoldoutsForRule returns empty for a delivery rule since it's global
             var localForRule1 = LocalHoldoutsConfig.GetHoldoutsForRule("rule_id_1");
@@ -642,6 +646,113 @@ namespace OptimizelySDK.Tests
                 "Decision source should be holdout since local holdout targets the experiment rule");
             Assert.AreEqual("local_holdout_exp_rule1", decision.Experiment?.Key,
                 "Decision experiment should be the local holdout targeting exp_rule_id_1");
+        }
+
+        // =====================================================================
+        // Level 3: localHoldouts datafile section tests (FSSDK-12792)
+        // =====================================================================
+
+        [Test]
+        public void TestLocalHoldoutsSection_ParsedSeparatelyFromHoldoutsSection()
+        {
+            // Verify that localHoldouts are parsed from the "localHoldouts" section
+            // and holdouts from the "holdouts" section
+            InitializeLocalHoldoutsConfig();
+
+            // Global holdouts come from "holdouts" section
+            Assert.IsNotNull(LocalHoldoutsConfig.Holdouts, "Holdouts should not be null");
+            Assert.AreEqual(1, LocalHoldoutsConfig.Holdouts.Length,
+                "Should have 1 global holdout in the holdouts section");
+            Assert.AreEqual("holdout_global_2", LocalHoldoutsConfig.Holdouts[0].Id);
+            Assert.IsTrue(LocalHoldoutsConfig.Holdouts[0].IsGlobal,
+                "Holdout from holdouts section should have IsGlobal=true");
+
+            // Local holdouts come from "localHoldouts" section (minus invalid ones)
+            Assert.IsNotNull(LocalHoldoutsConfig.LocalHoldouts, "LocalHoldouts should not be null");
+            // holdout_local_empty_rules and holdout_local_no_rules are invalid (empty/null includedRules)
+            Assert.AreEqual(3, LocalHoldoutsConfig.LocalHoldouts.Length,
+                "Should have 3 valid local holdouts (empty-rules and no-rules entries excluded)");
+
+            foreach (var localHoldout in LocalHoldoutsConfig.LocalHoldouts)
+            {
+                Assert.IsFalse(localHoldout.IsGlobal,
+                    $"Local holdout {localHoldout.Key} from localHoldouts section should have IsGlobal=false");
+                Assert.IsNotNull(localHoldout.IncludedRules,
+                    $"Valid local holdout {localHoldout.Key} should have non-null IncludedRules");
+                Assert.IsTrue(localHoldout.IncludedRules.Length > 0,
+                    $"Valid local holdout {localHoldout.Key} should have non-empty IncludedRules");
+            }
+        }
+
+        [Test]
+        public void TestIncludedRulesStrippedFromGlobalHoldoutsAtParseTime()
+        {
+            // The datafile has "includedRules": ["should_be_stripped"] on holdout_global_2.
+            // After parsing, IncludedRules should be null because section membership is the sole signal.
+            InitializeLocalHoldoutsConfig();
+
+            var globalHoldout = LocalHoldoutsConfig.Holdouts[0];
+            Assert.AreEqual("holdout_global_2", globalHoldout.Id);
+            Assert.IsNull(globalHoldout.IncludedRules,
+                "IncludedRules on a global holdout (from holdouts section) must be stripped to null at parse time");
+            Assert.IsTrue(globalHoldout.IsGlobal,
+                "Holdout from holdouts section must be global regardless of original includedRules value");
+        }
+
+        [Test]
+        public void TestInvalidLocalHoldout_MissingIncludedRules_ExcludedWithError()
+        {
+            // holdout_local_no_rules has no includedRules field → should be excluded with error log
+            // holdout_local_empty_rules has includedRules: [] → should also be excluded with error log
+            InitializeLocalHoldoutsConfig();
+
+            // Verify these invalid entries are excluded
+            var allLocalHoldoutIds = LocalHoldoutsConfig.LocalHoldouts.Select(h => h.Id).ToList();
+            Assert.IsFalse(allLocalHoldoutIds.Contains("holdout_local_no_rules"),
+                "Local holdout without includedRules should be excluded from evaluation");
+            Assert.IsFalse(allLocalHoldoutIds.Contains("holdout_local_empty_rules"),
+                "Local holdout with empty includedRules should be excluded from evaluation");
+
+            // Verify error was logged for invalid local holdouts
+            // Use AtLeastOnce because the shared LoggerMock may accumulate calls from
+            // other tests in this fixture that also call InitializeLocalHoldoutsConfig().
+            LoggerMock.Verify(l => l.Log(LogLevel.ERROR,
+                    It.Is<string>(s => s.Contains("local_holdout_no_rules") && s.Contains("missing includedRules"))),
+                Times.AtLeastOnce, "Should log error for local holdout missing includedRules");
+            LoggerMock.Verify(l => l.Log(LogLevel.ERROR,
+                    It.Is<string>(s => s.Contains("local_holdout_empty_rules") && s.Contains("missing includedRules"))),
+                Times.AtLeastOnce, "Should log error for local holdout with empty includedRules");
+        }
+
+        [Test]
+        public void TestBackwardCompatibility_DatafileWithoutLocalHoldoutsSection()
+        {
+            // The datafileWithHoldouts fixture has no "localHoldouts" key.
+            // All holdouts in the "holdouts" section should be treated as global.
+            var datafileWithHoldouts = TestData["datafileWithHoldouts"].ToString();
+            var oldConfig = DatafileProjectConfig.Create(datafileWithHoldouts, LoggerMock.Object,
+                new NoOpErrorHandler()) as DatafileProjectConfig;
+
+            Assert.IsNotNull(oldConfig, "Config should be created from old-format datafile");
+
+            // LocalHoldouts should be an empty array (initialized by default)
+            Assert.IsNotNull(oldConfig.LocalHoldouts, "LocalHoldouts should not be null even when absent from datafile");
+            Assert.AreEqual(0, oldConfig.LocalHoldouts.Length,
+                "LocalHoldouts should be empty when not present in datafile");
+
+            // All holdouts should be global
+            foreach (var holdout in oldConfig.Holdouts)
+            {
+                Assert.IsTrue(holdout.IsGlobal,
+                    $"Holdout {holdout.Key} from holdouts section should be global");
+                Assert.IsNull(holdout.IncludedRules,
+                    $"IncludedRules should be stripped from holdout {holdout.Key}");
+            }
+
+            // GetGlobalHoldouts should return all holdouts
+            var globals = oldConfig.GetGlobalHoldouts();
+            Assert.AreEqual(oldConfig.Holdouts.Length, globals.Count,
+                "All holdouts from old-format datafile should be global");
         }
     }
 }

--- a/OptimizelySDK.Tests/ProjectConfigTest.cs
+++ b/OptimizelySDK.Tests/ProjectConfigTest.cs
@@ -1418,6 +1418,9 @@ namespace OptimizelySDK.Tests
             Assert.IsNotNull(datafileProjectConfig.Holdouts);
             Assert.AreEqual(0, datafileProjectConfig.Holdouts.Length);
 
+            Assert.IsNotNull(datafileProjectConfig.LocalHoldouts);
+            Assert.AreEqual(0, datafileProjectConfig.LocalHoldouts.Length);
+
             // Methods should still work with empty holdouts
             var holdout = datafileProjectConfig.GetHoldout("any_id");
             Assert.IsNull(holdout);

--- a/OptimizelySDK.Tests/TestData/HoldoutTestData.json
+++ b/OptimizelySDK.Tests/TestData/HoldoutTestData.json
@@ -390,8 +390,11 @@
           }
         ],
         "audienceIds": [],
-        "audienceConditions": []
-      },
+        "audienceConditions": [],
+        "includedRules": ["should_be_stripped"]
+      }
+    ],
+    "localHoldouts": [
       {
         "id": "holdout_local_rule1",
         "key": "local_holdout_rule1",
@@ -460,6 +463,28 @@
         "audienceIds": [],
         "audienceConditions": [],
         "includedRules": []
+      },
+      {
+        "id": "holdout_local_no_rules",
+        "key": "local_holdout_no_rules",
+        "status": "Running",
+        "layerId": "layer_local_no_rules",
+        "variations": [
+          {
+            "id": "lvar_no_rules",
+            "key": "local_no_rules_off",
+            "featureEnabled": false,
+            "variables": []
+          }
+        ],
+        "trafficAllocation": [
+          {
+            "entityId": "lvar_no_rules",
+            "endOfRange": 10000
+          }
+        ],
+        "audienceIds": [],
+        "audienceConditions": []
       },
       {
         "id": "holdout_local_exp_rule1",

--- a/OptimizelySDK.Tests/UtilsTests/HoldoutConfigBasicTests.cs
+++ b/OptimizelySDK.Tests/UtilsTests/HoldoutConfigBasicTests.cs
@@ -126,47 +126,38 @@ namespace OptimizelySDK.Tests
         }
 
         // =====================================================================
-        // Level 1: Local Holdout / IsGlobal Classification Tests (FSSDK-12369)
+        // Level 1: IsGlobal Classification Tests (section-based scope)
         // =====================================================================
 
         [Test]
-        public void TestIsGlobal_NullIncludedRules_IsGlobal()
+        public void TestIsGlobal_DefaultIsTrue()
         {
-            // A holdout with IncludedRules == null is a global holdout
+            // By default, IsGlobal is true (holdout from "holdouts" section)
             var holdout = CreateTestHoldout("h1", "global_holdout");
-            holdout.IncludedRules = null;
 
-            Assert.IsTrue(holdout.IsGlobal, "Holdout with null IncludedRules should be global");
+            Assert.IsTrue(holdout.IsGlobal, "Holdout should default to global (IsGlobal=true)");
         }
 
         [Test]
-        public void TestIsGlobal_EmptyIncludedRules_IsNotGlobal()
+        public void TestIsGlobal_SetToFalse_IsLocal()
         {
-            // A holdout with IncludedRules == [] is LOCAL (empty array, not null)
-            var holdout = CreateTestHoldout("h1", "local_holdout_empty");
-            holdout.IncludedRules = new string[0];
-
-            Assert.IsFalse(holdout.IsGlobal, "Holdout with empty array IncludedRules should NOT be global");
-        }
-
-        [Test]
-        public void TestIsGlobal_NonEmptyIncludedRules_IsNotGlobal()
-        {
-            // A holdout with IncludedRules = ["rule_1"] is a local holdout
+            // Holdout from "localHoldouts" section has IsGlobal=false
             var holdout = CreateTestHoldout("h1", "local_holdout");
+            holdout.IsGlobal = false;
             holdout.IncludedRules = new[] { "rule_1" };
 
-            Assert.IsFalse(holdout.IsGlobal, "Holdout with non-empty IncludedRules should NOT be global");
+            Assert.IsFalse(holdout.IsGlobal, "Holdout with IsGlobal=false should be local");
         }
 
         [Test]
         public void TestGetGlobalHoldouts_ReturnsOnlyGlobalHoldouts()
         {
             var globalHoldout = CreateTestHoldout("global_id", "global_key");
-            globalHoldout.IncludedRules = null; // global
+            globalHoldout.IsGlobal = true;
 
             var localHoldout = CreateTestHoldout("local_id", "local_key");
-            localHoldout.IncludedRules = new[] { "rule_1" }; // local
+            localHoldout.IsGlobal = false;
+            localHoldout.IncludedRules = new[] { "rule_1" };
 
             var config = new HoldoutConfig(new[] { globalHoldout, localHoldout });
 
@@ -179,7 +170,8 @@ namespace OptimizelySDK.Tests
         public void TestGetGlobalHoldouts_NoGlobalHoldouts_ReturnsEmpty()
         {
             var localHoldout = CreateTestHoldout("local_id", "local_key");
-            localHoldout.IncludedRules = new[] { "rule_1" }; // local
+            localHoldout.IsGlobal = false;
+            localHoldout.IncludedRules = new[] { "rule_1" };
 
             var config = new HoldoutConfig(new[] { localHoldout });
 
@@ -191,6 +183,7 @@ namespace OptimizelySDK.Tests
         public void TestGetHoldoutsForRule_ReturnsMatchingLocalHoldout()
         {
             var localHoldout = CreateTestHoldout("local_id", "local_key");
+            localHoldout.IsGlobal = false;
             localHoldout.IncludedRules = new[] { "rule_1", "rule_2" };
 
             var config = new HoldoutConfig(new[] { localHoldout });
@@ -207,6 +200,7 @@ namespace OptimizelySDK.Tests
         public void TestGetHoldoutsForRule_UnknownRuleId_ReturnsEmpty()
         {
             var localHoldout = CreateTestHoldout("local_id", "local_key");
+            localHoldout.IsGlobal = false;
             localHoldout.IncludedRules = new[] { "rule_1" };
 
             var config = new HoldoutConfig(new[] { localHoldout });
@@ -219,6 +213,7 @@ namespace OptimizelySDK.Tests
         public void TestGetHoldoutsForRule_NullOrEmptyRuleId_ReturnsEmpty()
         {
             var localHoldout = CreateTestHoldout("local_id", "local_key");
+            localHoldout.IsGlobal = false;
             localHoldout.IncludedRules = new[] { "rule_1" };
 
             var config = new HoldoutConfig(new[] { localHoldout });
@@ -228,32 +223,30 @@ namespace OptimizelySDK.Tests
         }
 
         [Test]
-        public void TestGetHoldoutsForRule_EmptyIncludedRules_NoRuleMatches()
+        public void TestGetHoldoutsForRule_LocalWithNullIncludedRules_NoRuleMatches()
         {
-            // A local holdout with IncludedRules == [] matches NO rules
+            // A local holdout (IsGlobal=false) with null IncludedRules should not match any rules
             var localHoldout = CreateTestHoldout("local_id", "local_key");
-            localHoldout.IncludedRules = new string[0]; // empty array = local, but no rules
+            localHoldout.IsGlobal = false;
+            localHoldout.IncludedRules = null;
 
             var config = new HoldoutConfig(new[] { localHoldout });
 
-            // Should not appear in global holdouts
-            Assert.AreEqual(0, config.GetGlobalHoldouts().Count, "Empty-array holdout should not be global");
-
-            // Should not match any rule
-            Assert.AreEqual(0, config.GetHoldoutsForRule("any_rule").Count, "Empty-array holdout should match no rules");
+            Assert.AreEqual(0, config.GetGlobalHoldouts().Count, "Local holdout should not be global");
+            Assert.AreEqual(0, config.GetHoldoutsForRule("any_rule").Count, "Local holdout with null IncludedRules should match no rules");
         }
 
         [Test]
-        public void TestBackwardCompatibility_NullIncludedRulesDefaultsToGlobal()
+        public void TestBackwardCompatibility_DefaultIsGlobalIsTrue()
         {
-            // Old datafile holdouts have no includedRules field → IncludedRules is null → global
+            // Holdouts default to IsGlobal=true (matching "holdouts" section behavior)
             var legacyHoldout = CreateTestHoldout("legacy_id", "legacy_key");
-            // IncludedRules is null by default (not set)
+            // IsGlobal defaults to true
 
             var config = new HoldoutConfig(new[] { legacyHoldout });
 
             var globals = config.GetGlobalHoldouts();
-            Assert.AreEqual(1, globals.Count, "Legacy holdout (null IncludedRules) should be treated as global");
+            Assert.AreEqual(1, globals.Count, "Holdout with default IsGlobal=true should be treated as global");
             Assert.AreEqual("legacy_id", globals[0].Id);
         }
 
@@ -261,9 +254,11 @@ namespace OptimizelySDK.Tests
         public void TestMultipleLocalHoldoutsForSameRule()
         {
             var holdout1 = CreateTestHoldout("local_id_1", "local_key_1");
+            holdout1.IsGlobal = false;
             holdout1.IncludedRules = new[] { "rule_shared" };
 
             var holdout2 = CreateTestHoldout("local_id_2", "local_key_2");
+            holdout2.IsGlobal = false;
             holdout2.IncludedRules = new[] { "rule_shared" };
 
             var config = new HoldoutConfig(new[] { holdout1, holdout2 });
@@ -277,6 +272,7 @@ namespace OptimizelySDK.Tests
         {
             // A single local holdout can target rules from multiple flags
             var crossFlagHoldout = CreateTestHoldout("cross_id", "cross_key");
+            crossFlagHoldout.IsGlobal = false;
             crossFlagHoldout.IncludedRules = new[] { "rule_flag_a", "rule_flag_b", "rule_flag_c" };
 
             var config = new HoldoutConfig(new[] { crossFlagHoldout });

--- a/OptimizelySDK/Bucketing/DecisionService.cs
+++ b/OptimizelySDK/Bucketing/DecisionService.cs
@@ -916,7 +916,7 @@ namespace OptimizelySDK.Bucketing
 
             var userId = user.GetUserId();
 
-            // Check global holdouts first (highest priority — evaluated at flag level, before any rules)
+            // Check global holdouts first (from the "holdouts" section — evaluated at flag level, before any rules)
             var globalHoldouts = projectConfig.GetGlobalHoldouts();
             foreach (var holdout in globalHoldouts)
             {

--- a/OptimizelySDK/Config/DatafileProjectConfig.cs
+++ b/OptimizelySDK/Config/DatafileProjectConfig.cs
@@ -299,9 +299,15 @@ namespace OptimizelySDK.Config
         public Rollout[] Rollouts { get; set; }
 
         /// <summary>
-        /// Associative list of Holdouts.
+        /// Associative list of global Holdouts (from the "holdouts" section).
         /// </summary>
         public Holdout[] Holdouts { get; set; }
+
+        /// <summary>
+        /// Associative list of local Holdouts (from the "localHoldouts" section).
+        /// Local holdouts are rule-scoped via their IncludedRules array.
+        /// </summary>
+        public Holdout[] LocalHoldouts { get; set; }
 
         /// <summary>
         /// Associative list of Integrations.
@@ -327,7 +333,32 @@ namespace OptimizelySDK.Config
             FeatureFlags = FeatureFlags ?? new FeatureFlag[0];
             Rollouts = Rollouts ?? new Rollout[0];
             Holdouts = Holdouts ?? new Holdout[0];
+            LocalHoldouts = LocalHoldouts ?? new Holdout[0];
             Integrations = Integrations ?? new Integration[0];
+
+            // Mark global holdouts and strip IncludedRules (section membership is the sole signal for scope)
+            foreach (var holdout in Holdouts)
+            {
+                holdout.IsGlobal = true;
+                holdout.IncludedRules = null;
+            }
+
+            // Validate and mark local holdouts
+            var validLocalHoldouts = new List<Holdout>();
+            foreach (var holdout in LocalHoldouts)
+            {
+                holdout.IsGlobal = false;
+                if (holdout.IncludedRules == null || holdout.IncludedRules.Length == 0)
+                {
+                    Logger?.Log(LogLevel.ERROR,
+                        $"Local holdout \"{holdout.Key}\" (id={holdout.Id}) is missing includedRules -- excluding from evaluation.");
+                    continue;
+                }
+
+                validLocalHoldouts.Add(holdout);
+            }
+
+            LocalHoldouts = validLocalHoldouts.ToArray();
             _ExperimentKeyMap = new Dictionary<string, Experiment>();
 
             _GroupIdMap = ConfigParser<Group>.GenerateMap(Groups,
@@ -422,25 +453,24 @@ namespace OptimizelySDK.Config
                 }
             }
 
-            // Adding Holdout variations in variation id and key maps.
-            if (Holdouts != null)
+            // Adding Holdout variations in variation id and key maps (both global and local holdouts).
+            var allHoldoutsForMaps = Holdouts
+                .Concat(LocalHoldouts);
+            foreach (var holdout in allHoldoutsForMaps)
             {
-                foreach (var holdout in Holdouts)
-                {
-                    _VariationKeyMap[holdout.Key] = new Dictionary<string, Variation>();
-                    _VariationIdMap[holdout.Key] = new Dictionary<string, Variation>();
-                    _VariationIdMapByExperimentId[holdout.Id] = new Dictionary<string, Variation>();
-                    _VariationKeyMapByExperimentId[holdout.Id] = new Dictionary<string, Variation>();
+                _VariationKeyMap[holdout.Key] = new Dictionary<string, Variation>();
+                _VariationIdMap[holdout.Key] = new Dictionary<string, Variation>();
+                _VariationIdMapByExperimentId[holdout.Id] = new Dictionary<string, Variation>();
+                _VariationKeyMapByExperimentId[holdout.Id] = new Dictionary<string, Variation>();
 
-                    if (holdout.Variations != null)
+                if (holdout.Variations != null)
+                {
+                    foreach (var variation in holdout.Variations)
                     {
-                        foreach (var variation in holdout.Variations)
-                        {
-                            _VariationKeyMap[holdout.Key][variation.Key] = variation;
-                            _VariationIdMap[holdout.Key][variation.Id] = variation;
-                            _VariationKeyMapByExperimentId[holdout.Id][variation.Key] = variation;
-                            _VariationIdMapByExperimentId[holdout.Id][variation.Id] = variation;
-                        }
+                        _VariationKeyMap[holdout.Key][variation.Key] = variation;
+                        _VariationIdMap[holdout.Key][variation.Id] = variation;
+                        _VariationKeyMapByExperimentId[holdout.Id][variation.Key] = variation;
+                        _VariationIdMapByExperimentId[holdout.Id][variation.Id] = variation;
                     }
                 }
             }
@@ -562,7 +592,11 @@ namespace OptimizelySDK.Config
             _FlagVariationMap = flagToVariationsMap;
 
             // Initialize HoldoutConfig for managing flag-to-holdout relationships
-            _holdoutConfig = new HoldoutConfig(Holdouts ?? new Holdout[0]);
+            // Merge global holdouts and valid local holdouts
+            var allHoldoutsForConfig = Holdouts
+                .Concat(LocalHoldouts)
+                .ToArray();
+            _holdoutConfig = new HoldoutConfig(allHoldoutsForConfig);
         }
 
         /// <summary>
@@ -910,7 +944,7 @@ namespace OptimizelySDK.Config
         }
 
         /// <summary>
-        /// Returns all global holdouts (holdouts where IncludedRules is null).
+        /// Returns all global holdouts (from the "holdouts" datafile section).
         /// Global holdouts apply to all rules across all flags and are evaluated at flag level.
         /// </summary>
         /// <returns>Read-only list of global holdouts</returns>
@@ -920,7 +954,7 @@ namespace OptimizelySDK.Config
         }
 
         /// <summary>
-        /// Returns local holdouts that target a specific rule ID.
+        /// Returns local holdouts (from the "localHoldouts" section) that target a specific rule ID.
         /// Local holdouts are evaluated per-rule, after forced decisions but before regular rule evaluation.
         /// </summary>
         /// <param name="ruleId">The rule ID to look up holdouts for</param>

--- a/OptimizelySDK/Entity/Holdout.cs
+++ b/OptimizelySDK/Entity/Holdout.cs
@@ -19,7 +19,9 @@ using System.Collections.Generic;
 namespace OptimizelySDK.Entity
 {
     /// <summary>
-    /// Represents a holdout in an Optimizely project
+    /// Represents a holdout in an Optimizely project.
+    /// Scope (global vs local) is determined by section membership in the datafile,
+    /// not by the IncludedRules field.
     /// </summary>
     public class Holdout : ExperimentCore
     {
@@ -47,17 +49,17 @@ namespace OptimizelySDK.Entity
         }
 
         /// <summary>
-        /// Optional array of rule IDs that this holdout targets (local holdout).
-        /// When null, the holdout applies to all rules across all flags (global holdout).
-        /// When set to an array (even empty), the holdout only applies to the specified rules.
-        /// Rule IDs in this array are experiment/delivery rule IDs from the datafile, NOT flag IDs.
+        /// Optional array of rule IDs that this holdout targets (used only for local holdouts).
+        /// For global holdouts (from the "holdouts" section), this is always stripped to null at parse time.
+        /// For local holdouts (from the "localHoldouts" section), this must be a non-empty array.
         /// </summary>
         public string[] IncludedRules { get; set; }
 
         /// <summary>
-        /// Returns true if this is a global holdout (IncludedRules is null),
-        /// false if this is a local holdout (IncludedRules is a non-null array).
+        /// True if this holdout was parsed from the "holdouts" section (global scope).
+        /// False if parsed from the "localHoldouts" section (rule scope).
+        /// Set by the config parser; section membership is the sole signal for scope.
         /// </summary>
-        public bool IsGlobal => IncludedRules == null;
+        public bool IsGlobal { get; internal set; } = true;
     }
 }

--- a/OptimizelySDK/ProjectConfig.cs
+++ b/OptimizelySDK/ProjectConfig.cs
@@ -181,9 +181,14 @@ namespace OptimizelySDK
         Rollout[] Rollouts { get; set; }
 
         /// <summary>
-        /// Associative list of Holdouts.
+        /// Associative list of global Holdouts (from the "holdouts" section).
         /// </summary>
         Holdout[] Holdouts { get; set; }
+
+        /// <summary>
+        /// Associative list of local Holdouts (from the "localHoldouts" section).
+        /// </summary>
+        Holdout[] LocalHoldouts { get; set; }
 
         /// <summary>
         /// Associative list of Integrations.
@@ -333,14 +338,14 @@ namespace OptimizelySDK
         Holdout GetHoldout(string holdoutId);
 
         /// <summary>
-        /// Returns all global holdouts (holdouts where IncludedRules is null).
+        /// Returns all global holdouts (from the "holdouts" datafile section).
         /// Global holdouts apply to all rules across all flags and are evaluated at flag level.
         /// </summary>
         /// <returns>Read-only list of global holdouts</returns>
         List<Holdout> GetGlobalHoldouts();
 
         /// <summary>
-        /// Returns local holdouts that target a specific rule ID.
+        /// Returns local holdouts (from the "localHoldouts" section) that target a specific rule ID.
         /// Local holdouts are evaluated per-rule, after forced decisions but before regular rule evaluation.
         /// </summary>
         /// <param name="ruleId">The rule ID to look up holdouts for</param>

--- a/OptimizelySDK/Utils/HoldoutConfig.cs
+++ b/OptimizelySDK/Utils/HoldoutConfig.cs
@@ -23,6 +23,8 @@ namespace OptimizelySDK.Utils
     /// <summary>
     /// Configuration manager for holdouts, providing holdout ID mapping,
     /// global holdout access, and rule-level local holdout lookups.
+    /// Scope (global vs local) is determined by the IsGlobal property set at parse time,
+    /// which reflects section membership in the datafile.
     /// </summary>
     public class HoldoutConfig
     {
@@ -30,14 +32,15 @@ namespace OptimizelySDK.Utils
         private readonly Dictionary<string, Holdout> _holdoutIdMap;
 
         /// <summary>
-        /// Global holdouts — holdouts where IncludedRules is null.
+        /// Global holdouts — holdouts from the "holdouts" section (IsGlobal == true).
         /// These are evaluated at flag level, before any per-rule logic.
         /// </summary>
         private readonly List<Holdout> _globalHoldouts;
 
         /// <summary>
         /// Maps rule IDs to the local holdouts that target those rules.
-        /// A local holdout has IncludedRules set to a non-null array of rule IDs.
+        /// Local holdouts are from the "localHoldouts" section (IsGlobal == false)
+        /// and use their IncludedRules array for rule targeting.
         /// </summary>
         private readonly Dictionary<string, List<Holdout>> _ruleHoldoutsMap;
 
@@ -75,16 +78,14 @@ namespace OptimizelySDK.Utils
                 // Build ID mapping
                 _holdoutIdMap[holdout.Id] = holdout;
 
-                // Classify as global or local based on IncludedRules
+                // Classify based on IsGlobal (set by section membership at parse time)
                 if (holdout.IsGlobal)
                 {
-                    // IncludedRules == null → global holdout (applies to all rules across all flags)
                     _globalHoldouts.Add(holdout);
                 }
-                else
+                else if (holdout.IncludedRules != null)
                 {
-                    // IncludedRules != null → local holdout (applies only to the specified rules)
-                    // An empty IncludedRules array means local but matches no rules (intentional).
+                    // Local holdout — map each targeted rule ID
                     foreach (var ruleId in holdout.IncludedRules)
                     {
                         if (!_ruleHoldoutsMap.ContainsKey(ruleId))
@@ -116,7 +117,7 @@ namespace OptimizelySDK.Utils
         }
 
         /// <summary>
-        /// Returns all global holdouts (holdouts where IncludedRules is null).
+        /// Returns all global holdouts (from the "holdouts" datafile section).
         /// These apply to all rules across all flags and are evaluated at flag level.
         /// </summary>
         /// <returns>List of global holdouts</returns>
@@ -126,7 +127,7 @@ namespace OptimizelySDK.Utils
         }
 
         /// <summary>
-        /// Returns local holdouts that target a specific rule ID.
+        /// Returns local holdouts (from the "localHoldouts" section) that target a specific rule ID.
         /// These are evaluated per-rule, after forced decisions but before regular rule evaluation.
         /// </summary>
         /// <param name="ruleId">The rule ID to look up holdouts for</param>


### PR DESCRIPTION
## Summary

- Add new top-level `localHoldouts` datafile section to separate local (rule-scoped) holdouts from global holdouts
- Strip `includedRules` from global holdouts at parse time — section membership is the sole signal for scope
- Validate local holdouts: entries without `includedRules` are logged as errors and excluded
- Enforce forced decision priority over local holdouts (mandatory cross-SDK ordering)

## Changes

- **DatafileProjectConfig.cs**: Parse `localHoldouts` from datafile; strip `IncludedRules` from global holdouts; validate local holdouts
- **ProjectConfig.cs**: Add `LocalHoldouts` property to `IProjectConfig` interface
- **Holdout.cs**: Change `IsGlobal` to settable property with internal setter; update docstrings
- **HoldoutConfig.cs**: Use `holdout.IsGlobal` property instead of computing from `IncludedRules`
- **DecisionService.cs**: Update comment for section-based scope
- **Tests**: Add parsing tests, validation tests, backward compatibility tests, and mandatory forced-decision-beats-local-holdout test

## Jira Ticket

[FSSDK-12792](https://optimizely-ext.atlassian.net/browse/FSSDK-12792)

[FSSDK-12792]: https://optimizely-ext.atlassian.net/browse/FSSDK-12792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ