### PR TITLE
[FSSDK-12875] trusted publishing

### DIFF
--- a/.github/workflows/csharp_release.yml
+++ b/.github/workflows/csharp_release.yml
@@ -213,6 +213,8 @@ jobs:
     name: Publish package to NuGet after reviewing the artifact
     needs: [ variables, pack ]
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     # Review the `nuget-package` artifact ensuring the dlls are
     # organized before approving.
     environment: 'i-reviewed-nuget-package-artifact'
@@ -226,6 +228,11 @@ jobs:
           path: ./nuget
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ${{ secrets.NUGET_USER }}
       - name: Publish NuGet package
         run: |
-          dotnet nuget push ./nuget/Optimizely.SDK.${{ env.VERSION }}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_API_KEY }}
+          dotnet nuget push ./nuget/Optimizely.SDK.${{ env.VERSION }}.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ steps.nuget-login.outputs.NUGET_API_KEY }}


### PR DESCRIPTION
## Summary
This pull request updates the NuGet package publishing workflow in `.github/workflows/csharp_release.yml` to improve security and authentication practices. The main changes involve setting explicit permissions and switching to a more secure login step for publishing to NuGet.

**Security and authentication improvements:**

* Added `id-token: write` permission to the publish job to enable secure authentication with NuGet.
* Introduced a `NuGet/login@v1` step to perform NuGet authentication using credentials from GitHub secrets, replacing direct use of the API key.
* Updated the `dotnet nuget push` command to use the API key output from the NuGet login step, rather than referencing the secret directly.

## Test plan
Existing test should pass

## Issues
- FSSDK-12875