### PR TITLE
[AI-FSSDK] [FSSDK-12750] Use attribute id instead of key for CMAB prediction requests

### DIFF
--- a/OptimizelySDK.Tests/CmabTests/DecisionServiceCmabTest.cs
+++ b/OptimizelySDK.Tests/CmabTests/DecisionServiceCmabTest.cs
@@ -271,8 +271,8 @@ namespace OptimizelySDK.Tests.CmabTests
                     TEST_EXPERIMENT_ID,
                     TEST_USER_ID,
                     It.Is<IDictionary<string, object>>(attrs =>
-                        attrs.Count == 1 && attrs.ContainsKey(AGE_ATTRIBUTE_KEY) &&
-                        (int)attrs[AGE_ATTRIBUTE_KEY] == 25),
+                        attrs.Count == 1 && attrs.ContainsKey("age_attr_id") &&
+                        (int)attrs["age_attr_id"] == 25),
                     It.IsAny<string>(),
                     It.IsAny<TimeSpan?>()))
                 .Returns(VARIATION_A_ID);
@@ -300,7 +300,7 @@ namespace OptimizelySDK.Tests.CmabTests
                     TEST_EXPERIMENT_ID,
                     TEST_USER_ID,
                     It.Is<IDictionary<string, object>>(attrs =>
-                        attrs.Count == 1 && (int)attrs[AGE_ATTRIBUTE_KEY] == 25),
+                        attrs.Count == 1 && (int)attrs["age_attr_id"] == 25),
                     It.IsAny<string>(),
                     It.IsAny<TimeSpan?>()),
                 Times.Once);
@@ -334,7 +334,7 @@ namespace OptimizelySDK.Tests.CmabTests
             cmabClientMock.Setup(c => c.FetchDecision(
                     TEST_EXPERIMENT_ID,
                     TEST_USER_ID,
-                    It.Is<IDictionary<string, object>>(attrs => attrs.ContainsKey(AGE_ATTRIBUTE_KEY)),
+                    It.Is<IDictionary<string, object>>(attrs => attrs.ContainsKey("age_attr_id")),
                     It.IsAny<string>(),
                     It.IsAny<TimeSpan?>()))
                 .Returns(VARIATION_A_ID);
@@ -364,7 +364,7 @@ namespace OptimizelySDK.Tests.CmabTests
                     TEST_EXPERIMENT_ID,
                     TEST_USER_ID,
                     It.Is<IDictionary<string, object>>(attrs =>
-                        attrs.ContainsKey(AGE_ATTRIBUTE_KEY) && (int)attrs[AGE_ATTRIBUTE_KEY] == 25),
+                        attrs.ContainsKey("age_attr_id") && (int)attrs["age_attr_id"] == 25),
                     It.IsAny<string>(),
                     It.IsAny<TimeSpan?>()),
                 Times.Once);
@@ -372,7 +372,7 @@ namespace OptimizelySDK.Tests.CmabTests
                     TEST_EXPERIMENT_ID,
                     TEST_USER_ID,
                     It.Is<IDictionary<string, object>>(attrs =>
-                        attrs.ContainsKey(AGE_ATTRIBUTE_KEY) && (int)attrs[AGE_ATTRIBUTE_KEY] == 30),
+                        attrs.ContainsKey("age_attr_id") && (int)attrs["age_attr_id"] == 30),
                     It.IsAny<string>(),
                     It.IsAny<TimeSpan?>()),
                 Times.Once);
@@ -489,8 +489,8 @@ namespace OptimizelySDK.Tests.CmabTests
                     TEST_EXPERIMENT_ID,
                     TEST_USER_ID,
                     It.Is<IDictionary<string, object>>(attrs =>
-                        attrs.Count == 2 && (int)attrs["age"] == 25 &&
-                        (string)attrs["location"] == "USA" &&
+                        attrs.Count == 2 && (int)attrs["age_attr_id"] == 25 &&
+                        (string)attrs["location_attr_id"] == "USA" &&
                         !attrs.ContainsKey("extra")),
                     It.IsAny<string>(),
                     It.IsAny<TimeSpan?>()))

--- a/OptimizelySDK.Tests/CmabTests/DefaultCmabServiceTest.cs
+++ b/OptimizelySDK.Tests/CmabTests/DefaultCmabServiceTest.cs
@@ -71,7 +71,7 @@ namespace OptimizelySDK.Tests.CmabTests
             var userContext = CreateUserContext(TEST_USER_ID,
                 new Dictionary<string, object> { { "age", 25 } });
             var filteredAttributes =
-                new UserAttributes(new Dictionary<string, object> { { "age", 25 } });
+                new UserAttributes(new Dictionary<string, object> { { AGE_ATTRIBUTE_ID, 25 } });
             var cacheKey = DefaultCmabService.GetCacheKey(TEST_USER_ID, TEST_RULE_ID);
 
             _cmabCache.Save(cacheKey, new CmabCacheEntry
@@ -107,8 +107,8 @@ namespace OptimizelySDK.Tests.CmabTests
 
             _mockCmabClient.Setup(c => c.FetchDecision(TEST_RULE_ID, TEST_USER_ID,
                 It.Is<IDictionary<string, object>>(attrs =>
-                    attrs != null && attrs.Count == 1 && attrs.ContainsKey("age") &&
-                    (int)attrs["age"] == 25),
+                    attrs != null && attrs.Count == 1 && attrs.ContainsKey(AGE_ATTRIBUTE_ID) &&
+                    (int)attrs[AGE_ATTRIBUTE_ID] == 25),
                 It.IsAny<string>(),
                 It.IsAny<TimeSpan?>())).Returns("varB");
 
@@ -143,7 +143,7 @@ namespace OptimizelySDK.Tests.CmabTests
 
             _mockCmabClient.Setup(c => c.FetchDecision(TEST_RULE_ID, TEST_USER_ID,
                 It.Is<IDictionary<string, object>>(attrs =>
-                    attrs.Count == 1 && (int)attrs["age"] == 25),
+                    attrs.Count == 1 && (int)attrs[AGE_ATTRIBUTE_ID] == 25),
                 It.IsAny<string>(),
                 It.IsAny<TimeSpan?>())).Returns("varNew");
 
@@ -190,7 +190,7 @@ namespace OptimizelySDK.Tests.CmabTests
 
             _mockCmabClient.Setup(c => c.FetchDecision(TEST_RULE_ID, TEST_USER_ID,
                 It.Is<IDictionary<string, object>>(attrs =>
-                    attrs.Count == 1 && (int)attrs["age"] == 25),
+                    attrs.Count == 1 && (int)attrs[AGE_ATTRIBUTE_ID] == 25),
                 It.IsAny<string>(),
                 It.IsAny<TimeSpan?>())).Returns("varNew");
 
@@ -232,7 +232,7 @@ namespace OptimizelySDK.Tests.CmabTests
 
             _mockCmabClient.Setup(c => c.FetchDecision(TEST_RULE_ID, TEST_USER_ID,
                 It.Is<IDictionary<string, object>>(attrs =>
-                    attrs.Count == 1 && (int)attrs["age"] == 25),
+                    attrs.Count == 1 && (int)attrs[AGE_ATTRIBUTE_ID] == 25),
                 It.IsAny<string>(),
                 It.IsAny<TimeSpan?>())).Returns("varUpdated");
 
@@ -270,8 +270,8 @@ namespace OptimizelySDK.Tests.CmabTests
 
             _mockCmabClient.Setup(c => c.FetchDecision(TEST_RULE_ID, TEST_USER_ID,
                 It.Is<IDictionary<string, object>>(attrs => attrs.Count == 2 &&
-                                                            (int)attrs["age"] == 25 &&
-                                                            (string)attrs["location"] == "USA" &&
+                                                            (int)attrs[AGE_ATTRIBUTE_ID] == 25 &&
+                                                            (string)attrs[LOCATION_ATTRIBUTE_ID] == "USA" &&
                                                             !attrs.ContainsKey("extra")),
                 It.IsAny<string>(),
                 It.IsAny<TimeSpan?>())).Returns("varFiltered");
@@ -280,6 +280,45 @@ namespace OptimizelySDK.Tests.CmabTests
 
             Assert.IsNotNull(decision);
             Assert.AreEqual("varFiltered", decision.VariationId);
+            _mockCmabClient.VerifyAll();
+        }
+
+        [Test]
+        public void FilteredAttributesUseAttributeIdNotKey()
+        {
+            var experiment = CreateExperiment(TEST_RULE_ID,
+                new List<string> { AGE_ATTRIBUTE_ID, LOCATION_ATTRIBUTE_ID });
+            var attributeMap = new Dictionary<string, AttributeEntity>
+            {
+                { AGE_ATTRIBUTE_ID, new AttributeEntity { Id = AGE_ATTRIBUTE_ID, Key = "age" } },
+                {
+                    LOCATION_ATTRIBUTE_ID,
+                    new AttributeEntity { Id = LOCATION_ATTRIBUTE_ID, Key = "location" }
+                },
+            };
+            var projectConfig = CreateProjectConfig(TEST_RULE_ID, experiment, attributeMap);
+            var userContext = CreateUserContext(TEST_USER_ID, new Dictionary<string, object>
+            {
+                { "age", 25 },
+                { "location", "USA" },
+            });
+
+            _mockCmabClient.Setup(c => c.FetchDecision(TEST_RULE_ID, TEST_USER_ID,
+                It.Is<IDictionary<string, object>>(attrs =>
+                    attrs.Count == 2 &&
+                    attrs.ContainsKey(AGE_ATTRIBUTE_ID) &&
+                    !attrs.ContainsKey("age") &&
+                    attrs.ContainsKey(LOCATION_ATTRIBUTE_ID) &&
+                    !attrs.ContainsKey("location") &&
+                    (int)attrs[AGE_ATTRIBUTE_ID] == 25 &&
+                    (string)attrs[LOCATION_ATTRIBUTE_ID] == "USA"),
+                It.IsAny<string>(),
+                It.IsAny<TimeSpan?>())).Returns("varIdBased");
+
+            var decision = _cmabService.GetDecision(projectConfig, userContext, TEST_RULE_ID);
+
+            Assert.IsNotNull(decision);
+            Assert.AreEqual("varIdBased", decision.VariationId);
             _mockCmabClient.VerifyAll();
         }
 
@@ -509,8 +548,8 @@ namespace OptimizelySDK.Tests.CmabTests
                 TEST_RULE_ID,
                 TEST_USER_ID,
                 It.Is<IDictionary<string, object>>(attrs =>
-                    attrs != null && attrs.Count == 1 && attrs.ContainsKey("age") &&
-                    (int)attrs["age"] == 25),
+                    attrs != null && attrs.Count == 1 && attrs.ContainsKey(AGE_ATTRIBUTE_ID) &&
+                    (int)attrs[AGE_ATTRIBUTE_ID] == 25),
                 It.IsAny<string>(),
                 It.IsAny<TimeSpan?>()))
                 .Returns(() =>

--- a/OptimizelySDK/Cmab/DefaultCmabService.cs
+++ b/OptimizelySDK/Cmab/DefaultCmabService.cs
@@ -248,7 +248,7 @@ namespace OptimizelySDK.Cmab
                 if (attributeIdMap.TryGetValue(attributeId, out var attribute) &&
                     userAttributes.TryGetValue(attribute.Key, out var value))
                 {
-                    filtered[attribute.Key] = value;
+                    filtered[attribute.Id] = value;
                 }
             }
 


### PR DESCRIPTION
## Summary

The CMAB prediction request payload was incorrectly sending the attribute's key instead of its id in the "id" field. The CMAB prediction endpoint expects the attribute id, not the key, so this fix ensures the correct identifier is used when building filtered attribute maps for CMAB experiments.

## Changes

- Fix FilterAttributes in DefaultCmabService to use attribute id instead of key as the dictionary key
- Update CMAB service tests to verify attribute ids are used in filtered attribute maps
- Add explicit test case to confirm attribute id is used over attribute key

## Jira Ticket

[FSSDK-12750](https://optimizely-ext.atlassian.net/browse/FSSDK-12750)

[FSSDK-12750]: https://optimizely-ext.atlassian.net/browse/FSSDK-12750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ